### PR TITLE
Migrate tests to xunit.v3 and FsCheck 3

### DIFF
--- a/src/StrongTypes.Tests/Generative_Old/GeneratorHelpers_Old.cs
+++ b/src/StrongTypes.Tests/Generative_Old/GeneratorHelpers_Old.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FsCheck;
+using FsCheck.Fluent;
 
 namespace StrongTypes.Tests.Generative;
 

--- a/src/StrongTypes.Tests/Generative_Old/OptionGenerators_Old.cs
+++ b/src/StrongTypes.Tests/Generative_Old/OptionGenerators_Old.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FsCheck;
+using FsCheck.Fluent;
 
 namespace StrongTypes.Tests.Generative;
 
@@ -28,10 +29,10 @@ public class OptionGenerators
 
         Unit = Arb.From(Gen.Constant(StrongTypes.Unit.Value).SometimesEmpty()); // No shrinker needed for Unit
 
-        var referenceTypeGenerator = Arb.From<int>().Generator.Select(i => new ReferenceType(i));
+        var referenceTypeGenerator = ArbMap.Default.ArbFor<int>().Generator.Select(i => new ReferenceType(i));
         ReferenceType = Arb.From(referenceTypeGenerator.SometimesEmpty(), Shrinkers.Options.ReferenceType);
         ReferenceTypes = Arb.From(referenceTypeGenerator.ToList().SometimesEmpty(), Shrinkers.Options.ReferenceTypeList);
-        var referenceTypeBaseGenerator = Arb.From<int>().Generator.Select(i => new ReferenceTypeBase(i));
+        var referenceTypeBaseGenerator = ArbMap.Default.ArbFor<int>().Generator.Select(i => new ReferenceTypeBase(i));
         ReferenceTypeBase = Arb.From(referenceTypeBaseGenerator.SometimesEmpty(), Shrinkers.Options.ReferenceTypeBase);
         ReferenceTypeBases = Arb.From(referenceTypeBaseGenerator.ToList().SometimesEmpty(), Shrinkers.Options.ReferenceTypeBaseList);
     }
@@ -86,11 +87,11 @@ public class OptionGenerators
 
     private static Gen<Option<T>> DefaultOptionGenerator<T>()
     {
-        return Arb.From<T>().Generator.SometimesEmpty();
+        return ArbMap.Default.ArbFor<T>().Generator.SometimesEmpty();
     }
 
     private static Gen<Option<List<T>>> DefaultOptionListGenerator<T>()
     {
-        return Arb.From<T>().Generator.ToList().SometimesEmpty();
+        return ArbMap.Default.ArbFor<T>().Generator.ToList().SometimesEmpty();
     }
 }

