### PR TITLE
Emit per-component Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,12 @@
 component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        informational: true
+      - type: patch
+        target: auto
+        informational: true
   individual_components:
     - component_id: strongtypes
       name: StrongTypes


### PR DESCRIPTION
## Summary
- Add `default_rules.statuses` under `component_management` so each of the five components posts its own `project` and `patch` status check on PRs.
- Kept `informational: true` so coverage never fails the PR, matching the existing default in `codecov.yml`.

## Test plan
- [ ] On the resulting PR, confirm five per-component status checks appear (StrongTypes, StrongTypes.Analyzers, StrongTypes.EfCore, StrongTypes.Api, StrongTypes.FsCheck) alongside the existing default ones.
- [ ] Confirm none of them block the PR (all informational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)