### PR TITLE
Switch Maybe<T> JSON to flat merge-patch shape

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,17 +106,17 @@ var missing =
 
 ### JSON
 
-`Maybe<T>` serializes via `System.Text.Json` as `{ "Value": x }` for `Some` and `{ "Value": null }` for `None`. Deserialization also accepts `{}` for `None`, so callers can omit the property entirely.
+`Maybe<T>` serializes via `System.Text.Json` to the raw JSON representation of the inner value: `Some(x)` writes as `x` and `None` writes as `null`. Deserialization is the inverse — `null` reads as `None`, any value reads as `Some`. The wire format matches what a plain `T?` would produce, so callers and consumers don't need to know the property is a `Maybe` at all.
 
 ### Idiomatic usage: tri-state PATCH
 
-HTTP `PATCH` has a long-standing modelling problem for nullable fields: a request needs to distinguish three intents — *don't touch this field*, *clear this field to null*, and *set it to a new value*. A plain `T?` collapses the first two cases. `Maybe<T>?` keeps them apart, because `Maybe<T>` itself is a value, so wrapping it in `T?` adds a real third state:
+HTTP `PATCH` has a long-standing modelling problem for nullable fields: a request needs to distinguish three intents — *don't touch this field*, *clear this field to null*, and *set it to a new value*. A plain `T?` collapses the first two cases, because on the wire "property absent" and "property set to null" both bind to a null reference. `Maybe<T>?` keeps them apart, because `Maybe<T>` itself is a value, so wrapping it in `Nullable<>` adds a real third state — and the tri-state is encoded on the wire using the standard JSON Merge Patch ([RFC 7396](https://datatracker.ietf.org/doc/html/rfc7396)) conventions:
 
-| JSON                     | Property value      | Intent                |
-| ------------------------ | ------------------- | --------------------- |
-| field omitted, or `null` | `null`              | leave field untouched |
-| `{}` or `{"Value":null}` | `Maybe<T>.None`     | clear field to `null` |
-| `{"Value":x}`            | `Maybe<T>.Some(x)`  | set field to `x`      |
+| JSON          | Property value       | Intent                |
+| ------------- | -------------------- | --------------------- |
+| field omitted | `null`               | leave field untouched |
+| `null`        | `Maybe<T>.None`      | clear field to `null` |
+| `x`           | `Maybe<T>.Some(x)`   | set field to `x`      |
 
 The request DTO and PATCH handler then read straight off pattern matching, with no out-of-band sentinel values:
 
@@ -139,6 +139,13 @@ public async Task<IActionResult> Patch(Guid id, PatchRequest request)
     await Db.SaveChangesAsync();
     return Ok();
 }