--- a/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionCreateTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionCreateTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class OptionCreateTests
 {
-    public OptionCreateTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Create()
     {

--- a/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionEmptyTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionEmptyTests_Old.cs
@@ -1,16 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
+using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class OptionEmptyTests
 {
-    public OptionEmptyTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Empty()
     {

--- a/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionValuedTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Creation_Old/OptionValuedTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class OptionValuedTests
 {
-    public OptionValuedTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Valued()
     {

--- a/src/StrongTypes.Tests/Options_Old/Creation_Old/ToOptionTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Creation_Old/ToOptionTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class ToOptionTests
 {
-    public ToOptionTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void ToOption()
     {

--- a/src/StrongTypes.Tests/Options_Old/EqualityTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/EqualityTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class EqualityTests
 {
-    public EqualityTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void Equality()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Enumerable_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Enumerable_Old.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class FlattenTests_Enumerable
 {
-    public FlattenTests_Enumerable()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Flatten()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Nullable_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Nullable_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class FlattenTests_Nullable
 {
-    public FlattenTests_Nullable()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Flatten()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Option_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/FlattenTests_Option_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class FlattenTests_Option
 {
-    public FlattenTests_Option()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Flatten()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrElseTests_Lazy_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrElseTests_Lazy_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrElseTests_Lazy
 {
-    public GetOrElseTests_Lazy()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrElseLazy()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrElseTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrElseTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrElseTests
 {
-    public GetOrElseTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrElse()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrFalseTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrFalseTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrFalseTests
 {
-    public GetOrFalseTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrFalse()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrFalseTests_WithFunc_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrFalseTests_WithFunc_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrFalseTests_WithFunc
 {
-    public GetOrFalseTests_WithFunc()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrFalse_WithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrNullTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrNullTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrNullTests
 {
-    public GetOrNullTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrNull()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrNull_WithFunc_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrNull_WithFunc_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrNullTests_WithFunc
 {
-    public GetOrNullTests_WithFunc()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrNull_WithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrZeroTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrZeroTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrZeroTests
 {
-    public GetOrZeroTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrZero()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrZeroTests_WithFunc_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/GetOrZeroTests_WithFunc_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrZeroTests_WithFunc
 {
-    public GetOrZeroTests_WithFunc()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrZero_WithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/IsTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/IsTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class IsTests
 {
-    public IsTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Is()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/OrElseTests_Lazy_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/OrElseTests_Lazy_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class OrElseTests_Lazy
 {
-    public OrElseTests_Lazy()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void OrElse()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/OrElseTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/OrElseTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class OrElseTests
 {
-    public OrElseTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void OrElse()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/SelectManyTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/SelectManyTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class SelectManyTests
 {
-    public SelectManyTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void SelectMany()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/SelectTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/SelectTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class SelectTests
 {
-    public SelectTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void Select()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToNullableTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToNullableTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class ToNullableTests
 {
-    public ToNullableTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void ToNullable()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToNullableTests_WithFunc_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToNullableTests_WithFunc_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class ToNullableTests_WithFunc
 {
-    public ToNullableTests_WithFunc()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void ToNullable_WithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToTryTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/ToTryTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class ToTryTests
 {
-    public ToTryTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void ToTry()
     {

--- a/src/StrongTypes.Tests/Options_Old/Extensions_Old/WhereTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/Extensions_Old/WhereTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class WhereTests
 {
-    public WhereTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Where()
     {

--- a/src/StrongTypes.Tests/Options_Old/FlatMapTests_Nullable_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/FlatMapTests_Nullable_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class FlatMapTests_Nullable
 {
-    public FlatMapTests_Nullable()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void FlatMap()
     {

--- a/src/StrongTypes.Tests/Options_Old/FlatMapTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/FlatMapTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class FlatMapTests
 {
-    public FlatMapTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void FlatMap()
     {

--- a/src/StrongTypes.Tests/Options_Old/GetOrDefaultTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/GetOrDefaultTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrDefaultTests
 {
-    public GetOrDefaultTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrDefault()
     {

--- a/src/StrongTypes.Tests/Options_Old/GetOrDefaultTests_WithFunc_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/GetOrDefaultTests_WithFunc_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetOrDefaultTests_WithFunc
 {
-    public GetOrDefaultTests_WithFunc()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetOrDefault_WithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/GetTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/GetTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetTests
 {
-    public GetTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void Get()
     {

--- a/src/StrongTypes.Tests/Options_Old/GetTests_WithFuncParameter_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/GetTests_WithFuncParameter_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class GetTests_WithFuncParameter
 {
-    public GetTests_WithFuncParameter()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void GetWithFunc()
     {

--- a/src/StrongTypes.Tests/Options_Old/IsEmptyTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/IsEmptyTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class IsEmptyTests
 {
-    public IsEmptyTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void IsEmpty()
     {

--- a/src/StrongTypes.Tests/Options_Old/MapEmptyTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/MapEmptyTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class MapEmptyTests
 {
-    public MapEmptyTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void MapEmpty()
     {

--- a/src/StrongTypes.Tests/Options_Old/MapTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/MapTests_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class MapTests
 {
-    public MapTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void Map()
     {

--- a/src/StrongTypes.Tests/Options_Old/MatchTests_Action_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/MatchTests_Action_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class MatchTests_Action
 {
-    public MatchTests_Action()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void Match()
     {

--- a/src/StrongTypes.Tests/Options_Old/MatchTests_Func_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/MatchTests_Func_Old.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
@@ -6,13 +6,9 @@ using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class MatchTests_Func
 {
-    public MatchTests_Func()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     internal void Match()
     {

--- a/src/StrongTypes.Tests/Options_Old/NonEmptyTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/NonEmptyTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class NonEmptyTests
 {
-    public NonEmptyTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void NonEmpty()
     {

--- a/src/StrongTypes.Tests/Options_Old/ToEnumerableTests_Old.cs
+++ b/src/StrongTypes.Tests/Options_Old/ToEnumerableTests_Old.cs
@@ -1,17 +1,13 @@
-﻿using FsCheck;
+using FsCheck;
 using FsCheck.Xunit;
 using StrongTypes.Tests.Generative;
 using Xunit;
 
 namespace StrongTypes.Tests.Options;
 
+[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]
 public class ToEnumerableTests
 {
-    public ToEnumerableTests()
-    {
-        Arb.Register<OptionGenerators>();
-    }
-
     [Fact]
     public void ToEnumerable()
     {

--- a/src/StrongTypes.Tests/StrongTypes.Tests.csproj
+++ b/src/StrongTypes.Tests/StrongTypes.Tests.csproj
@@ -1,20 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <LangVersion>14.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>CS1591</NoWarn>
     <IsPackable>false</IsPackable>
-    <OutputType>Exe</OutputType>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="3.3.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StrongTypes\StrongTypes.csproj" />


### PR DESCRIPTION
## Summary
- Switch `StrongTypes.Tests` to standalone xunit.v3 3.2.2 (OutputType=Exe, IsTestProject=true; drop Microsoft.NET.Test.Sdk and xunit.runner.visualstudio) — matches the `KaliCZ/demopage` shape
- Upgrade FsCheck.Xunit → `FsCheck.Xunit.v3 3.3.2` and migrate the test code to the FsCheck 3 API
- Bump BenchmarkDotNet `0.13.6` → `0.15.8`

## FsCheck 2 → 3 migration notes
- Added `using FsCheck.Fluent;` wherever generator combinators (`Arb.From`, `Gen.Constant`, `Gen.Choose`, `Gen.ArrayOf`, LINQ on `Gen<T>`) are used
- Replaced the v2 parameterless `Arb.From<T>()` default-lookup (4 call sites) with `ArbMap.Default.ArbFor<T>()` — `Arb.Default` is internal in v3
- Replaced global `Arb.Register<OptionGenerators>()` calls in 38 test class constructors with class-level `[Properties(Arbitrary = new[] { typeof(OptionGenerators) })]`

## Test plan
- [x] `dotnet build src/StrongTypes.slnx` — 0 errors, 0 warnings
- [x] `dotnet run --project src/StrongTypes.Tests` (MTP exe host) — 420 tests, 0 failed
- [x] Benchmarks project still builds against BenchmarkDotNet 0.15.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)