### PR TITLE
Disable ReSharper PossibleMultipleEnumeration warnings in tests

### DIFF
--- a/src/StrongTypes.Tests/Collections/ExceptionsAggregateTests.cs
+++ b/src/StrongTypes.Tests/Collections/ExceptionsAggregateTests.cs
@@ -46,6 +46,7 @@ public class ExceptionsAggregateTests
         CustomException[] array = Enumerable.Range(0, 10).Select(i => new CustomException($"{i} potatoes")).ToArray();
         INonEmptyEnumerable<Exception> nonEmpty = array.AsNonEmpty().Get();
 
+        // ReSharper disable PossibleMultipleEnumeration
         OptionAssert.NonEmpty(enumerable.Aggregate());
         Assert.Equal(array, ((AggregateException)enumerable.Aggregate().Get()).InnerExceptions);
 

--- a/src/StrongTypes.Tests/Collections/FirstOptionTests.cs
+++ b/src/StrongTypes.Tests/Collections/FirstOptionTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace StrongTypes.Tests.Collections;
 
+// ReSharper disable PossibleMultipleEnumeration
 public class FirstOptionTests
 {
     [Fact]

--- a/src/StrongTypes.Tests/Collections/LastOptionTests.cs
+++ b/src/StrongTypes.Tests/Collections/LastOptionTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace StrongTypes.Tests.Collections;
 
+// ReSharper disable PossibleMultipleEnumeration
 public class LastOptionTests
 {
     [Fact]

--- a/src/StrongTypes.Tests/Collections/SingleOptionTests.cs
+++ b/src/StrongTypes.Tests/Collections/SingleOptionTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace StrongTypes.Tests.Collections;
 
+// ReSharper disable PossibleMultipleEnumeration
 public class SingleOptionTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- Adds file-scoped `// ReSharper disable PossibleMultipleEnumeration` to test files that intentionally enumerate collections multiple times (FirstOptionTests, LastOptionTests, SingleOptionTests, ExceptionsAggregateTests)

## Test plan
- [ ] Verify tests still pass
- [ ] Confirm no new ReSharper warnings in affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)