### PR TITLE
Add DTO-level JSON round-trip tests for Maybe properties

### DIFF
--- a/src/StrongTypes.Tests/Maybe/MaybeDtoJsonTests.cs
+++ b/src/StrongTypes.Tests/Maybe/MaybeDtoJsonTests.cs
@@ -1,0 +1,89 @@
+#nullable enable
+
+using System.Text.Json;
+using Xunit;
+
+namespace StrongTypes.Tests;
+
+/// <summary>
+/// Round-trip coverage for DTOs whose properties are <see cref="Maybe{T}"/>
+/// and <see cref="Maybe{T}"/>? — the realistic request-body shape. Each case
+/// asserts both directions against a single canonical JSON string: reading
+/// the string produces the expected DTO, and serializing the DTO produces
+/// the same string back.
+/// </summary>
+public class MaybeDtoJsonTests
+{
+    private sealed record IntDto(Maybe<int> Value, Maybe<int>? NullableValue);
+    private sealed record StringDto(Maybe<string> Value, Maybe<string>? NullableValue);
+
+    private static void AssertRoundTrip<T>(T value, string json)
+    {
+        Assert.Equal(json, JsonSerializer.Serialize(value));
+        Assert.Equal(value, JsonSerializer.Deserialize<T>(json));
+    }
+
+    // ── IntDto: Maybe<int> required, Maybe<int>? optional ───────────────
+
+    [Fact]
+    public void IntDto_Some_NullableNull() => AssertRoundTrip(
+        new IntDto(Maybe.Some(7), null),
+        """{"Value":{"Value":7},"NullableValue":null}""");
+
+    [Fact]
+    public void IntDto_Some_NullableSome() => AssertRoundTrip(
+        new IntDto(Maybe.Some(7), Maybe.Some(3)),
+        """{"Value":{"Value":7},"NullableValue":{"Value":3}}""");
+
+    [Fact]
+    public void IntDto_Some_NullableNone() => AssertRoundTrip(
+        new IntDto(Maybe.Some(7), Maybe<int>.None),
+        """{"Value":{"Value":7},"NullableValue":{"Value":null}}""");
+
+    [Fact]
+    public void IntDto_None_NullableNull() => AssertRoundTrip(
+        new IntDto(Maybe<int>.None, null),
+        """{"Value":{"Value":null},"NullableValue":null}""");
+
+    [Fact]
+    public void IntDto_None_NullableSome() => AssertRoundTrip(
+        new IntDto(Maybe<int>.None, Maybe.Some(3)),
+        """{"Value":{"Value":null},"NullableValue":{"Value":3}}""");
+
+    [Fact]
+    public void IntDto_None_NullableNone() => AssertRoundTrip(
+        new IntDto(Maybe<int>.None, Maybe<int>.None),
+        """{"Value":{"Value":null},"NullableValue":{"Value":null}}""");
+
+    // ── StringDto: reference-type payload, same state matrix ────────────
+
+    [Fact]
+    public void StringDto_Some_NullableNull() => AssertRoundTrip(
+        new StringDto(Maybe.Some("hi"), null),
+        """{"Value":{"Value":"hi"},"NullableValue":null}""");
+
+    [Fact]
+    public void StringDto_Some_NullableSome() => AssertRoundTrip(
+        new StringDto(Maybe.Some("hi"), Maybe.Some("there")),
+        """{"Value":{"Value":"hi"},"NullableValue":{"Value":"there"}}""");
+
+    [Fact]
+    public void StringDto_Some_NullableNone() => AssertRoundTrip(
+        new StringDto(Maybe.Some("hi"), Maybe<string>.None),
+        """{"Value":{"Value":"hi"},"NullableValue":{"Value":null}}""");
+
+    [Fact]
+    public void StringDto_None_NullableNull() => AssertRoundTrip(
+        new StringDto(Maybe<string>.None, null),
+        """{"Value":{"Value":null},"NullableValue":null}""");
+
+    [Fact]
+    public void StringDto_None_NullableSome() => AssertRoundTrip(
+        new StringDto(Maybe<string>.None, Maybe.Some("there")),
+        """{"Value":{"Value":null},"NullableValue":{"Value":"there"}}""");
+
+    [Fact]
+    public void StringDto_None_NullableNone() => AssertRoundTrip(
+        new StringDto(Maybe<string>.None, Maybe<string>.None),
+        """{"Value":{"Value":null},"NullableValue":{"Value":null}}""");
+}


### PR DESCRIPTION
## Summary

- Adds `MaybeDtoJsonTests` covering DTOs whose properties are `Maybe<T>` and `Maybe<T>?` — the realistic request-body shape.
- Each test asserts both read and write against a single canonical JSON string, so `JsonSerializer.Deserialize(json)` → DTO and `JsonSerializer.Serialize(dto)` → the same string are both verified in one case and any future wire-format drift trips the round trip.
- Covers the full state matrix for both a value-type payload (`Maybe<int>`) and a reference-type payload (`Maybe<string>`):
  - required `Maybe<T>`: `Some` / `None`
  - nullable `Maybe<T>?`: `null` / `Some` / `None`-inside-present

## Context

Follows the closure of #43. That PR attempted to collapse `Maybe<T>` JSON to a flat merge-patch shape with zero converter registration; the combination of "struct `Maybe<T>`" and "no opt-in" isn't reachable under STJ's current nullable handling. These tests pin the behaviour of the existing `{ "Value": x }` converter shape against realistic request DTOs so future changes to the wire format surface immediately.

## Test plan

- [x] `dotnet test src/StrongTypes.Tests` — 472 passing, 0 failing.
- [ ] CI green on the PR.