### PR TITLE
Collect and report code coverage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,14 +104,14 @@ jobs:
         header: coverage
         path: coverage-report/FileSummary.md
 
-    # Evaluation mode alongside the custom sticky comment above. No token
-    # needed for public repos; codecov-action uses OIDC. Requires the repo
-    # to be enabled at https://app.codecov.io/ — sign in with GitHub and
-    # add KaliCZ/StrongTypes.
+    # Evaluation mode alongside the custom sticky comment above. The repo
+    # must be enabled at https://app.codecov.io/ with CODECOV_TOKEN stored
+    # as a repo secret.
     - name: Upload coverage to Codecov
       if: ${{ !cancelled() && hashFiles('coverage-report/Cobertura.xml') != '' }}
       uses: codecov/codecov-action@v5
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage-report/Cobertura.xml
         fail_ci_if_error: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,15 @@ permissions:
 
 jobs:
   build:
+    # Release events publish via the `publish` job below, which does its
+    # own Release build + tests before shipping. PRs and pushes to main
+    # use Debug here so coverage sequence points line up 1:1 with source
+    # (Release merges sequence points and folds constant branches).
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
 
     env:
-      config: 'Release'
+      config: 'Debug'
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
 
@@ -122,9 +127,11 @@ jobs:
         retention-days: 5
 
   publish:
-    needs: build
     # Gate on main: a Release drafted through the UI carries the selected
     # branch in target_commitish. Only releases targeted at main publish.
+    # No `needs: build` — the PR/push `build` job doesn't run on release
+    # events, so this job validates Release binaries itself via the Test
+    # step below before pushing to nuget.org.
     if: github.event_name == 'release' && github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
     environment: Nuget.org
@@ -171,6 +178,23 @@ jobs:
           -p:Version="$VERSION" \
           -p:PackageReleaseNotes="See $RELEASE_URL" \
           -p:PackageOutputPath="$PWD/out"
+
+    # Validate the Release binaries we're about to publish. PRs already
+    # ran the full suite in Debug; this step catches config-specific
+    # regressions (compiler optimizations, trimming, etc.) before nupkgs
+    # leave the runner.
+    - name: Test
+      run: dotnet test --no-restore --no-build --configuration $config
+
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-logs-release
+        path: |
+          **/TestResults/**/*.log
+          **/TestResults/**/*.trx
+        retention-days: 5
 
     - name: Publish packages
       run: dotnet nuget push ./out/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,14 +61,21 @@ jobs:
         reportgenerator \
           "-reports:**/TestResults/**/*.cobertura.xml" \
           "-targetdir:coverage-report" \
-          "-reporttypes:MarkdownSummaryGithub;HtmlInline;Cobertura" \
+          "-reporttypes:HtmlInline;Cobertura" \
           "-title:StrongTypes"
+
+    # ReportGenerator's markdown outputs group by class, which surfaces every
+    # compiler-generated closure type as its own row (e.g. `MaybeExtensions<A, B>`,
+    # `MaybeExtensions<A, R>`, …). Our own summary groups by source file instead.
+    - name: Render file-grouped coverage summary
+      if: ${{ !cancelled() && hashFiles('coverage-report/Cobertura.xml') != '' }}
+      run: python3 scripts/coverage-summary.py coverage-report/Cobertura.xml coverage-report/FileSummary.md
 
     - name: Append coverage summary to job summary
       if: ${{ !cancelled() }}
       run: |
-        if [ -f coverage-report/SummaryGithub.md ]; then
-          cat coverage-report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+        if [ -f coverage-report/FileSummary.md ]; then
+          cat coverage-report/FileSummary.md >> "$GITHUB_STEP_SUMMARY"
         else
           echo "No coverage summary to append."
         fi
@@ -77,11 +84,11 @@ jobs:
     # rather than piling up new ones, so authors get a single up-to-date view
     # of coverage without inbox noise.
     - name: Post coverage summary as PR comment
-      if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('coverage-report/SummaryGithub.md') != '' }}
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('coverage-report/FileSummary.md') != '' }}
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: coverage
-        path: coverage-report/SummaryGithub.md
+        path: coverage-report/FileSummary.md
 
     - name: Upload coverage report
       if: ${{ !cancelled() && hashFiles('coverage-report/**') != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,17 @@ jobs:
         header: coverage
         path: coverage-report/FileSummary.md
 
+    # Evaluation mode alongside the custom sticky comment above. No token
+    # needed for public repos; codecov-action uses OIDC. Requires the repo
+    # to be enabled at https://app.codecov.io/ — sign in with GitHub and
+    # add KaliCZ/StrongTypes.
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() && hashFiles('coverage-report/Cobertura.xml') != '' }}
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage-report/Cobertura.xml
+        fail_ci_if_error: false
+
     - name: Upload coverage report
       if: ${{ !cancelled() && hashFiles('coverage-report/**') != '' }}
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -37,8 +38,58 @@ jobs:
     - name: Build
       run: dotnet build --configuration $config --no-restore
 
+    # `-- --coverage ...` forwards flags to Microsoft.Testing.Platform's code
+    # coverage extension; each test project emits a Cobertura XML under its
+    # own TestResults/ folder, which ReportGenerator merges in the next step.
     - name: Test