+```
+
+For the tri-state to survive deserialization, `MaybeJsonConverterFactory` has to be registered in `JsonSerializerOptions.Converters`. The `[JsonConverter]` attribute on `Maybe<T>` covers `Maybe<T>` itself, but `System.Text.Json`'s built-in `Nullable<T>` handling would otherwise intercept JSON `null` before the underlying converter runs, collapsing the *clear* case back into a null reference. Registering the factory makes STJ route `Nullable<Maybe<T>>` through the library's own converter, which preserves `null` as `Maybe<T>.None`:
+
+```csharp
+builder.Services.AddControllers()
+    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new MaybeJsonConverterFactory()));
 ```
 
 The `StrongTypes.Api` project in this repo uses exactly this pattern — see [`StructTypeEntityControllerBase.Patch`](src/StrongTypes.Api/Controllers/StructTypeEntityControllerBase.cs) and [`StructEntityPatchRequest`](src/StrongTypes.Api/Models/EntityModels.cs) for the production version that round-trips through both SQL Server and PostgreSQL.

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
@@ -244,10 +244,12 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
 
     // ── Patch ────────────────────────────────────────────────────────────
     //
-    // Patch wire semantics:
-    //   Value        — null/absent ⇒ skip. Non-null ⇒ update.
-    //   NullableValue — null/absent ⇒ skip. Maybe Some ⇒ update. Maybe Empty ⇒ clear.
-    // "Empty" on the wire is any of {}, {"Value":null}, or {"value":null}.
+    // Patch wire semantics follow JSON Merge Patch (RFC 7396): each field is
+    // independently absent, null, or a value.
+    //   Value        — absent/null ⇒ skip. A value ⇒ update.
+    //                  (The field is non-nullable on the entity, so there is
+    //                  nothing to clear; explicit null is a no-op.)
+    //   NullableValue — absent ⇒ skip. null ⇒ clear. A value ⇒ update.
 
     [Fact]
     public async Task Patch_EmptyBody_LeavesBothFieldsUnchanged()
@@ -279,8 +281,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     {
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
 
-        var response = await Patch(PatchEndpoint(created.Id),
-            new { value = (object?)null, nullableValue = (object?)null });
+        var response = await Patch(PatchEndpoint(created.Id), new { value = (object?)null });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var expected = Create(FirstValid);
@@ -293,7 +294,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     {
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = (object?)null });
 
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = UpdatedValid } });
+        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = UpdatedValid });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         await AssertEntity(SqlSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
@@ -301,23 +302,11 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     }
 
     [Fact]
-    public async Task Patch_NullableValueEmptyObject_ClearsNullableValue()
+    public async Task Patch_NullableValueExplicitNull_ClearsNullableValue()
     {
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
 
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueWithExplicitNullInner_ClearsNullableValue()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = (object?)null } });
+        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = (object?)null });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
@@ -329,7 +318,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     {
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = (object?)null });
 
-        var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid, nullableValue = new { Value = UpdatedValid } });
+        var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid, nullableValue = UpdatedValid });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         await AssertEntity(SqlSet, created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));

--- a/src/StrongTypes.Api/Models/EntityModels.cs
+++ b/src/StrongTypes.Api/Models/EntityModels.cs
@@ -7,13 +7,14 @@ public record StructEntityRequest<T>(T Value, T? NullableValue) where T : struct
 public record ReferenceEntityRequest<T>(T Value, T? NullableValue) where T : class;
 
 /// <summary>
-/// PATCH request body. Each field is independently "sent or not":
+/// PATCH request body following JSON Merge Patch (RFC 7396). Each field is
+/// independently absent, <c>null</c>, or a value:
 /// <list type="bullet">
-///   <item><description><c>Value</c>: <c>null</c> (or absent) ⇒ do not update; a value ⇒ update.
-///     The entity's Value is non-nullable so it can only be updated, never cleared.</description></item>
-///   <item><description><c>NullableValue</c>: <c>null</c> (or absent) ⇒ do not update;
-///     <c>Maybe</c> empty (<c>{}</c> or <c>{"Value":null}</c>) ⇒ clear to null on the entity;
-///     <c>{"Value":x}</c> ⇒ set to x.</description></item>
+///   <item><description><c>Value</c>: absent or <c>null</c> ⇒ do not update;
+///     a value ⇒ update. The entity's Value is non-nullable so it can only
+///     be updated, never cleared — explicit <c>null</c> is a no-op.</description></item>
+///   <item><description><c>NullableValue</c>: absent ⇒ do not update;
+///     <c>null</c> ⇒ clear to null on the entity; a value ⇒ set to that value.</description></item>
 /// </list>
 /// </summary>
 public record StructEntityPatchRequest<T>(T? Value, Maybe<T>? NullableValue) where T : struct;

--- a/src/StrongTypes.Api/Program.cs
+++ b/src/StrongTypes.Api/Program.cs
@@ -1,10 +1,17 @@
 using Microsoft.EntityFrameworkCore;
+using StrongTypes;
 using StrongTypes.Api.Data;
 using StrongTypes.EfCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+// Register MaybeJsonConverterFactory globally so Maybe<T>? PATCH properties
+// distinguish absent/null/value. The [JsonConverter] attribute on Maybe<T>
+// covers Maybe<T> itself, but STJ's built-in Nullable<T> handling wraps the
+// inner converter in a way that collapses JSON null into a null nullable —
+// the factory needs to intercept Nullable<Maybe<T>> via Options.Converters.
+builder.Services.AddControllers()
+    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(new MaybeJsonConverterFactory()));
 builder.Services.AddDbContext<SqlServerDbContext>(options => options
     .UseSqlServer(builder.Configuration.GetConnectionString("SqlServer"))
     .UseStrongTypes());

--- a/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
+++ b/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
@@ -189,6 +189,93 @@ public class MaybeJsonConverterTests
         Assert.Equal("42", json);
     }
 
+    [Fact]
+    public void ReadNullable_ReferenceType_Scalar_IsPresentSome()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<string>?>("\"hello\"", TriStateOptions());
+        Assert.Equal(Maybe<string>.Some("hello"), m);
+    }
+
+    [Fact]
+    public void ReadNullable_ReferenceType_Null_IsPresentNone()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<string>?>("null", TriStateOptions());
+        Assert.True(m.HasValue);
+        Assert.Equal(Maybe<string>.None, m!.Value);
+    }
+
+    [Fact]
+    public void WriteNullable_ReferenceType_Some()
+    {
+        var json = JsonSerializer.Serialize<Maybe<string>?>(Maybe<string>.Some("hi"), TriStateOptions());
+        Assert.Equal("\"hi\"", json);
+    }
+
+    // ── Nullable + strong-type inner converters ─────────────────────────
+
+    [Fact]
+    public void ReadNullable_MaybeOfNonEmptyString_Some()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<NonEmptyString>?>("\"abc\"", TriStateOptions());
+        Assert.Equal(Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc")), m);
+    }
+
+    [Fact]
+    public void ReadNullable_MaybeOfNonEmptyString_Null_IsPresentNone()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<NonEmptyString>?>("null", TriStateOptions());
+        Assert.True(m.HasValue);
+        Assert.Equal(Maybe<NonEmptyString>.None, m!.Value);
+    }
+
+    [Fact]
+    public void WriteNullable_MaybeOfNonEmptyString_Some()
+    {
+        var json = JsonSerializer.Serialize<Maybe<NonEmptyString>?>(
+            Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc")), TriStateOptions());
+        Assert.Equal("\"abc\"", json);
+    }
+
+    [Fact]
+    public void ReadNullable_MaybeOfNonEmptyString_InvalidValue_Throws()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Maybe<NonEmptyString>?>("\"   \"", TriStateOptions()));
+    }
+
+    [Fact]
+    public void ReadNullable_MaybeOfPositiveInt_Some()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>?>("7", TriStateOptions());
+        Assert.Equal(Maybe<Positive<int>>.Some(Positive<int>.Create(7)), m);
+    }
+
+    [Fact]
+    public void ReadNullable_MaybeOfPositiveInt_Null_IsPresentNone()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>?>("null", TriStateOptions());
+        Assert.True(m.HasValue);
+        Assert.Equal(Maybe<Positive<int>>.None, m!.Value);
+    }
+
+    [Fact]
+    public void WriteNullable_MaybeOfPositiveInt_Some()
+    {
+        var json = JsonSerializer.Serialize<Maybe<Positive<int>>?>(
+            Maybe<Positive<int>>.Some(Positive<int>.Create(7)), TriStateOptions());
+        Assert.Equal("7", json);
+    }
+
+    [Fact]
+    public void ReadNullable_MaybeOfPositiveInt_InvalidValue_Throws()
+    {
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Maybe<Positive<int>>?>("0", TriStateOptions()));
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<Maybe<Positive<int>>?>("-5", TriStateOptions()));
+    }
+
     // The absent/null/value distinction only matters in a parent object
     // context, because "absent" means STJ never invokes the converter for
     // that property. Two records cover both shapes end-to-end — Maybe<T>?

--- a/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
+++ b/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
@@ -9,83 +9,56 @@ namespace StrongTypes.Tests;
 [Properties(Arbitrary = new[] { typeof(Generators) })]
 public class MaybeJsonConverterTests
 {
-    // ── Read: all three accepted shapes map to the expected Maybe ───────
+    // ── Maybe<T>: flat wire format (raw value, not an object wrapper) ────
 
     [Fact]
-    public void Read_EmptyObject_IsEmpty()
+    public void Read_Null_IsNone()
     {
-        var m = JsonSerializer.Deserialize<Maybe<int>>("{}");
+        var m = JsonSerializer.Deserialize<Maybe<int>>("null");
         Assert.False(m.HasValue);
     }
 
     [Fact]
-    public void Read_ValueNull_IsEmpty()
+    public void Read_Scalar_IsSome()
     {
-        var m = JsonSerializer.Deserialize<Maybe<int>>("""{"Value":null}""");
-        Assert.False(m.HasValue);
+        var m = JsonSerializer.Deserialize<Maybe<int>>("4");
+        Assert.Equal(Maybe<int>.Some(4), m);
     }
 
     [Fact]
-    public void Read_ValueSet_IsSome()
+    public void Read_ReferenceType_Scalar_IsSome()
     {
-        var m = JsonSerializer.Deserialize<Maybe<int>>("""{"Value":4}""");
-        Assert.True(m.HasValue);
-        Assert.Equal(4, m.Value);
-    }
-
-    [Fact]
-    public void Read_CaseInsensitivePropertyName()
-    {
-        var m = JsonSerializer.Deserialize<Maybe<int>>("""{"value":4}""");
-        Assert.True(m.HasValue);
-        Assert.Equal(4, m.Value);
-    }
-
-    [Fact]
-    public void Read_UnknownProperty_Ignored()
-    {
-        var m = JsonSerializer.Deserialize<Maybe<int>>("""{"Extra":"x","Value":7}""");
-        Assert.Equal(Maybe<int>.Some(7), m);
-    }
-
-    [Fact]
-    public void Read_ReferenceType_ValueSet_IsSome()
-    {
-        var m = JsonSerializer.Deserialize<Maybe<string>>("""{"Value":"hello"}""");
+        var m = JsonSerializer.Deserialize<Maybe<string>>("\"hello\"");
         Assert.Equal(Maybe<string>.Some("hello"), m);
     }
 
     [Fact]
-    public void Read_ReferenceType_EmptyObject_IsEmpty()
+    public void Read_ReferenceType_Null_IsNone()
     {
-        var m = JsonSerializer.Deserialize<Maybe<string>>("{}");
+        var m = JsonSerializer.Deserialize<Maybe<string>>("null");
         Assert.False(m.HasValue);
     }
 
-    // ── Write: always emits {"Value": ...} shape ────────────────────────
-
     [Fact]
-    public void Write_Some_EmitsValueProperty()
+    public void Write_Some_EmitsRawValue()
     {
         var json = JsonSerializer.Serialize(Maybe<int>.Some(42));
-        Assert.Equal("""{"Value":42}""", json);
+        Assert.Equal("42", json);
     }
 
     [Fact]
-    public void Write_Empty_EmitsValueNull()
+    public void Write_None_EmitsNull()
     {
         var json = JsonSerializer.Serialize(Maybe<int>.None);
-        Assert.Equal("""{"Value":null}""", json);
+        Assert.Equal("null", json);
     }
 
     [Fact]
     public void Write_ReferenceType_Some()
     {
         var json = JsonSerializer.Serialize(Maybe<string>.Some("hi"));
-        Assert.Equal("""{"Value":"hi"}""", json);
+        Assert.Equal("\"hi\"", json);
     }
-
-    // ── Roundtrip (property-based) ──────────────────────────────────────
 
     [Property]
     public void Roundtrip_Int(Maybe<int> m)
@@ -101,21 +74,20 @@ public class MaybeJsonConverterTests
         Assert.Equal(m, JsonSerializer.Deserialize<Maybe<string>>(json));
     }
 
-    // ── Interop with strong-type converters ─────────────────────────────
+    // ── Interop with strong-type inner converters ───────────────────────
 
     [Fact]
     public void Read_MaybeOfNonEmptyString_UsesItsConverter()
     {
-        var m = JsonSerializer.Deserialize<Maybe<NonEmptyString>>("""{"Value":"abc"}""");
-        Assert.True(m.HasValue);
-        Assert.Equal(NonEmptyString.Create("abc"), m.Value);
+        var m = JsonSerializer.Deserialize<Maybe<NonEmptyString>>("\"abc\"");
+        Assert.Equal(Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc")), m);
     }
 
     [Fact]
     public void Write_MaybeOfNonEmptyString_UsesItsConverter()
     {
         var json = JsonSerializer.Serialize(Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc")));
-        Assert.Equal("""{"Value":"abc"}""", json);
+        Assert.Equal("\"abc\"", json);
     }
 
     [Fact]
@@ -124,21 +96,20 @@ public class MaybeJsonConverterTests
         // The inner NonEmptyString converter rejects whitespace/empty, and that
         // JsonException must surface — we don't want a silent fallback to None.
         Assert.Throws<JsonException>(() =>
-            JsonSerializer.Deserialize<Maybe<NonEmptyString>>("""{"Value":"   "}"""));
+            JsonSerializer.Deserialize<Maybe<NonEmptyString>>("\"   \""));
     }
 
     [Fact]
     public void Read_MaybeOfPositiveInt_Some()
     {
-        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>>("""{"Value":7}""");
-        Assert.True(m.HasValue);
-        Assert.Equal(Positive<int>.Create(7), m.Value);
+        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>>("7");
+        Assert.Equal(Maybe<Positive<int>>.Some(Positive<int>.Create(7)), m);
     }
 
     [Fact]
-    public void Read_MaybeOfPositiveInt_Empty()
+    public void Read_MaybeOfPositiveInt_Null_IsNone()
     {
-        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>>("{}");
+        var m = JsonSerializer.Deserialize<Maybe<Positive<int>>>("null");
         Assert.False(m.HasValue);
     }
 
@@ -146,19 +117,19 @@ public class MaybeJsonConverterTests
     public void Write_MaybeOfPositiveInt_Some()
     {
         var json = JsonSerializer.Serialize(Maybe<Positive<int>>.Some(Positive<int>.Create(7)));
-        Assert.Equal("""{"Value":7}""", json);
+        Assert.Equal("7", json);
     }
 
     [Fact]
     public void Read_MaybeOfPositiveInt_InvalidValue_Throws()
     {
-        // Zero violates the Positive invariant — the inner converter throws
-        // and that exception propagates through the Maybe converter.
+        // Zero violates the Positive invariant — the inner converter throws and
+        // that exception propagates through the Maybe converter.
         Assert.Throws<JsonException>(() =>
-            JsonSerializer.Deserialize<Maybe<Positive<int>>>("""{"Value":0}"""));
+            JsonSerializer.Deserialize<Maybe<Positive<int>>>("0"));
 
         Assert.Throws<JsonException>(() =>
-            JsonSerializer.Deserialize<Maybe<Positive<int>>>("""{"Value":-5}"""));
+            JsonSerializer.Deserialize<Maybe<Positive<int>>>("-5"));
     }
 
     [Property]
@@ -166,5 +137,85 @@ public class MaybeJsonConverterTests
     {
         var json = JsonSerializer.Serialize(m);
         Assert.Equal(m, JsonSerializer.Deserialize<Maybe<Positive<int>>>(json));
+    }
+
+    // ── Maybe<T>?: tri-state for HTTP PATCH ─────────────────────────────
+    //
+    // STJ's default Nullable<T> handling intercepts JSON null before the
+    // underlying converter runs, which would collapse null into a null
+    // nullable. Registering MaybeJsonConverterFactory in Options.Converters
+    // provides an explicit Nullable<Maybe<T>> converter that keeps the three
+    // states distinct.
+
+    private static JsonSerializerOptions TriStateOptions() => new()
+    {
+        Converters = { new MaybeJsonConverterFactory() }
+    };
+
+    [Fact]
+    public void ReadNullable_JsonNull_IsPresentNone()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<int>?>("null", TriStateOptions());
+        Assert.True(m.HasValue);
+        Assert.Equal(Maybe<int>.None, m!.Value);
+    }
+
+    [Fact]
+    public void ReadNullable_JsonValue_IsPresentSome()
+    {
+        var m = JsonSerializer.Deserialize<Maybe<int>?>("7", TriStateOptions());
+        Assert.True(m.HasValue);
+        Assert.Equal(Maybe<int>.Some(7), m!.Value);
+    }
+
+    [Fact]
+    public void WriteNullable_Null_EmitsJsonNull()
+    {
+        var json = JsonSerializer.Serialize<Maybe<int>?>(null, TriStateOptions());
+        Assert.Equal("null", json);
+    }
+
+    [Fact]
+    public void WriteNullable_None_EmitsJsonNull()
+    {
+        var json = JsonSerializer.Serialize<Maybe<int>?>(Maybe<int>.None, TriStateOptions());
+        Assert.Equal("null", json);
+    }
+
+    [Fact]
+    public void WriteNullable_Some_EmitsRawValue()
+    {
+        var json = JsonSerializer.Serialize<Maybe<int>?>(Maybe<int>.Some(42), TriStateOptions());
+        Assert.Equal("42", json);
+    }
+
+    // The absent/null/value distinction only matters in a parent object
+    // context, because "absent" means STJ never invokes the converter for
+    // that property. A simple record exercises all three states end-to-end.
+    private sealed record PatchDto(int? Value, Maybe<int>? NullableValue);
+
+    [Fact]
+    public void ReadPatchDto_PropertyAbsent_StaysNull()
+    {
+        var dto = JsonSerializer.Deserialize<PatchDto>("""{"Value":1}""", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(1, dto!.Value);
+        Assert.Null(dto.NullableValue);
+    }
+
+    [Fact]
+    public void ReadPatchDto_PropertyJsonNull_IsPresentNone()
+    {
+        var dto = JsonSerializer.Deserialize<PatchDto>("""{"NullableValue":null}""", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(Maybe<int>.None, dto!.NullableValue);
+    }
+
+    [Fact]
+    public void ReadPatchDto_PropertyJsonValue_IsPresentSome()
+    {
+        var dto = JsonSerializer.Deserialize<PatchDto>("""{"NullableValue":42}""", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(Maybe<int>.Some(42), dto!.NullableValue);
     }
 }

--- a/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
+++ b/src/StrongTypes.Tests/Maybe/MaybeJsonConverterTests.cs
@@ -191,8 +191,12 @@ public class MaybeJsonConverterTests
 
     // The absent/null/value distinction only matters in a parent object
     // context, because "absent" means STJ never invokes the converter for
-    // that property. A simple record exercises all three states end-to-end.
+    // that property. Two records cover both shapes end-to-end — Maybe<T>?
+    // for the tri-state PATCH case and plain Maybe<T> for the flat case.
     private sealed record PatchDto(int? Value, Maybe<int>? NullableValue);
+    private sealed record PlainDto(Maybe<int> NullableValue);
+
+    // ── Maybe<T>? as a property: read ────────────────────────────────────
 
     [Fact]
     public void ReadPatchDto_PropertyAbsent_StaysNull()
@@ -217,5 +221,72 @@ public class MaybeJsonConverterTests
         var dto = JsonSerializer.Deserialize<PatchDto>("""{"NullableValue":42}""", TriStateOptions());
         Assert.NotNull(dto);
         Assert.Equal(Maybe<int>.Some(42), dto!.NullableValue);
+    }
+
+    // ── Maybe<T>? as a property: write ───────────────────────────────────
+
+    [Fact]
+    public void WritePatchDto_PropertyNull_EmitsJsonNull()
+    {
+        var json = JsonSerializer.Serialize(new PatchDto(null, null), TriStateOptions());
+        Assert.Equal("""{"Value":null,"NullableValue":null}""", json);
+    }
+
+    [Fact]
+    public void WritePatchDto_PropertyNone_EmitsJsonNull()
+    {
+        var json = JsonSerializer.Serialize(new PatchDto(null, Maybe<int>.None), TriStateOptions());
+        Assert.Equal("""{"Value":null,"NullableValue":null}""", json);
+    }
+
+    [Fact]
+    public void WritePatchDto_PropertySome_EmitsRawValue()
+    {
+        var json = JsonSerializer.Serialize(new PatchDto(null, Maybe<int>.Some(42)), TriStateOptions());
+        Assert.Equal("""{"Value":null,"NullableValue":42}""", json);
+    }
+
+    // ── Maybe<T> as a property (non-nullable): read ──────────────────────
+    // Absent and null both land on Maybe<T>.None — the flat shape collapses
+    // them, which is why PATCH DTOs use Maybe<T>? instead.
+
+    [Fact]
+    public void ReadPlainDto_PropertyAbsent_IsNone()
+    {
+        var dto = JsonSerializer.Deserialize<PlainDto>("{}", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(Maybe<int>.None, dto!.NullableValue);
+    }
+
+    [Fact]
+    public void ReadPlainDto_PropertyJsonNull_IsNone()
+    {
+        var dto = JsonSerializer.Deserialize<PlainDto>("""{"NullableValue":null}""", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(Maybe<int>.None, dto!.NullableValue);
+    }
+
+    [Fact]
+    public void ReadPlainDto_PropertyJsonValue_IsSome()
+    {
+        var dto = JsonSerializer.Deserialize<PlainDto>("""{"NullableValue":42}""", TriStateOptions());
+        Assert.NotNull(dto);
+        Assert.Equal(Maybe<int>.Some(42), dto!.NullableValue);
+    }
+
+    // ── Maybe<T> as a property (non-nullable): write ─────────────────────
+
+    [Fact]
+    public void WritePlainDto_PropertyNone_EmitsJsonNull()
+    {
+        var json = JsonSerializer.Serialize(new PlainDto(Maybe<int>.None), TriStateOptions());
+        Assert.Equal("""{"NullableValue":null}""", json);
+    }
+
+    [Fact]
+    public void WritePlainDto_PropertySome_EmitsRawValue()
+    {
+        var json = JsonSerializer.Serialize(new PlainDto(Maybe<int>.Some(42)), TriStateOptions());
+        Assert.Equal("""{"NullableValue":42}""", json);
     }
 }

--- a/src/StrongTypes/Maybe/MaybeJsonConverter.cs
+++ b/src/StrongTypes/Maybe/MaybeJsonConverter.cs
@@ -8,83 +8,104 @@ using System.Text.Json.Serialization;
 namespace StrongTypes;
 
 /// <summary>
-/// <see cref="JsonConverterFactory"/> for <see cref="Maybe{T}"/> that accepts any of
-/// the following JSON shapes as inputs:
+/// <see cref="JsonConverterFactory"/> for <see cref="Maybe{T}"/> and for
+/// <see cref="Nullable{T}"/> of <see cref="Maybe{T}"/>. Both use the flat wire
+/// format — the underlying <typeparamref name="T"/>'s JSON value, not an object
+/// wrapper:
 /// <list type="bullet">
-///   <item><description><c>{}</c> — empty Maybe</description></item>
-///   <item><description><c>{ "Value": null }</c> — empty Maybe</description></item>
-///   <item><description><c>{ "Value": x }</c> — <see cref="Maybe{T}.Some"/> with the parsed value</description></item>
+///   <item><description><c>Maybe&lt;T&gt;</c> serializes <c>Some(x)</c> as the raw
+///     JSON representation of <c>x</c> and <c>None</c> as <c>null</c>.
+///     Deserialization is the inverse: <c>null</c> ⇒ <c>None</c>, any value ⇒
+///     <c>Some</c>.</description></item>
+///   <item><description><c>Maybe&lt;T&gt;?</c> distinguishes three states on the
+///     wire — the three states of an HTTP <c>PATCH</c> body:
+///     <list type="bullet">
+///       <item><description>property absent ⇒ the property stays <c>null</c> (STJ
+///         never invokes the converter).</description></item>
+///       <item><description>property <c>null</c> ⇒ the property is a present
+///         nullable whose value is <c>Maybe&lt;T&gt;.None</c>.</description></item>
+///       <item><description>property has a value ⇒ the property is a present
+///         nullable whose value is <c>Maybe&lt;T&gt;.Some(x)</c>.</description></item>
+///     </list>
+///     This only works when the factory is registered in
+///     <see cref="JsonSerializerOptions.Converters"/> — the <c>[JsonConverter]</c>
+///     attribute on <see cref="Maybe{T}"/> is resolved for <c>Maybe&lt;T&gt;</c>
+///     only, and STJ's built-in <c>Nullable&lt;T&gt;</c> handling would otherwise
+///     collapse JSON <c>null</c> into a <c>null</c> nullable and lose the
+///     distinction from absence.</description></item>
 /// </list>
-/// Writes an empty Maybe as <c>{ "Value": null }</c> and a populated Maybe as
-/// <c>{ "Value": x }</c>.
 /// </summary>
 public sealed class MaybeJsonConverterFactory : JsonConverterFactory
 {
     private static readonly ConcurrentDictionary<Type, JsonConverter> s_converterCache = new();
 
-    public override bool CanConvert(Type typeToConvert) =>
-        typeToConvert.IsGenericType
-        && typeToConvert.GetGenericTypeDefinition() == typeof(Maybe<>);
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (!typeToConvert.IsGenericType) return false;
+        var generic = typeToConvert.GetGenericTypeDefinition();
+        if (generic == typeof(Maybe<>)) return true;
+        if (generic == typeof(Nullable<>))
+        {
+            var inner = typeToConvert.GetGenericArguments()[0];
+            return inner.IsGenericType && inner.GetGenericTypeDefinition() == typeof(Maybe<>);
+        }
+        return false;
+    }
 
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>
         s_converterCache.GetOrAdd(typeToConvert, static t =>
         {
-            var innerType = t.GetGenericArguments()[0];
-            var converterType = typeof(Inner<>).MakeGenericType(innerType);
-            return (JsonConverter)Activator.CreateInstance(converterType)!;
+            if (t.GetGenericTypeDefinition() == typeof(Maybe<>))
+            {
+                var innerType = t.GetGenericArguments()[0];
+                var converterType = typeof(Inner<>).MakeGenericType(innerType);
+                return (JsonConverter)Activator.CreateInstance(converterType)!;
+            }
+
+            // Nullable<Maybe<T>> — unwrap twice to get T.
+            var maybeType = t.GetGenericArguments()[0];
+            var valueType = maybeType.GetGenericArguments()[0];
+            var nullableConverterType = typeof(NullableInner<>).MakeGenericType(valueType);
+            return (JsonConverter)Activator.CreateInstance(nullableConverterType)!;
         });
 
     private sealed class Inner<T> : JsonConverter<Maybe<T>> where T : notnull
     {
+        public override bool HandleNull => true;
+
         public override Maybe<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-                throw new JsonException($"Expected StartObject for {typeof(Maybe<T>).Name}, got {reader.TokenType}.");
-
-            Maybe<T> result = default;
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject) return result;
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                    throw new JsonException();
-
-                var propName = reader.GetString();
-                reader.Read();
-
-                if (string.Equals(propName, "Value", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (reader.TokenType == JsonTokenType.Null)
-                    {
-                        result = default;
-                    }
-                    else
-                    {
-                        var value = JsonSerializer.Deserialize<T>(ref reader, options);
-                        // T : notnull at declaration, but the wire is honest — only
-                        // wrap in Some when the parsed value is actually non-null.
-                        if (value is not null)
-                            result = Maybe<T>.Some(value);
-                    }
-                }
-                else
-                {
-                    reader.Skip();
-                }
-            }
-
-            throw new JsonException($"Unexpected end of JSON while reading {typeof(Maybe<T>).Name}.");
+            if (reader.TokenType == JsonTokenType.Null) return default;
+            var value = JsonSerializer.Deserialize<T>(ref reader, options);
+            return value is null ? default : Maybe<T>.Some(value);
         }
 
         public override void Write(Utf8JsonWriter writer, Maybe<T> value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WritePropertyName("Value");
             if (value.HasValue)
                 JsonSerializer.Serialize(writer, value.InternalValue, options);
             else
                 writer.WriteNullValue();
-            writer.WriteEndObject();
+        }
+    }
+
+    private sealed class NullableInner<T> : JsonConverter<Maybe<T>?> where T : notnull
+    {
+        public override bool HandleNull => true;
+
+        public override Maybe<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null) return Maybe<T>.None;
+            var value = JsonSerializer.Deserialize<T>(ref reader, options);
+            return value is null ? Maybe<T>.None : Maybe<T>.Some(value);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Maybe<T>? value, JsonSerializerOptions options)
+        {
+            if (value is { } m && m.HasValue)
+                JsonSerializer.Serialize(writer, m.InternalValue, options);
+            else
+                writer.WriteNullValue();
         }
     }
 }

--- a/src/StrongTypes/Maybe/MaybeJsonConverter.cs
+++ b/src/StrongTypes/Maybe/MaybeJsonConverter.cs
@@ -10,8 +10,7 @@ namespace StrongTypes;
 /// <summary>
 /// <see cref="JsonConverterFactory"/> for <see cref="Maybe{T}"/> and for
 /// <see cref="Nullable{T}"/> of <see cref="Maybe{T}"/>. Both use the flat wire
-/// format — the underlying <typeparamref name="T"/>'s JSON value, not an object
-/// wrapper:
+/// format — the underlying <c>T</c>'s JSON value, not an object wrapper:
 /// <list type="bullet">
 ///   <item><description><c>Maybe&lt;T&gt;</c> serializes <c>Some(x)</c> as the raw
 ///     JSON representation of <c>x</c> and <c>None</c> as <c>null</c>.


### PR DESCRIPTION
## Summary

`Maybe<T>` previously serialized as `{"Value": x}` / `{"Value": null}`. The wrapper object was chosen to give `Maybe<T>?` tri-state PATCH semantics (absent = no-op, `{}` = clear, `{"Value": x}` = set), but that shape is non-idiomatic — RFC 7396 (JSON Merge Patch), RFC 6902 (JSON Patch), Protobuf FieldMask, and GraphQL all encode the same three intents through key presence on a flat value.

This PR moves the wire format to the flat shape:

| JSON          | `Maybe<T>?` value    | Intent               |
| ------------- | -------------------- | -------------------- |
| field omitted | `null`               | leave field untouched |
| `null`        | `Maybe<T>.None`      | clear field to `null` |
| `x`           | `Maybe<T>.Some(x)`   | set field to `x`      |

### Implementation

- `MaybeJsonConverter.cs` — `Maybe<T>` now writes `Some(x)` as the raw JSON of `x` and `None` as `null`. The factory also produces a dedicated `JsonConverter<Maybe<T>?>` with `HandleNull = true`, mapping JSON `null` to `Maybe<T>.None` and a value to `Maybe<T>.Some(x)`. STJ's built-in `Nullable<T>` handling would otherwise intercept `null` before our converter runs and collapse the *clear* case into a null reference.
- `StrongTypes.Api/Program.cs` — registers the factory in `JsonSerializerOptions.Converters`. The `[JsonConverter]` attribute on `Maybe<T>` alone isn't enough because attributes on `Maybe<T>` don't carry over to `Nullable<Maybe<T>>`.
- `readme.md` — the `### JSON` and `### Idiomatic usage: tri-state PATCH` sections document the new flat shape and the factory-registration requirement.
- `EntityModels.cs` — XML doc on `StructEntityPatchRequest` / `ReferenceEntityPatchRequest` updated to describe merge-patch semantics.

