### PR TITLE
Point PackageReleaseNotes at the GitHub Release URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,13 +92,13 @@ jobs:
     # packages are picked up automatically by setting the same two properties.
     - name: Build and pack
       env:
-        NOTES: ${{ github.event.release.body }}
+        RELEASE_URL: ${{ github.event.release.html_url }}
         VERSION: ${{ steps.version.outputs.version }}
       run: |
         dotnet build StrongTypes.slnx \
           -c $config \
           -p:Version="$VERSION" \
-          -p:PackageReleaseNotes="$NOTES" \
+          -p:PackageReleaseNotes="See $RELEASE_URL" \
           -p:PackageOutputPath="$PWD/out"
 
     - name: Publish packages


### PR DESCRIPTION
## Summary
- NuGet.org renders `PackageReleaseNotes` as plain text, so the rich markdown we write in the GitHub Release (headings, per-package sections, fenced code) would arrive on nuget.org as literal `###` and lose its structure.
- Replace the embedded release body with `See <release URL>`. Nuget.org auto-links the URL, so readers click through to the fully-rendered Release page.
- Keeps a single canonical source of truth for release notes — no drift between the package metadata and the GitHub Release.

## Test plan
- [ ] Draft a Release on `main` with a test tag and confirm the three published packages show `See https://github.com/KaliCZ/StrongTypes/releases/tag/<tag>` as the release notes on nuget.org, with the URL clickable.
- [ ] Confirm the `.nupkg` attachments and nuget.org publish still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)