-      run: dotnet test --no-restore --no-build --configuration $config
+      run: >-
+        dotnet test --no-restore --no-build --configuration $config
+        --
+        --coverage
+        --coverage-output-format cobertura
+
+    - name: Generate coverage report
+      if: ${{ !cancelled() }}
+      run: |
+        shopt -s globstar nullglob
+        files=(**/TestResults/**/*.cobertura.xml)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No coverage files found; skipping report generation."
+          exit 0
+        fi
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        reportgenerator \
+          "-reports:**/TestResults/**/*.cobertura.xml" \
+          "-targetdir:coverage-report" \
+          "-reporttypes:MarkdownSummaryGithub;HtmlInline;Cobertura" \
+          "-title:StrongTypes"
+
+    - name: Append coverage summary to job summary
+      if: ${{ !cancelled() }}
+      run: |
+        if [ -f coverage-report/SummaryGithub.md ]; then
+          cat coverage-report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "No coverage summary to append."
+        fi
+
+    # Sticky comment: subsequent runs on the same PR edit the existing comment
+    # rather than piling up new ones, so authors get a single up-to-date view
+    # of coverage without inbox noise.
+    - name: Post coverage summary as PR comment
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && hashFiles('coverage-report/SummaryGithub.md') != '' }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: coverage
+        path: coverage-report/SummaryGithub.md
+
+    - name: Upload coverage report
+      if: ${{ !cancelled() && hashFiles('coverage-report/**') != '' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-report
+        path: coverage-report
+        retention-days: 14
 
     - name: Upload test logs
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     # Debug keeps per-statement sequence points so coverage lines up 1:1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,25 @@ jobs:
           "-reporttypes:HtmlInline;Cobertura" \
           "-title:StrongTypes"
 
+    # List the files this PR touches so the summary can highlight their coverage
+    # instead of drowning in a `below 50%` list dominated by unmigrated legacy code.
+    - name: List changed files
+      if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path' > changed-files.txt
+
     # ReportGenerator's markdown outputs group by class, which surfaces every
     # compiler-generated closure type as its own row (e.g. `MaybeExtensions<A, B>`,
     # `MaybeExtensions<A, R>`, …). Our own summary groups by source file instead.
     - name: Render file-grouped coverage summary
       if: ${{ !cancelled() && hashFiles('coverage-report/Cobertura.xml') != '' }}
-      run: python3 scripts/coverage-summary.py coverage-report/Cobertura.xml coverage-report/FileSummary.md
+      run: |
+        args=(coverage-report/Cobertura.xml coverage-report/FileSummary.md)
+        if [ -f changed-files.txt ]; then
+          args+=(--changed-files changed-files.txt)
+        fi
+        python3 scripts/coverage-summary.py "${args[@]}"
 
     - name: Append coverage summary to job summary
       if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build
+name: ci
 
 on:
   push:
@@ -7,22 +7,18 @@ on:
   pull_request:
     branches:
       - main
-  release:
-    types: [published]
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  build:
-    # Release events publish via the `publish` job below, which does its
-    # own Release build + tests before shipping. PRs and pushes to main
-    # use Debug here so coverage sequence points line up 1:1 with source
-    # (Release merges sequence points and folds constant branches).
-    if: github.event_name != 'release'
+  test:
     runs-on: ubuntu-latest
 
+    # Debug keeps per-statement sequence points so coverage lines up 1:1
+    # with source. Release merges points and folds constant branches,
+    # which skews the numbers; shipping validation happens in release.yml.
     env:
       config: 'Debug'
       DOTNET_NOLOGO: true
@@ -125,81 +121,3 @@ jobs:
           **/TestResults/**/*.log
           **/TestResults/**/*.trx
         retention-days: 5
-
-  publish:
-    # Gate on main: a Release drafted through the UI carries the selected
-    # branch in target_commitish. Only releases targeted at main publish.
-    # No `needs: build` — the PR/push `build` job doesn't run on release
-    # events, so this job validates Release binaries itself via the Test
-    # step below before pushing to nuget.org.
-    if: github.event_name == 'release' && github.event.release.target_commitish == 'main'
-    runs-on: ubuntu-latest
-    environment: Nuget.org
-    permissions:
-      contents: write
-
-    env:
-      config: 'Release'
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    - name: Setup .NET 10
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: 10.0.x
-
-    - name: Parse version from tag
-      id: version
-      run: |
-        TAG="${GITHUB_REF_NAME}"
-        echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-
-    # GeneratePackageOnBuild=true in the csproj files means `dotnet build`
-    # produces the nupkg as a side-effect; no separate `dotnet pack` step
-    # needed. -p:Version cascades into referenced projects (EfCore's
-    # ProjectReference to core), so EfCore's nuspec pins its core
-    # dependency to the same version.
-    # Build the whole solution; non-publishable projects (tests, internal
-    # source generators, analyzers) set IsPackable=false so they produce no
-    # nupkg. GeneratePackageOnBuild=true on publishable csprojs means the
-    # build itself emits .nupkg files into PackageOutputPath. New publishable
-    # packages are picked up automatically by setting the same two properties.
-    - name: Build and pack
-      env:
-        RELEASE_URL: ${{ github.event.release.html_url }}
-        VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        dotnet build StrongTypes.slnx \
-          -c $config \
-          -p:Version="$VERSION" \
-          -p:PackageReleaseNotes="See $RELEASE_URL" \
-          -p:PackageOutputPath="$PWD/out"
-
-    # Validate the Release binaries we're about to publish. PRs already
-    # ran the full suite in Debug; this step catches config-specific
-    # regressions (compiler optimizations, trimming, etc.) before nupkgs
-    # leave the runner.
-    - name: Test
-      run: dotnet test --no-restore --no-build --configuration $config
-
-    - name: Upload test logs
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: test-logs-release
-        path: |
-          **/TestResults/**/*.log
-          **/TestResults/**/*.trx
-        retention-days: 5
-
-    - name: Publish packages
-      run: dotnet nuget push ./out/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}
-
-    - name: Attach packages to release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload "$GITHUB_REF_NAME" ./out/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # Gate on main: a Release drafted through the UI carries the selected
+    # branch in target_commitish. Only releases targeted at main publish.
+    if: github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+    environment: Nuget.org
+    permissions:
+      contents: write
+
+    env:
+      config: 'Release'
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Parse version from tag
+      id: version
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+        echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+    # GeneratePackageOnBuild=true in the csproj files means `dotnet build`
+    # produces the nupkg as a side-effect; no separate `dotnet pack` step
+    # needed. -p:Version cascades into referenced projects (EfCore's
+    # ProjectReference to core), so EfCore's nuspec pins its core
+    # dependency to the same version.
+    # Build the whole solution; non-publishable projects (tests, internal
+    # source generators, analyzers) set IsPackable=false so they produce no
+    # nupkg. GeneratePackageOnBuild=true on publishable csprojs means the
+    # build itself emits .nupkg files into PackageOutputPath. New publishable
+    # packages are picked up automatically by setting the same two properties.
+    - name: Build and pack
+      env:
+        RELEASE_URL: ${{ github.event.release.html_url }}
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        dotnet build StrongTypes.slnx \
+          -c $config \
+          -p:Version="$VERSION" \
+          -p:PackageReleaseNotes="See $RELEASE_URL" \
+          -p:PackageOutputPath="$PWD/out"
+
+    # Validate the Release binaries we're about to publish. PRs already
+    # ran the full suite in Debug; this step catches config-specific
+    # regressions (compiler optimizations, trimming, etc.) before nupkgs
+    # leave the runner.
+    - name: Test
+      run: dotnet test --no-restore --no-build --configuration $config
+
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-logs-release
+        path: |
+          **/TestResults/**/*.log
+          **/TestResults/**/*.trx
+        retention-days: 5
+
+    - name: Publish packages
+      run: dotnet nuget push ./out/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}
+
+    - name: Attach packages to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "$GITHUB_REF_NAME" ./out/*.nupkg

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+component_management:
+  individual_components:
+    - component_id: strongtypes
+      name: StrongTypes
+      paths: ["src/StrongTypes/**"]
+    - component_id: analyzers
+      name: StrongTypes.Analyzers
+      paths: ["src/StrongTypes.Analyzers/**"]
+    - component_id: efcore
+      name: StrongTypes.EfCore
+      paths: ["src/StrongTypes.EfCore/**"]
+    - component_id: api
+      name: StrongTypes.Api
+      paths: ["src/StrongTypes.Api/**"]
+    - component_id: fscheck
+      name: StrongTypes.FsCheck
+      paths: ["src/StrongTypes.FsCheck/**"]
+
+comment:
+  layout: "header, diff, components, tree"
+  require_changes: false
+
+coverage:
+  status:
+    # `informational: true` posts a status but never fails the PR. Keeps
+    # codecov in evaluation mode alongside our custom sticky comment.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render a file-grouped Markdown coverage summary from a merged Cobertura XML.
+"""Render a project/folder-grouped Markdown coverage summary from a merged Cobertura XML.
 
 Cobertura emits one ``<class>`` per constructed generic type, and each one
 carries a full copy of the source file's ``<line>`` entries. Summing naively
@@ -15,6 +15,11 @@ import argparse
 import re
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from dataclasses import dataclass
+
+
+ROOT_FOLDER = "(root)"
+GENERATED_FOLDER = "generated"
 
 
 def repo_relative(path: str) -> str:
@@ -35,22 +40,46 @@ def _format_arity(match: re.Match[str]) -> str:
     return f"<{params}>"
 
 
-def display_path(path: str) -> str:
-    """Compact noisy paths for readability in the summary table.
+@dataclass
+class Row:
+    project: str
+    folder: str
+    filename: str   # display basename (arity-normalized for generated code)
+    rel: str        # repo-relative path used for change-set matching
+    lines_cov: int
+    lines_total: int
+    branches_cov: int
+    branches_total: int
 
-    Source-generator output lives under ``src/<proj>/obj/<config>/<tfm>/<generator>/…``.
-    Those long prefixes push the table too wide, so collapse them to
-    ``generated/`` and translate ``Foo`1`` → ``Foo<T>`` so the filename
-    doesn't contain a stray backtick that breaks out of the markdown code span.
+
+def classify(rel: str) -> tuple[str, str, str]:
+    """Split a repo-relative path into (project, folder, display filename).
+
+    Normal files live under ``src/<project>/<folder>/<file>``. Source-generator
+    output lives under ``src/<project>/obj/<config>/<tfm>/<generator>/<file>.g.cs``;
+    we bucket those into a ``generated`` folder under the same project with a
+    compacted filename, since the long obj-path prefix is noise in a table.
     """
-    rel = repo_relative(path)
-    if "/obj/" in rel and rel.endswith(".g.cs"):
-        basename = rel.rsplit("/", 1)[-1]
+    parts = rel.split("/")
+    if len(parts) < 2 or parts[0] != "src":
+        return ("(other)", ROOT_FOLDER, rel)
+
+    project = parts[1]
+    remaining = parts[2:]
+
+    if len(remaining) >= 2 and remaining[0] == "obj" and rel.endswith(".g.cs"):
+        basename = remaining[-1]
         if basename.startswith("StrongTypes."):
             basename = basename[len("StrongTypes."):]
         basename = _ARITY_RE.sub(_format_arity, basename)
-        return f"generated/{basename}"
-    return rel
+        return (project, GENERATED_FOLDER, basename)
+
+    if len(remaining) == 1:
+        return (project, ROOT_FOLDER, remaining[0])
+
+    folder = "/".join(remaining[:-1])
+    filename = remaining[-1]
+    return (project, folder, filename)
 
 
 def parse_cobertura(path: str) -> dict[str, dict[int, list]]:
@@ -94,75 +123,119 @@ def load_changed_files(path: str | None) -> set[str] | None:
         return None
     try:
         with open(path, encoding="utf-8") as f:
-            entries = {line.strip() for line in f if line.strip()}
+            return {line.strip() for line in f if line.strip()}
     except FileNotFoundError:
         return None
-    return entries
 
 
-def render(cobertura_path: str, output_path: str, changed_files: set[str] | None) -> None:
-    per_file = parse_cobertura(cobertura_path)
-
-    rows = []
+def build_rows(per_file: dict[str, dict[int, list]]) -> list[Row]:
+    rows: list[Row] = []
     for filename, lines in per_file.items():
         lines_total = len(lines)
         lines_cov = sum(1 for e in lines.values() if e[0])
         branches_cov = sum(e[1] for e in lines.values())
         branches_total = sum(e[2] for e in lines.values())
-        rows.append((
-            display_path(filename),
-            repo_relative(filename),
-            lines_cov,
-            lines_total,
-            branches_cov,
-            branches_total,
+        rel = repo_relative(filename)
+        project, folder, display = classify(rel)
+        rows.append(Row(
+            project=project,
+            folder=folder,
+            filename=display,
+            rel=rel,
+            lines_cov=lines_cov,
+            lines_total=lines_total,
+            branches_cov=branches_cov,
+            branches_total=branches_total,
         ))
-    rows.sort(key=lambda r: r[0])
+    return rows
 
-    total_cov = sum(r[2] for r in rows)
-    total_lines = sum(r[3] for r in rows)
-    total_bcov = sum(r[4] for r in rows)
-    total_branches = sum(r[5] for r in rows)
+
+def _row_cells(r: Row, path_override: str | None = None) -> str:
+    label = path_override if path_override is not None else r.filename
+    return (
+        f"| `{label}` | {r.lines_cov} / {r.lines_total} ({pct(r.lines_cov, r.lines_total)}) | "
+        f"{r.branches_cov} / {r.branches_total} ({pct(r.branches_cov, r.branches_total)}) |"
+    )
+
+
+def render(cobertura_path: str, output_path: str, changed_files: set[str] | None) -> None:
+    rows = build_rows(parse_cobertura(cobertura_path))
+
+    total_lc = sum(r.lines_cov for r in rows)
+    total_lt = sum(r.lines_total for r in rows)
+    total_bc = sum(r.branches_cov for r in rows)
+    total_bt = sum(r.branches_total for r in rows)
 
     out: list[str] = []
     out.append("## Coverage")
     out.append("")
     out.append(
-        f"**Lines:** {total_cov} / {total_lines} "
-        f"({pct(total_cov, total_lines)}) &nbsp;&nbsp; "
-        f"**Branches:** {total_bcov} / {total_branches} "
-        f"({pct(total_bcov, total_branches)})"
+        f"**Lines:** {total_lc} / {total_lt} "
+        f"({pct(total_lc, total_lt)}) &nbsp;&nbsp; "
+        f"**Branches:** {total_bc} / {total_bt} "
+        f"({pct(total_bc, total_bt)})"
     )
     out.append("")
 
     if changed_files is not None:
-        changed_rows = [r for r in rows if r[1] in changed_files]
+        changed_rows = sorted(
+            (r for r in rows if r.rel in changed_files),
+            key=lambda r: (r.project, r.folder, r.filename.lower()),
+        )
         out.append("### Files changed in this PR")
         out.append("")
         if changed_rows:
             out.append("| File | Lines | Branches |")
             out.append("|---|---:|---:|")
-            for disp, _rel, cov, tot, bcov, btot in changed_rows:
-                out.append(
-                    f"| `{disp}` | {cov} / {tot} ({pct(cov, tot)}) | "
-                    f"{bcov} / {btot} ({pct(bcov, btot)}) |"
-                )
+            for r in changed_rows:
+                # Full project-qualified path helps readers locate the file
+                # when the table is flat across projects.
+                label = f"{r.project}/{r.folder}/{r.filename}" if r.folder != ROOT_FOLDER else f"{r.project}/{r.filename}"
+                out.append(_row_cells(r, path_override=label))
         else:
             out.append("_No coverage-instrumented files changed in this PR._")
         out.append("")
 
-    out.append("<details><summary>All files</summary>")
-    out.append("")
-    out.append("| File | Lines | Branches |")
-    out.append("|---|---:|---:|")
-    for disp, _rel, cov, tot, bcov, btot in rows:
+    projects: dict[str, list[Row]] = defaultdict(list)
+    for r in rows:
+        projects[r.project].append(r)
+
+    for project in sorted(projects):
+        proj_rows = projects[project]
+        p_lc = sum(r.lines_cov for r in proj_rows)
+        p_lt = sum(r.lines_total for r in proj_rows)
+        p_bc = sum(r.branches_cov for r in proj_rows)
+        p_bt = sum(r.branches_total for r in proj_rows)
         out.append(
-            f"| `{disp}` | {cov} / {tot} ({pct(cov, tot)}) | "
-            f"{bcov} / {btot} ({pct(bcov, btot)}) |"
+            f"<details><summary><b>{project}</b> — "
+            f"lines {pct(p_lc, p_lt)} ({p_lc}/{p_lt}), "
+            f"branches {pct(p_bc, p_bt)} ({p_bc}/{p_bt})</summary>"
         )
-    out.append("")
-    out.append("</details>")
-    out.append("")
+        out.append("")
+
+        folders: dict[str, list[Row]] = defaultdict(list)
+        for r in proj_rows:
+            folders[r.folder].append(r)
+
+        for folder in sorted(folders):
+            f_rows = sorted(folders[folder], key=lambda r: r.filename.lower())
+            f_lc = sum(r.lines_cov for r in f_rows)
+            f_lt = sum(r.lines_total for r in f_rows)
+            f_bc = sum(r.branches_cov for r in f_rows)
+            f_bt = sum(r.branches_total for r in f_rows)
+            out.append(
+                f"**{folder}** — "
+                f"lines {pct(f_lc, f_lt)}, branches {pct(f_bc, f_bt)}"
+            )
+            out.append("")
+            out.append("| File | Lines | Branches |")
+            out.append("|---|---:|---:|")
+            for r in f_rows:
+                out.append(_row_cells(r))
+            out.append("")
+
+        out.append("</details>")
+        out.append("")
 
     with open(output_path, "w", encoding="utf-8") as f:
         f.write("\n".join(out))

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
 """Render a file-grouped Markdown coverage summary from a merged Cobertura XML.
 
-ReportGenerator's Markdown outputs group by class, which gets noisy for
-extension-method-heavy code: compiler-generated closure types surface as
-separate rows like `MaybeExtensions<A, B>`, `MaybeExtensions<A, R>`, …, all
-coming from the same .cs file. Cobertura's `<class filename="…">` attribute
-lets us collapse those back to one row per source file.
+Cobertura emits one ``<class>`` per constructed generic type, and each one
+carries a full copy of the source file's ``<line>`` entries. Summing naively
+multiplies physical lines by the number of instantiations (e.g. a 200-line
+file materialized as 700 closed generics becomes 140,000 "lines"). We dedupe
+by (filename, line number) so each physical line is counted once, and take
+the max of branch coverage across instantiations so a branch exercised by any
+instantiation is credited at the source level.
 """
 from __future__ import annotations
 
-import os
-import sys
+import argparse
+import re
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-
-
-LOW_COVERAGE_THRESHOLD = 50.0
 
 
 def repo_relative(path: str) -> str:
@@ -23,106 +22,163 @@ def repo_relative(path: str) -> str:
     marker = "/src/"
     idx = path.find(marker)
     if idx >= 0:
-        return path[idx + 1 :]
+        return path[idx + 1:]
     return path.lstrip("/")
 
 
-def render(cobertura_path: str, output_path: str) -> None:
-    tree = ET.parse(cobertura_path)
-    root = tree.getroot()
+_ARITY_RE = re.compile(r"`(\d+)")
 
-    # filename -> [lines_covered, lines_total, branches_covered, branches_total]
-    by_file: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0, 0])
+
+def _format_arity(match: re.Match[str]) -> str:
+    n = int(match.group(1))
+    params = "T" if n == 1 else ",".join(f"T{i}" for i in range(1, n + 1))
+    return f"<{params}>"
+
+
+def display_path(path: str) -> str:
+    """Compact noisy paths for readability in the summary table.
+
+    Source-generator output lives under ``src/<proj>/obj/<config>/<tfm>/<generator>/…``.
+    Those long prefixes push the table too wide, so collapse them to
+    ``generated/`` and translate ``Foo`1`` → ``Foo<T>`` so the filename
+    doesn't contain a stray backtick that breaks out of the markdown code span.
+    """
+    rel = repo_relative(path)
+    if "/obj/" in rel and rel.endswith(".g.cs"):
+        basename = rel.rsplit("/", 1)[-1]
+        if basename.startswith("StrongTypes."):
+            basename = basename[len("StrongTypes."):]
+        basename = _ARITY_RE.sub(_format_arity, basename)
+        return f"generated/{basename}"
+    return rel
+
+
+def parse_cobertura(path: str) -> dict[str, dict[int, list]]:
+    tree = ET.parse(path)
+    root = tree.getroot()
+    # entry schema: [any_hit, branches_covered_max, branches_total_max]
+    per_file: dict[str, dict[int, list]] = defaultdict(
+        lambda: defaultdict(lambda: [False, 0, 0])
+    )
 
     for cls in root.iter("class"):
         filename = cls.get("filename")
         if not filename:
             continue
-        bucket = by_file[filename]
+        file_lines = per_file[filename]
         for line in cls.iter("line"):
+            num = int(line.get("number", "0"))
             hits = int(line.get("hits", "0"))
-            bucket[1] += 1
+            entry = file_lines[num]
             if hits > 0:
-                bucket[0] += 1
+                entry[0] = True
             if line.get("branch") == "true":
                 cond = line.get("condition-coverage", "")
-                # condition-coverage looks like "50% (1/2)"
                 if "(" in cond and "/" in cond:
                     frac = cond.split("(", 1)[1].rstrip(")")
-                    covered, total = frac.split("/")
-                    bucket[2] += int(covered)
-                    bucket[3] += int(total)
+                    covered_s, total_s = frac.split("/")
+                    covered, total = int(covered_s), int(total_s)
+                    if covered > entry[1]:
+                        entry[1] = covered
+                    if total > entry[2]:
+                        entry[2] = total
+    return per_file
 
-    rows = sorted(
-        (
-            (repo_relative(fname), cov, tot, bcov, btot)
-            for fname, (cov, tot, bcov, btot) in by_file.items()
-        ),
-        key=lambda r: r[0],
-    )
 
-    total_cov = sum(r[1] for r in rows)
-    total_lines = sum(r[2] for r in rows)
-    total_bcov = sum(r[3] for r in rows)
-    total_branches = sum(r[4] for r in rows)
+def pct(covered: int, total: int) -> str:
+    return f"{(covered / total * 100):.1f}%" if total else "n/a"
 
-    def pct(covered: int, total: int) -> str:
-        return f"{(covered / total * 100):.1f}%" if total else "n/a"
 
-    low = [r for r in rows if r[2] > 0 and (r[1] / r[2] * 100) < LOW_COVERAGE_THRESHOLD]
+def load_changed_files(path: str | None) -> set[str] | None:
+    if not path:
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            entries = {line.strip() for line in f if line.strip()}
+    except FileNotFoundError:
+        return None
+    return entries
 
-    lines: list[str] = []
-    lines.append("## Coverage")
-    lines.append("")
-    lines.append(
+
+def render(cobertura_path: str, output_path: str, changed_files: set[str] | None) -> None:
+    per_file = parse_cobertura(cobertura_path)
+
+    rows = []
+    for filename, lines in per_file.items():
+        lines_total = len(lines)
+        lines_cov = sum(1 for e in lines.values() if e[0])
+        branches_cov = sum(e[1] for e in lines.values())
+        branches_total = sum(e[2] for e in lines.values())
+        rows.append((
+            display_path(filename),
+            repo_relative(filename),
+            lines_cov,
+            lines_total,
+            branches_cov,
+            branches_total,
+        ))
+    rows.sort(key=lambda r: r[0])
+
+    total_cov = sum(r[2] for r in rows)
+    total_lines = sum(r[3] for r in rows)
+    total_bcov = sum(r[4] for r in rows)
+    total_branches = sum(r[5] for r in rows)
+
+    out: list[str] = []
+    out.append("## Coverage")
+    out.append("")
+    out.append(
         f"**Lines:** {total_cov} / {total_lines} "
         f"({pct(total_cov, total_lines)}) &nbsp;&nbsp; "
         f"**Branches:** {total_bcov} / {total_branches} "
         f"({pct(total_bcov, total_branches)})"
     )
-    lines.append("")
+    out.append("")
 
-    if low:
-        lines.append(f"### Files below {LOW_COVERAGE_THRESHOLD:.0f}% line coverage")
-        lines.append("")
-        lines.append("Consider adding tests — these files drag the number down.")
-        lines.append("")
-        lines.append("| File | Lines | Branches |")
-        lines.append("|---|---:|---:|")
-        for fname, cov, tot, bcov, btot in low:
-            lines.append(
-                f"| `{fname}` | {cov} / {tot} ({pct(cov, tot)}) | "
-                f"{bcov} / {btot} ({pct(bcov, btot)}) |"
-            )
-        lines.append("")
-    else:
-        lines.append(
-            f"No files below {LOW_COVERAGE_THRESHOLD:.0f}% line coverage."
-        )
-        lines.append("")
+    if changed_files is not None:
+        changed_rows = [r for r in rows if r[1] in changed_files]
+        out.append("### Files changed in this PR")
+        out.append("")
+        if changed_rows:
+            out.append("| File | Lines | Branches |")
+            out.append("|---|---:|---:|")
+            for disp, _rel, cov, tot, bcov, btot in changed_rows:
+                out.append(
+                    f"| `{disp}` | {cov} / {tot} ({pct(cov, tot)}) | "
+                    f"{bcov} / {btot} ({pct(bcov, btot)}) |"
+                )
+        else:
+            out.append("_No coverage-instrumented files changed in this PR._")
+        out.append("")
 
-    lines.append("<details><summary>All files</summary>")
-    lines.append("")
-    lines.append("| File | Lines | Branches |")
-    lines.append("|---|---:|---:|")
-    for fname, cov, tot, bcov, btot in rows:
-        lines.append(
-            f"| `{fname}` | {cov} / {tot} ({pct(cov, tot)}) | "
+    out.append("<details><summary>All files</summary>")
+    out.append("")
+    out.append("| File | Lines | Branches |")
+    out.append("|---|---:|---:|")
+    for disp, _rel, cov, tot, bcov, btot in rows:
+        out.append(
+            f"| `{disp}` | {cov} / {tot} ({pct(cov, tot)}) | "
             f"{bcov} / {btot} ({pct(bcov, btot)}) |"
         )
-    lines.append("")
-    lines.append("</details>")
-    lines.append("")
+    out.append("")
+    out.append("</details>")
+    out.append("")
 
     with open(output_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines))
+        f.write("\n".join(out))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cobertura")
+    parser.add_argument("output")
+    parser.add_argument(
+        "--changed-files",
+        help="Path to a newline-delimited list of repo-relative paths changed in this PR.",
+    )
+    args = parser.parse_args()
+    render(args.cobertura, args.output, load_changed_files(args.changed_files))
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print(
-            f"usage: {os.path.basename(sys.argv[0])} <cobertura.xml> <output.md>",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    render(sys.argv[1], sys.argv[2])
+    main()

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Render a file-grouped Markdown coverage summary from a merged Cobertura XML.
+
+ReportGenerator's Markdown outputs group by class, which gets noisy for
+extension-method-heavy code: compiler-generated closure types surface as
+separate rows like `MaybeExtensions<A, B>`, `MaybeExtensions<A, R>`, …, all
+coming from the same .cs file. Cobertura's `<class filename="…">` attribute
+lets us collapse those back to one row per source file.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+
+
+LOW_COVERAGE_THRESHOLD = 50.0
+
+
+def repo_relative(path: str) -> str:
+    path = path.replace("\\", "/")
+    marker = "/src/"
+    idx = path.find(marker)
+    if idx >= 0:
+        return path[idx + 1 :]
+    return path.lstrip("/")
+
+
+def render(cobertura_path: str, output_path: str) -> None:
+    tree = ET.parse(cobertura_path)
+    root = tree.getroot()
+
+    # filename -> [lines_covered, lines_total, branches_covered, branches_total]
+    by_file: dict[str, list[int]] = defaultdict(lambda: [0, 0, 0, 0])
+
+    for cls in root.iter("class"):
+        filename = cls.get("filename")
+        if not filename:
+            continue
+        bucket = by_file[filename]
+        for line in cls.iter("line"):
+            hits = int(line.get("hits", "0"))
+            bucket[1] += 1
+            if hits > 0:
+                bucket[0] += 1
+            if line.get("branch") == "true":
+                cond = line.get("condition-coverage", "")
+                # condition-coverage looks like "50% (1/2)"
+                if "(" in cond and "/" in cond:
+                    frac = cond.split("(", 1)[1].rstrip(")")
+                    covered, total = frac.split("/")
+                    bucket[2] += int(covered)
+                    bucket[3] += int(total)
+
+    rows = sorted(
+        (
+            (repo_relative(fname), cov, tot, bcov, btot)
+            for fname, (cov, tot, bcov, btot) in by_file.items()
+        ),
+        key=lambda r: r[0],
+    )
+
+    total_cov = sum(r[1] for r in rows)
+    total_lines = sum(r[2] for r in rows)
+    total_bcov = sum(r[3] for r in rows)
+    total_branches = sum(r[4] for r in rows)
+
+    def pct(covered: int, total: int) -> str:
+        return f"{(covered / total * 100):.1f}%" if total else "n/a"
+
+    low = [r for r in rows if r[2] > 0 and (r[1] / r[2] * 100) < LOW_COVERAGE_THRESHOLD]
+
+    lines: list[str] = []
+    lines.append("## Coverage")
+    lines.append("")
+    lines.append(
+        f"**Lines:** {total_cov} / {total_lines} "
+        f"({pct(total_cov, total_lines)}) &nbsp;&nbsp; "
+        f"**Branches:** {total_bcov} / {total_branches} "
+        f"({pct(total_bcov, total_branches)})"
+    )
+    lines.append("")
+
+    if low:
+        lines.append(f"### Files below {LOW_COVERAGE_THRESHOLD:.0f}% line coverage")
+        lines.append("")
+        lines.append("Consider adding tests — these files drag the number down.")
+        lines.append("")
+        lines.append("| File | Lines | Branches |")
+        lines.append("|---|---:|---:|")
+        for fname, cov, tot, bcov, btot in low:
+            lines.append(
+                f"| `{fname}` | {cov} / {tot} ({pct(cov, tot)}) | "
+                f"{bcov} / {btot} ({pct(bcov, btot)}) |"
+            )
+        lines.append("")
+    else:
+        lines.append(
+            f"No files below {LOW_COVERAGE_THRESHOLD:.0f}% line coverage."
+        )
+        lines.append("")
+
+    lines.append("<details><summary>All files</summary>")
+    lines.append("")
+    lines.append("| File | Lines | Branches |")
+    lines.append("|---|---:|---:|")
+    for fname, cov, tot, bcov, btot in rows:
+        lines.append(
+            f"| `{fname}` | {cov} / {tot} ({pct(cov, tot)}) | "
+            f"{bcov} / {btot} ({pct(bcov, btot)}) |"
+        )
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            f"usage: {os.path.basename(sys.argv[0])} <cobertura.xml> <output.md>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    render(sys.argv[1], sys.argv[2])

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -211,6 +211,10 @@ def render(cobertura_path: str, output_path: str, changed_files: set[str] | None
             f"lines {pct(p_lc, p_lt)} ({p_lc}/{p_lt}), "
             f"branches {pct(p_bc, p_bt)} ({p_bc}/{p_bt})</summary>"
         )
+        # Blank line lets markdown re-parse inside <details>; the <br> gives
+        # the collapsed-header row breathing room above the first folder.
+        out.append("")
+        out.append("<br>")
         out.append("")
 
         folders: dict[str, list[Row]] = defaultdict(list)
@@ -224,14 +228,17 @@ def render(cobertura_path: str, output_path: str, changed_files: set[str] | None
             f_bc = sum(r.branches_cov for r in f_rows)
             f_bt = sum(r.branches_total for r in f_rows)
             out.append(
-                f"**{folder}** — "
-                f"lines {pct(f_lc, f_lt)}, branches {pct(f_bc, f_bt)}"
+                f"<details open><summary><b>{folder}</b> — "
+                f"lines {pct(f_lc, f_lt)} ({f_lc}/{f_lt}), "
+                f"branches {pct(f_bc, f_bt)} ({f_bc}/{f_bt})</summary>"
             )
             out.append("")
             out.append("| File | Lines | Branches |")
             out.append("|---|---:|---:|")
             for r in f_rows:
                 out.append(_row_cells(r))
+            out.append("")
+            out.append("</details>")
             out.append("")
 
         out.append("</details>")

--- a/src/StrongTypes.Analyzers.Tests/StrongTypes.Analyzers.Tests.csproj
+++ b/src/StrongTypes.Analyzers.Tests/StrongTypes.Analyzers.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/StrongTypes.Api.IntegrationTests/StrongTypes.Api.IntegrationTests.csproj
+++ b/src/StrongTypes.Api.IntegrationTests/StrongTypes.Api.IntegrationTests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/src/StrongTypes.Tests/StrongTypes.Tests.csproj
+++ b/src/StrongTypes.Tests/StrongTypes.Tests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit.v3" Version="3.3.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds coverage collection + reporting to PRs via **two parallel channels** so we can compare and pick one:

1. **Custom sticky comment** — `scripts/coverage-summary.py` renders Cobertura into a markdown summary grouped by project → folder with nested collapsibles, absolute counts alongside percentages, and a `Files changed in this PR` section scoped to the PR diff. Also fixes generic-heavy totals (Cobertura emits one `<class>` per constructed generic; we dedupe by `(filename, line number)` so a 200-line file isn't counted as 140,000).
2. **Codecov** — `codecov/codecov-action@v5` uploads the merged Cobertura to codecov.io, with `codecov.yml` mapping paths to one component per project. Both `project` and `patch` statuses are `informational: true` so codecov can't fail the PR while we're evaluating.

Also **splits the workflow**: `build.yml` runs on push/PR in **Debug** (so coverage sequence points line up 1:1 with source); the new `release.yml` runs on release events in **Release**, tests the shipping binaries, and only then pushes to nuget.org.

## How it works

**Collection.** Each test project references `Microsoft.Testing.Extensions.CodeCoverage`. The `Test` step forwards coverage flags through the `--` separator:

```
dotnet test --no-restore --no-build --configuration Debug -- --coverage --coverage-output-format cobertura
```

**Merge.** `dotnet-reportgenerator-globaltool` consolidates per-project `*.cobertura.xml` into one merged XML plus a drill-down HTML report.

**Rendering (custom).** `scripts/coverage-summary.py` reads the merged XML and emits a markdown document with:
- overall line / branch percentages
- a `Files changed in this PR` table driven by `gh pr view --json files`
- one `<details>` per project with project-level totals in the summary line
- nested `<details open>` per folder inside each project, with per-folder totals
- source-generator output under `src/<proj>/obj/**/*.g.cs` folds into a `generated/` folder, with arity backticks (`` `1``) translated to `<T>` so the filename stays inside its markdown code span

