### PR TITLE
Fix Pack step failing on main after source generator

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Pack
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: dotnet pack ./src/StrongTypes/StrongTypes.csproj -c $config --no-build -o out
+      run: dotnet pack ./src/StrongTypes/StrongTypes.csproj -c $config -o out
 
     - name: Upload NuGet package
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- The Pack step on `main` has been failing since #25 with `NETSDK1085: 'NoBuild' was true but 'Build' was invoked` on `StrongTypes.SourceGenerators.csproj`. `dotnet pack --no-build` still resolves `ProjectReference`s, which invokes Build on the analyzer project and trips the NoBuild guard.
- Dropping `--no-build` lets pack perform a no-op incremental build and succeed. Verified locally — `Kalicz.StrongTypes.0.2.0.nupkg` is produced cleanly.

## Why this wasn't caught in PR CI
The Pack step is gated on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, so PRs never exercise it. Both #25 and #26 merged green and broke main on the post-merge push. Worth a follow-up to also run Pack in PR CI so this can't recur.

## Test plan
- [x] Local: `dotnet build -c Release` then `dotnet pack ./src/StrongTypes/StrongTypes.csproj -c Release -o out` succeeds and emits the nupkg.
- [ ] CI on this PR stays green (Pack won't actually run here — still gated to main push).
- [ ] After merge, the build-and-test run on `main` goes green end-to-end.