### PR TITLE
Attach .nupkg files to the GitHub Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
     if: github.event_name == 'release' && github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
     environment: Nuget.org
+    permissions:
+      contents: write
 
     env:
       config: 'Release'
@@ -101,3 +103,8 @@ jobs:
 
     - name: Publish packages
       run: dotnet nuget push ./out/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}
+
+    - name: Attach packages to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "$GITHUB_REF_NAME" ./out/*.nupkg


### PR DESCRIPTION
## Summary
- The `publish` job pushed packages to nuget.org but left the Release page with no downloadable assets.
- Add a step that runs `gh release upload` against the triggering tag, uploading every `.nupkg` in `./out`.
- Grant `contents: write` on the `publish` job (top-level permission is `contents: read`) so the upload is authorized.

## Test plan
- [ ] Draft a Release on `main` with a tag like `v0.0.0-test` and confirm the three packages (`StrongTypes`, `StrongTypes.EfCore`, `StrongTypes.FsCheck`) appear as Release assets.
- [ ] Confirm the nuget.org push still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)