**Rendering (codecov).** `codecov.yml` sets `comment: layout: header, diff, components, tree` so the codecov comment shows overall delta, the `@@ Coverage Diff @@` block, a per-component table (one row per project), and a folder-grouped file tree.

**Visibility.** Coverage surfaces four ways:
- Job summary (custom markdown appended to `$GITHUB_STEP_SUMMARY`)
- Custom sticky PR comment (header `coverage`, edits in place via `marocchino/sticky-pull-request-comment@v2`)
- Codecov PR comment (separate sticky)
- HTML artifact (`coverage-report`, 14-day retention) for offline drill-down

**Safety.** Every downstream step uses `!cancelled()` + `hashFiles` guards so a build failure leaves no misleading red steps.

## Workflow split

| Event | Workflow | Config | Purpose |
|---|---|---|---|
| push to main, pull_request | `build.yml` | Debug | test + coverage + PR comments |
| release published | `release.yml` | Release | build + test + pack + publish + attach |

Debug-in-CI matters for coverage fidelity: Release merges sequence points and can fold constant branches, slightly distorting the numbers. Shipping binaries are still validated in Release via `release.yml`'s `Test` step before nuget push.

## Test plan

- [ ] `build` workflow runs green on this PR
- [ ] Job summary shows the coverage table
- [ ] Custom sticky `coverage` comment appears with the project/folder breakdown
- [ ] Codecov comment appears with the per-component table
- [ ] `coverage-report` artifact is attached and contains the HTML drill-down
- [ ] Re-running the workflow updates both comments in place rather than stacking
- [ ] Generic-heavy files show realistic line counts (not the old inflated totals)