### PR TITLE
Pack EF Core package in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,9 @@ jobs:
 
     - name: Pack
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: dotnet pack ./src/StrongTypes/StrongTypes.csproj -c $config -o out
+      run: |
+        dotnet pack ./src/StrongTypes/StrongTypes.csproj -c $config -o out
+        dotnet pack ./src/StrongTypes.EfCore/StrongTypes.EfCore.csproj -c $config -o out
 
     - name: Upload NuGet package
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- CI's Pack step only packed `StrongTypes.csproj`, so `Kalicz.StrongTypes.EfCore` never made it to the `nuget-package` artifact or to the nuget.org push.
- Add a second `dotnet pack` for `src/StrongTypes.EfCore/StrongTypes.EfCore.csproj` into the same `out/` directory; the existing artifact upload and `dotnet nuget push ./*.nupkg` pick up both packages automatically.

## Test plan
- [ ] Merge to main and confirm both `Kalicz.StrongTypes.*.nupkg` files appear in the workflow's `nuget-package` artifact.
- [ ] Confirm both packages are pushed to nuget.org by the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)