### Tests

- `MaybeJsonConverterTests.cs` rewritten for the flat shape. Full read/write matrix on both sides:
  - **Top-level `Maybe<T>`** — read null/value, write None/Some, reference-type, roundtrips, inner-converter interop (NonEmptyString, Positive\<int\>) including invalid-inner-value throws.
  - **Top-level `Maybe<T>?`** — every non-nullable top-level case mirrored: int, string, NonEmptyString, Positive\<int\>; read null ⇒ present None; write null/None/Some all emit `null`/`null`/`x`.
  - **Parent-record properties** — `PatchDto(int?, Maybe<int>?)` covers absent / null / value on both read and write; `PlainDto(Maybe<int>)` covers the flat-shape collapse (absent and null both ⇒ None) on read and write.
- `EntityTests.cs` PATCH suite updated to send the flat JSON (`{"nullableValue": x}`, `{"nullableValue": null}`, field absent). Dropped the now-redundant `Patch_NullableValueWithExplicitNullInner_ClearsNullableValue`. Semantics comment block at the top rewritten in merge-patch terms.

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test src/StrongTypes.Tests` passes (unit converter tests, including the new nullable parity set)
- [ ] `dotnet test src/StrongTypes.Api.IntegrationTests` passes (PATCH flat-JSON e2e across SQL Server + PostgreSQL)
- [ ] Skim the rendered readme to confirm the flat-PATCH table and the factory-registration example look right

https://claude.ai/code/session_01Tx7cofXtcsTkPbYyFTY5Pn