### PR TITLE
Ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 src/packages
 src/.idea
 .idea/
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so Claude Code's isolation worktrees (created under `.claude/worktrees/`) and other per-user harness state don't show up as untracked changes in `git status`.

## Test plan
- [x] `git status` in a clean checkout with a Claude Code worktree present no longer lists `.claude/`