### PR TITLE
Drop Maybe<string>/Maybe<NonEmptyString> cross-type equality

### DIFF
--- a/src/StrongTypes.Tests/Maybe/MaybeTests.cs
+++ b/src/StrongTypes.Tests/Maybe/MaybeTests.cs
@@ -262,39 +262,21 @@ public class MaybeTests
         Assert.Equal(Maybe<int>.None.GetHashCode(), Maybe<int>.None.GetHashCode());
     }
 
-    // ── Cross-type equality: Maybe<string> <-> Maybe<NonEmptyString> ────
-
+    // Cross-closed-generic pairs (e.g. Maybe<string> vs Maybe<NonEmptyString>)
+    // always compare unequal through Equals(object). Keeping Equals(object) strict
+    // preserves its symmetry contract — we can't teach bare `string` or bare `int`
+    // to see a Maybe<T> on the other side, so we don't pretend the relationship
+    // exists in one direction. Typed IEquatable<T> and operator == remain available
+    // for ergonomic same-T comparisons.
     [Fact]
-    public void CrossTypeEquality_StringEqualsNonEmptyString_WhenValuesMatch()
+    public void Equality_DifferentClosedGenerics_AlwaysUnequal()
     {
         var str = Maybe<string>.Some("abc");
         var nes = Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc"));
-        Assert.True(str.Equals((object)nes));
-        Assert.True(nes.Equals((object)str));
-    }
-
-    [Fact]
-    public void CrossTypeEquality_StringDiffersFromNonEmptyString_WhenValuesDiffer()
-    {
-        var str = Maybe<string>.Some("abc");
-        var nes = Maybe<NonEmptyString>.Some(NonEmptyString.Create("xyz"));
         Assert.False(str.Equals((object)nes));
         Assert.False(nes.Equals((object)str));
-    }
-
-    [Fact]
-    public void CrossTypeEquality_BothEmpty_Equal()
-    {
-        Assert.True(Maybe<string>.None.Equals((object)Maybe<NonEmptyString>.None));
-        Assert.True(Maybe<NonEmptyString>.None.Equals((object)Maybe<string>.None));
-    }
-
-    [Fact]
-    public void CrossTypeEquality_HashCodesMatch()
-    {
-        var str = Maybe<string>.Some("abc");
-        var nes = Maybe<NonEmptyString>.Some(NonEmptyString.Create("abc"));
-        Assert.Equal(str.GetHashCode(), nes.GetHashCode());
+        Assert.False(Maybe<string>.None.Equals((object)Maybe<NonEmptyString>.None));
+        Assert.False(Maybe<NonEmptyString>.None.Equals((object)Maybe<string>.None));
     }
 
     // ── Comparison ──────────────────────────────────────────────────────

--- a/src/StrongTypes/Maybe/Maybe.cs
+++ b/src/StrongTypes/Maybe/Maybe.cs
@@ -94,28 +94,8 @@ public readonly struct Maybe<T> :
     public bool Equals(T? other) =>
         IsSome && other is not null && EqualityComparer<T>.Default.Equals(InternalValue, other);
 
-    // Cross-type equality between Maybe<string> and Maybe<NonEmptyString> mirrors the
-    // legacy Option_Old behaviour. A broader scheme covering numeric strong types is
-    // tracked separately; see the follow-up GitHub issue referenced in the PR.
-    public override bool Equals(object? obj)
-    {
-        if (obj is Maybe<T> same) return Equals(same);
-
-        if (typeof(T) == typeof(string) && obj is Maybe<NonEmptyString> nesOther)
-        {
-            if (IsSome != nesOther.IsSome) return false;
-            if (IsNone) return true;
-            return string.Equals((string)(object)InternalValue!, nesOther.InternalValue.Value);
-        }
-        if (typeof(T) == typeof(NonEmptyString) && obj is Maybe<string> strOther)
-        {
-            if (IsSome != strOther.IsSome) return false;
-            if (IsNone) return true;
-            return string.Equals(((NonEmptyString)(object)InternalValue!).Value, strOther.InternalValue);
-        }
-
-        return false;
-    }
+    public override bool Equals(object? obj) =>
+        obj is Maybe<T> same && Equals(same);
 
     public override int GetHashCode() =>
         IsSome ? EqualityComparer<T>.Default.GetHashCode(InternalValue) : 0;


### PR DESCRIPTION
## Summary
- Remove the hardcoded `Maybe<string>` / `Maybe<NonEmptyString>` branch in `Maybe<T>.Equals(object)`; `Equals(object)` now matches only same-closed-generic `Maybe<T>`.
- Replace the four cross-equality tests with a single test that locks in the new strict behaviour.

Per discussion on #37, the typed equality surface (`IEquatable<Maybe<T>>.Equals`, `IEquatable<T>.Equals`, `operator ==`) structurally cannot participate in cross-type equality — different closed generic types do not bind to those overloads. Only `Equals(object)` ever saw the relationship, producing asymmetric behaviour relative to the typed paths. Keeping `Equals(object)` strict matches the standard BCL convention (`string`, `int`, `DateTime` all Self-only) and keeps hash-based collection semantics consistent. The typed `Maybe<T> == T` ergonomics are unchanged.

Closes #37.

## Test plan
- [x] `dotnet test` — 469/469 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)