### PR TITLE
Security improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # GitHub Actions — SHA-pinned third-party actions get auto-bumped here
+  # so we keep supply-chain protection without manual upkeep.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # NuGet packages across all csproj files in the solution.
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+    groups:
+      nuget:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
     needs: build-and-test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    environment: production
+    environment: Nuget.org
 
     steps:
     - name: Download NuGet package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,7 +59,7 @@ jobs:
         retention-days: 1
 
     - name: Test Report
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@3eeb9fc888e82e8be2fb356bbeec2750231672bc  # v1
       if: success() || failure()
       with:
         name: StrongTypes Tests report
@@ -71,6 +71,7 @@ jobs:
     needs: build-and-test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
     - name: Download NuGet package


### PR DESCRIPTION
## Summary
- Pin `dorny/test-reporter` to its v1 commit SHA (`3eeb9fc`) so a compromised or re-pointed tag can't silently swap the action
- Gate the `publish` job on the `Nuget.org` environment so `NUGET_TOKEN` lives in an environment-scoped secret (with `main`-only branch policy) instead of a plain repo secret
- Add Dependabot config for GitHub Actions (`/`) and NuGet (`/src`) — weekly grouped updates

## Manual setup (done)
- `Nuget.org` environment created with `can_admins_bypass: false`
- Deployment branch policy limited to `main`
- `NUGET_TOKEN` moved from repo secrets to the `Nuget.org` environment

## Test plan
- [ ] CI passes on this PR (publish job skipped on PR — correct)
- [ ] After merge, push to main triggers publish job and pushes NuGet package via the environment-scoped token

🤖 Generated with [Claude Code](https://claude.com/claude-code)