### PR TITLE
Add SVG diagrams to readme (closes #61)

### DIFF
--- a/docs/diagrams/covariance.svg
+++ b/docs/diagrams/covariance.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
+  <style>
+    .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .mono       { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .mono-out   { font: 700 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6366F1; }
+    .tag        { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; }
+    .edge-label { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .hint       { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+  </style>
+
+  <defs>
+    <marker id="cv-arrow" markerWidth="12" markerHeight="12" refX="11" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 11,4 L 0,8 z" fill="#6366F1"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="300" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="899" height="299" fill="none" stroke="#E5E7EB" rx="12"/>
+
+  <text class="title-text" x="40" y="38">Covariant interface: out T</text>
+  <text class="subtitle"   x="40" y="58">A more-derived element type flows upward to a less-derived interface.</text>
+
+  <!-- Concrete card (left) -->
+  <rect x="60" y="110" width="320" height="110" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text class="tag" x="80" y="135" fill="#6B7280">concrete collection</text>
+  <text class="mono" x="80" y="172">NonEmptyEnumerable&lt;<tspan font-weight="700" fill="#0EA5E9">Dog</tspan>&gt;</text>
+  <text class="hint" x="80" y="197">Dog : Animal</text>
+
+  <!-- Interface card (right) -->
+  <rect x="520" y="110" width="320" height="110" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+  <text class="tag" x="540" y="135" fill="#4338CA">covariant interface</text>
+  <text class="mono" x="540" y="172">INonEmptyEnumerable&lt;<tspan font-weight="700" fill="#0EA5E9">Animal</tspan>&gt;</text>
+  <text class="mono-out" x="540" y="197">out T</text>
+
+  <!-- Arrow with label -->
+  <path d="M 380 165 L 520 165" stroke="#6366F1" stroke-width="2" marker-end="url(#cv-arrow)"/>
+  <text class="edge-label" x="450" y="155" text-anchor="middle" fill="#4338CA">implicit upcast</text>
+  <text class="hint" x="450" y="185" text-anchor="middle">(no conversion needed)</text>
+
+  <!-- Bottom explanation -->
+  <text class="hint" x="450" y="260" text-anchor="middle">
+    Because <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">T</tspan> is declared <tspan font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#6366F1">out</tspan>, every <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">NonEmptyEnumerable&lt;TDerived&gt;</tspan> is assignable to <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">INonEmptyEnumerable&lt;TBase&gt;</tspan>.
+  </text>
+</svg>

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -1,0 +1,193 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+  <style>
+    .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .layer-title  { font: 700 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .mono         { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
+    .mono-sm      { font: 11px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #4B5563; }
+    .external     { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.08em; text-transform: uppercase; }
+    .flow-tag     { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.1em; text-transform: uppercase; }
+    .type-label   { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .badge-head   { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; }
+    .badge-sub    { font: 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; opacity: 0.9; }
+    .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
+    .no-validate  { font: italic 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #9CA3AF; }
+  </style>
+
+  <defs>
+    <marker id="imp-arrow-amber" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#F59E0B"/>
+    </marker>
+    <marker id="imp-arrow-green" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <rect width="1100" height="760" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="1099" height="759" fill="none" stroke="#E5E7EB" rx="10"/>
+
+  <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
+  <g>
+    <!-- Header bar -->
+    <rect x="20" y="20" width="1060" height="34" rx="6" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="panel-title" x="40" y="43" fill="#B45309">Without StrongTypes</text>
+    <text class="panel-sub" x="1060" y="43" text-anchor="end" fill="#92400E">every layer has to validate — the type carries no guarantee</text>
+
+    <!-- Write flow tag -->
+    <text class="flow-tag" x="40" y="88">Write ↓</text>
+
+    <!-- ───── JSON in column (x=20-200) ───── -->
+    <text class="external" x="40" y="110">JSON in</text>
+    <rect x="30" y="120" width="175" height="40" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="40" y="145">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="125" y="177" text-anchor="middle">parses to ↓</text>
+
+    <rect x="30" y="185" width="175" height="60" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="40" y="204">class Request {</text>
+    <text class="mono" x="52" y="221"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="40" y="238">}</text>
+
+    <!-- ───── Badge: Custom validation code (over arrow 1) ───── -->
+    <rect x="218" y="108" width="155" height="34" rx="17" fill="#F59E0B"/>
+    <text class="badge-head" x="295" y="122" text-anchor="middle">✓ Custom validation code</text>
+    <text class="badge-sub" x="295" y="136" text-anchor="middle">you write the if-check</text>
+
+    <!-- Arrow 1: JSON → Controller -->
+    <line x1="205" y1="215" x2="250" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+
+    <!-- ───── Controller box ───── -->
+    <rect x="250" y="160" width="220" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="360" y="185" text-anchor="middle" fill="#B45309">Controller</text>
+    <line x1="265" y1="198" x2="455" y2="198" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-sm" x="265" y="218">if (string.IsNullOrWhite</text>
+    <text class="mono-sm" x="265" y="234">    Space(req.Name))</text>
+    <text class="mono-sm" x="265" y="250">  return BadRequest();</text>
+
+    <!-- ───── Badge: Custom validation code (over arrow 2) ───── -->
+    <rect x="483" y="108" width="155" height="34" rx="17" fill="#F59E0B"/>
+    <text class="badge-head" x="560" y="122" text-anchor="middle">✓ Custom validation code</text>
+    <text class="badge-sub" x="560" y="136" text-anchor="middle">defensive re-check</text>
+
+    <!-- Arrow 2: Controller → Service -->
+    <line x1="470" y1="215" x2="515" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="492" y="207" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- ───── Service box ───── -->
+    <rect x="515" y="160" width="220" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="625" y="185" text-anchor="middle" fill="#B45309">Service</text>
+    <line x1="530" y1="198" x2="720" y2="198" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-sm" x="530" y="218">if (string.IsNullOrWhite</text>
+    <text class="mono-sm" x="530" y="234">    Space(name))</text>
+    <text class="mono-sm" x="530" y="250">  throw ...;</text>
+
+    <!-- Arrow 3: Service → Entity -->
+    <line x1="735" y1="215" x2="815" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="775" y="207" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- ───── Entity box ───── -->
+    <rect x="815" y="160" width="250" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="940" y="185" text-anchor="middle" fill="#B45309">Entity / DB</text>
+    <line x1="830" y1="198" x2="1050" y2="198" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-sm" x="830" y="222">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
+    <text class="mono-sm" x="830" y="240">    { get; set; }</text>
+
+    <!-- ────────── Read flow ────────── -->
+    <text class="flow-tag" x="40" y="305">Read ↑</text>
+
+    <!-- Read arrow 3: Entity → Service -->
+    <line x1="815" y1="325" x2="735" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="775" y="318" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- Read arrow 2: Service → Controller -->
+    <line x1="515" y1="325" x2="470" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="492" y="318" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- Read arrow 1: Controller → left (JSON out) -->
+    <line x1="250" y1="325" x2="205" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+
+    <!-- "string all the way back" explanation -->
+    <text class="note" x="40" y="360">Even on the way out, the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#B45309">string</tspan> — the next caller has no idea whether the value is empty.</text>
+  </g>
+
+  <!-- Divider -->
+  <line x1="60" y1="395" x2="1040" y2="395" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="5 4"/>
+
+  <!-- ═══════════════════ PANEL 2: With StrongTypes ═══════════════════ -->
+  <g transform="translate(0, 390)">
+    <!-- Header bar -->
+    <rect x="20" y="20" width="1060" height="34" rx="6" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="panel-title" x="40" y="43" fill="#047857">With StrongTypes</text>
+    <text class="panel-sub" x="1060" y="43" text-anchor="end" fill="#065F46">validated once when receiving the value; the type guarantee is understood by every layer</text>
+
+    <!-- Write flow tag -->
+    <text class="flow-tag" x="40" y="88">Write ↓</text>
+
+    <!-- ───── JSON in column ───── -->
+    <text class="external" x="40" y="110">JSON in</text>
+    <rect x="30" y="120" width="175" height="40" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="40" y="145">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="125" y="177" text-anchor="middle">parses to ↓</text>
+
+    <rect x="30" y="185" width="175" height="60" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="40" y="204">class Request {</text>
+    <text class="mono" x="52" y="221"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono" x="40" y="238">}</text>
+
+    <!-- ───── Badge: Automatic JSON validation (over arrow 1) ───── -->
+    <rect x="218" y="108" width="155" height="34" rx="17" fill="#10B981"/>
+    <text class="badge-head" x="295" y="122" text-anchor="middle">✓ Automatic JSON validation</text>
+    <text class="badge-sub" x="295" y="136" text-anchor="middle">ASP.NET + JsonConverter</text>
+
+    <!-- Arrow 1: JSON → Controller -->
+    <line x1="205" y1="215" x2="250" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+
+    <!-- ───── Controller box ───── -->
+    <rect x="250" y="160" width="220" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="360" y="185" text-anchor="middle" fill="#047857">Controller</text>
+    <line x1="265" y1="198" x2="455" y2="198" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="360" y="230" text-anchor="middle">— no custom validation —</text>
+    <text class="mono-sm" x="360" y="250" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+
+    <!-- No-validate hint above arrow 2 -->
+    <text class="no-validate" x="492" y="127" text-anchor="middle">no validation needed</text>
+
+    <!-- Arrow 2: Controller → Service -->
+    <line x1="470" y1="215" x2="515" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="492" y="207" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- ───── Service box ───── -->
+    <rect x="515" y="160" width="220" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="625" y="185" text-anchor="middle" fill="#047857">Service</text>
+    <line x1="530" y1="198" x2="720" y2="198" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="625" y="230" text-anchor="middle">— no custom validation —</text>
+    <text class="mono-sm" x="625" y="250" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+
+    <!-- Arrow 3: Service → Entity -->
+    <line x1="735" y1="215" x2="815" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="775" y="207" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- ───── Entity box ───── -->
+    <rect x="815" y="160" width="250" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="940" y="185" text-anchor="middle" fill="#047857">Entity / DB</text>
+    <line x1="830" y1="198" x2="1050" y2="198" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="830" y="222">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
+    <text class="mono-sm" x="830" y="240">    { get; set; }</text>
+
+    <!-- ────────── Read flow ────────── -->
+    <text class="flow-tag" x="40" y="305">Read ↑</text>
+
+    <!-- Read arrow 3: Entity → Service -->
+    <line x1="815" y1="325" x2="735" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="775" y="318" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- Read arrow 2: Service → Controller -->
+    <line x1="515" y1="325" x2="470" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="492" y="318" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- Read arrow 1: Controller → left -->
+    <line x1="250" y1="325" x2="205" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+
+    <!-- Explanation -->
+    <text class="note" x="40" y="360">The type travels all the way back out — the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#047857">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
+  </g>
+</svg>

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -1,17 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
   <style>
     .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .layer-title  { font: 700 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .layer-title-sm { font: 700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .mono         { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
     .mono-sm      { font: 11px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #4B5563; }
+    .mono-xs      { font: 10px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #4B5563; }
     .external     { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.08em; text-transform: uppercase; }
     .flow-tag     { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.1em; text-transform: uppercase; }
     .type-label   { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .type-label-sm { font: 600 11px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .badge-head   { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; }
     .badge-sub    { font: 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; opacity: 0.9; }
     .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
-    .no-validate  { font: italic 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #9CA3AF; }
   </style>
 
   <defs>
@@ -23,171 +25,225 @@
     </marker>
   </defs>
 
-  <rect width="1100" height="760" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="1099" height="759" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect width="990" height="760" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="989" height="759" fill="none" stroke="#E5E7EB" rx="10"/>
 
   <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
   <g>
     <!-- Header bar -->
-    <rect x="20" y="20" width="1060" height="34" rx="6" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="panel-title" x="40" y="43" fill="#B45309">Without StrongTypes</text>
-    <text class="panel-sub" x="1060" y="43" text-anchor="end" fill="#92400E">every layer has to validate — the type carries no guarantee</text>
+    <rect x="15" y="15" width="960" height="32" rx="6" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="panel-title" x="35" y="36" fill="#B45309">Without StrongTypes</text>
+    <text class="panel-sub" x="970" y="36" text-anchor="end" fill="#92400E">every layer has to validate — the type carries no guarantee</text>
 
     <!-- Write flow tag -->
-    <text class="flow-tag" x="40" y="88">Write ↓</text>
+    <text class="flow-tag" x="35" y="65">Write ↓</text>
 
-    <!-- ───── JSON in column (x=20-200) ───── -->
-    <text class="external" x="40" y="110">JSON in</text>
-    <rect x="30" y="120" width="175" height="40" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
-    <text class="mono" x="40" y="145">{ "name": "Alice" }</text>
-    <text class="mono-sm" x="125" y="177" text-anchor="middle">parses to ↓</text>
+    <!-- ───── JSON in column ───── -->
+    <text class="external" x="25" y="82">JSON in</text>
+    <rect x="20" y="89" width="155" height="34" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
 
-    <rect x="30" y="185" width="175" height="60" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
-    <text class="mono" x="40" y="204">class Request {</text>
-    <text class="mono" x="52" y="221"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
-    <text class="mono" x="40" y="238">}</text>
+    <rect x="20" y="146" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="30" y="163">class Request {</text>
+    <text class="mono" x="42" y="180"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="30" y="197">}</text>
 
-    <!-- ───── Badge: Custom validation code (over arrow 1) ───── -->
-    <rect x="218" y="108" width="155" height="34" rx="17" fill="#F59E0B"/>
-    <text class="badge-head" x="295" y="122" text-anchor="middle">✓ Custom validation code</text>
-    <text class="badge-sub" x="295" y="136" text-anchor="middle">you write the if-check</text>
+    <!-- ───── Badge: Custom validation code (above Controller) ───── -->
+    <rect x="195" y="78" width="155" height="32" rx="16" fill="#F59E0B"/>
+    <text class="badge-head" x="272" y="92" text-anchor="middle">✓ Custom validation code</text>
+    <text class="badge-sub" x="272" y="105" text-anchor="middle">you write the if-check</text>
 
     <!-- Arrow 1: JSON → Controller -->
-    <line x1="205" y1="215" x2="250" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <line x1="175" y1="170" x2="195" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
 
     <!-- ───── Controller box ───── -->
-    <rect x="250" y="160" width="220" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="360" y="185" text-anchor="middle" fill="#B45309">Controller</text>
-    <line x1="265" y1="198" x2="455" y2="198" stroke="#FCD34D" stroke-width="1"/>
-    <text class="mono-sm" x="265" y="218">if (string.IsNullOrWhite</text>
-    <text class="mono-sm" x="265" y="234">    Space(req.Name))</text>
-    <text class="mono-sm" x="265" y="250">  return BadRequest();</text>
+    <rect x="195" y="125" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="312" y="146" text-anchor="middle" fill="#B45309">Controller</text>
+    <line x1="210" y1="158" x2="415" y2="158" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-xs" x="210" y="178">if (string.IsNullOrWhiteSpace(name))</text>
+    <text class="mono-xs" x="210" y="195" xml:space="preserve">    return BadRequest();</text>
 
-    <!-- ───── Badge: Custom validation code (over arrow 2) ───── -->
-    <rect x="483" y="108" width="155" height="34" rx="17" fill="#F59E0B"/>
-    <text class="badge-head" x="560" y="122" text-anchor="middle">✓ Custom validation code</text>
-    <text class="badge-sub" x="560" y="136" text-anchor="middle">defensive re-check</text>
+    <!-- ───── Badge: Multiple custom validations in code (above Services) ───── -->
+    <rect x="482" y="78" width="240" height="32" rx="16" fill="#F59E0B"/>
+    <text class="badge-head" x="602" y="92" text-anchor="middle">✓ Multiple custom validations in code</text>
+    <text class="badge-sub" x="602" y="105" text-anchor="middle">every service that touches the value re-validates</text>
 
-    <!-- Arrow 2: Controller → Service -->
-    <line x1="470" y1="215" x2="515" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="492" y="207" text-anchor="middle" fill="#B45309">string</text>
+    <!-- Arrow 2: Controller → Services -->
+    <line x1="430" y1="170" x2="485" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="457" y="160" text-anchor="middle" fill="#B45309">string</text>
 
-    <!-- ───── Service box ───── -->
-    <rect x="515" y="160" width="220" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="625" y="185" text-anchor="middle" fill="#B45309">Service</text>
-    <line x1="530" y1="198" x2="720" y2="198" stroke="#FCD34D" stroke-width="1"/>
-    <text class="mono-sm" x="530" y="218">if (string.IsNullOrWhite</text>
-    <text class="mono-sm" x="530" y="234">    Space(name))</text>
-    <text class="mono-sm" x="530" y="250">  throw ...;</text>
+    <!-- ───── Services box (with shadow stack) ───── -->
+    <rect x="497" y="113" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.45"/>
+    <rect x="491" y="119" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.7"/>
+    <rect x="485" y="125" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="602" y="146" text-anchor="middle" fill="#B45309">Services</text>
+    <line x1="500" y1="158" x2="705" y2="158" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-xs" x="500" y="178">if (string.IsNullOrWhiteSpace(name))</text>
+    <text class="mono-xs" x="500" y="195" xml:space="preserve">    throw ...;</text>
 
-    <!-- Arrow 3: Service → Entity -->
-    <line x1="735" y1="215" x2="815" y2="215" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="775" y="207" text-anchor="middle" fill="#B45309">string</text>
+    <!-- Arrow 3: Services → Entity -->
+    <line x1="720" y1="170" x2="775" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label" x="747" y="160" text-anchor="middle" fill="#B45309">string</text>
 
     <!-- ───── Entity box ───── -->
-    <rect x="815" y="160" width="250" height="110" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="940" y="185" text-anchor="middle" fill="#B45309">Entity / DB</text>
-    <line x1="830" y1="198" x2="1050" y2="198" stroke="#FCD34D" stroke-width="1"/>
-    <text class="mono-sm" x="830" y="222">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
-    <text class="mono-sm" x="830" y="240">    { get; set; }</text>
+    <rect x="775" y="125" width="200" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title" x="875" y="146" text-anchor="middle" fill="#B45309">Entity / DB</text>
+    <line x1="790" y1="158" x2="960" y2="158" stroke="#FCD34D" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
 
-    <!-- ────────── Read flow ────────── -->
-    <text class="flow-tag" x="40" y="305">Read ↑</text>
+    <!-- ─────── Light divider between Write and Usage ─────── -->
+    <line x1="35" y1="217" x2="955" y2="217" stroke="#F3F4F6" stroke-width="1"/>
 
-    <!-- Read arrow 3: Entity → Service -->
-    <line x1="815" y1="325" x2="735" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="775" y="318" text-anchor="middle" fill="#B45309">string</text>
+    <!-- ────────── Usage row ────────── -->
+    <text class="flow-tag" x="35" y="234">Usage ↑</text>
 
-    <!-- Read arrow 2: Service → Controller -->
-    <line x1="515" y1="325" x2="470" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="492" y="318" text-anchor="middle" fill="#B45309">string</text>
+    <!-- Re-validate badge -->
+    <rect x="482" y="242" width="240" height="32" rx="16" fill="#F59E0B"/>
+    <text class="badge-head" x="602" y="256" text-anchor="middle">✓ Re-validate before using the value</text>
+    <text class="badge-sub" x="602" y="269" text-anchor="middle">e.g. background jobs, business rules</text>
 
-    <!-- Read arrow 1: Controller → left (JSON out) -->
-    <line x1="250" y1="325" x2="205" y2="325" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <!-- ─── Response box (Usage row, left) ─── -->
+    <text class="external" x="25" y="292">JSON out</text>
+    <rect x="20" y="299" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="30" y="316">class Response {</text>
+    <text class="mono" x="42" y="333"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="30" y="350">}</text>
 
-    <!-- "string all the way back" explanation -->
-    <text class="note" x="40" y="360">Even on the way out, the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#B45309">string</tspan> — the next caller has no idea whether the value is empty.</text>
+    <!-- ─── Controller box (Usage row, empty) ─── -->
+    <rect x="195" y="299" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="312" y="320" text-anchor="middle" fill="#B45309">Controller</text>
+    <text class="mono-xs" x="312" y="340" text-anchor="middle" font-style="italic" fill="#9CA3AF">maps to Response</text>
+
+    <!-- ─── Services box (Usage row, with shadow stack) ─── -->
+    <rect x="497" y="287" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.45"/>
+    <rect x="491" y="293" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.7"/>
+    <rect x="485" y="299" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="602" y="320" text-anchor="middle" fill="#B45309">Services</text>
+    <text class="mono-xs" x="602" y="340" text-anchor="middle">re-check before use</text>
+
+    <!-- ─── Entity box (Usage row) ─── -->
+    <rect x="775" y="299" width="200" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="875" y="320" text-anchor="middle" fill="#B45309">Entity / DB</text>
+    <text class="mono-sm" x="875" y="342" text-anchor="middle">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
+
+    <!-- Usage arrow: Entity → Services -->
+    <line x1="775" y1="326" x2="720" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label-sm" x="747" y="317" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- Usage arrow: Services → Controller -->
+    <line x1="485" y1="326" x2="430" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label-sm" x="457" y="317" text-anchor="middle" fill="#B45309">string</text>
+
+    <!-- Usage arrow: Controller → Response -->
+    <line x1="195" y1="326" x2="175" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+
+    <!-- Note -->
+    <text class="note" x="35" y="375">Even on the way out, the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#B45309">string</tspan> — and any internal use of the entity must re-check.</text>
   </g>
 
-  <!-- Divider -->
-  <line x1="60" y1="395" x2="1040" y2="395" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="5 4"/>
+  <!-- Divider between panels -->
+  <line x1="50" y1="392" x2="940" y2="392" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="5 4"/>
 
   <!-- ═══════════════════ PANEL 2: With StrongTypes ═══════════════════ -->
   <g transform="translate(0, 390)">
     <!-- Header bar -->
-    <rect x="20" y="20" width="1060" height="34" rx="6" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="panel-title" x="40" y="43" fill="#047857">With StrongTypes</text>
-    <text class="panel-sub" x="1060" y="43" text-anchor="end" fill="#065F46">validated once when receiving the value; the type guarantee is understood by every layer</text>
+    <rect x="15" y="15" width="960" height="32" rx="6" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="panel-title" x="35" y="36" fill="#047857">With StrongTypes</text>
+    <text class="panel-sub" x="970" y="36" text-anchor="end" fill="#065F46">validated once when receiving the value; the type guarantee is understood by every layer</text>
 
     <!-- Write flow tag -->
-    <text class="flow-tag" x="40" y="88">Write ↓</text>
+    <text class="flow-tag" x="35" y="65">Write ↓</text>
 
     <!-- ───── JSON in column ───── -->
-    <text class="external" x="40" y="110">JSON in</text>
-    <rect x="30" y="120" width="175" height="40" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
-    <text class="mono" x="40" y="145">{ "name": "Alice" }</text>
-    <text class="mono-sm" x="125" y="177" text-anchor="middle">parses to ↓</text>
+    <text class="external" x="25" y="82">JSON in</text>
+    <rect x="20" y="89" width="155" height="34" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
 
-    <rect x="30" y="185" width="175" height="60" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
-    <text class="mono" x="40" y="204">class Request {</text>
-    <text class="mono" x="52" y="221"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
-    <text class="mono" x="40" y="238">}</text>
+    <rect x="20" y="146" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono" x="30" y="163">class Request {</text>
+    <text class="mono" x="42" y="180"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono" x="30" y="197">}</text>
 
-    <!-- ───── Badge: Automatic JSON validation (over arrow 1) ───── -->
-    <rect x="218" y="108" width="155" height="34" rx="17" fill="#10B981"/>
-    <text class="badge-head" x="295" y="122" text-anchor="middle">✓ Automatic JSON validation</text>
-    <text class="badge-sub" x="295" y="136" text-anchor="middle">ASP.NET + JsonConverter</text>
+    <!-- ───── Badge: Automatic JSON validation ───── -->
+    <rect x="195" y="78" width="180" height="32" rx="16" fill="#10B981"/>
+    <text class="badge-head" x="285" y="92" text-anchor="middle">✓ Automatic JSON validation</text>
+    <text class="badge-sub" x="285" y="105" text-anchor="middle">ASP.NET + JsonConverter</text>
 
     <!-- Arrow 1: JSON → Controller -->
-    <line x1="205" y1="215" x2="250" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <line x1="175" y1="170" x2="195" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
 
     <!-- ───── Controller box ───── -->
-    <rect x="250" y="160" width="220" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="360" y="185" text-anchor="middle" fill="#047857">Controller</text>
-    <line x1="265" y1="198" x2="455" y2="198" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="360" y="230" text-anchor="middle">— no custom validation —</text>
-    <text class="mono-sm" x="360" y="250" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+    <rect x="195" y="125" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="285" y="146" text-anchor="middle" fill="#047857">Controller</text>
+    <line x1="210" y1="158" x2="360" y2="158" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="285" y="186" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
 
-    <!-- No-validate hint above arrow 2 -->
-    <text class="no-validate" x="492" y="127" text-anchor="middle">no validation needed</text>
+    <!-- Arrow 2: Controller → Services -->
+    <line x1="375" y1="170" x2="485" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="430" y="160" text-anchor="middle" fill="#047857">NonEmptyString</text>
 
-    <!-- Arrow 2: Controller → Service -->
-    <line x1="470" y1="215" x2="515" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="492" y="207" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <!-- ───── Services box (with shadow stack) ───── -->
+    <rect x="497" y="113" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <rect x="491" y="119" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.7"/>
+    <rect x="485" y="125" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="575" y="146" text-anchor="middle" fill="#047857">Services</text>
+    <line x1="500" y1="158" x2="650" y2="158" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="575" y="186" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
 
-    <!-- ───── Service box ───── -->
-    <rect x="515" y="160" width="220" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="625" y="185" text-anchor="middle" fill="#047857">Service</text>
-    <line x1="530" y1="198" x2="720" y2="198" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="625" y="230" text-anchor="middle">— no custom validation —</text>
-    <text class="mono-sm" x="625" y="250" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
-
-    <!-- Arrow 3: Service → Entity -->
-    <line x1="735" y1="215" x2="815" y2="215" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="775" y="207" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <!-- Arrow 3: Services → Entity -->
+    <line x1="665" y1="170" x2="775" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label" x="720" y="160" text-anchor="middle" fill="#047857">NonEmptyString</text>
 
     <!-- ───── Entity box ───── -->
-    <rect x="815" y="160" width="250" height="110" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="940" y="185" text-anchor="middle" fill="#047857">Entity / DB</text>
-    <line x1="830" y1="198" x2="1050" y2="198" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="830" y="222">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
-    <text class="mono-sm" x="830" y="240">    { get; set; }</text>
+    <rect x="775" y="125" width="200" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title" x="875" y="146" text-anchor="middle" fill="#047857">Entity / DB</text>
+    <line x1="790" y1="158" x2="960" y2="158" stroke="#6EE7B7" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
 
-    <!-- ────────── Read flow ────────── -->
-    <text class="flow-tag" x="40" y="305">Read ↑</text>
+    <!-- ─────── Light divider between Write and Usage ─────── -->
+    <line x1="35" y1="217" x2="955" y2="217" stroke="#D1FAE5" stroke-width="1"/>
 
-    <!-- Read arrow 3: Entity → Service -->
-    <line x1="815" y1="325" x2="735" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="775" y="318" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <!-- ────────── Usage row ────────── -->
+    <text class="flow-tag" x="35" y="234">Usage ↑</text>
 
-    <!-- Read arrow 2: Service → Controller -->
-    <line x1="515" y1="325" x2="470" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="492" y="318" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <!-- ─── Response box (Usage row, left) ─── -->
+    <text class="external" x="25" y="257">JSON out</text>
+    <rect x="20" y="264" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <text class="mono-sm" x="30" y="282">class Response {</text>
+    <text class="mono-sm" x="42" y="298"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono-sm" x="30" y="314">}</text>
 
-    <!-- Read arrow 1: Controller → left -->
-    <line x1="250" y1="325" x2="205" y2="325" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <!-- ─── Controller box (Usage row, empty) ─── -->
+    <rect x="195" y="264" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="285" y="285" text-anchor="middle" fill="#047857">Controller</text>
+    <text class="mono-xs" x="285" y="305" text-anchor="middle" font-style="italic" fill="#6EE7B7">maps to Response</text>
 
-    <!-- Explanation -->
-    <text class="note" x="40" y="360">The type travels all the way back out — the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#047857">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
+    <!-- ─── Services box (Usage row, with shadow stack) ─── -->
+    <rect x="497" y="252" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
+    <rect x="491" y="258" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.7"/>
+    <rect x="485" y="264" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="575" y="285" text-anchor="middle" fill="#047857">Services</text>
+    <text class="mono-xs" x="575" y="305" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+
+    <!-- ─── Entity box (Usage row) ─── -->
+    <rect x="775" y="264" width="200" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="layer-title-sm" x="875" y="285" text-anchor="middle" fill="#047857">Entity / DB</text>
+    <text class="mono-sm" x="875" y="307" text-anchor="middle">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
+
+    <!-- Usage arrow: Entity → Services -->
+    <line x1="775" y1="291" x2="665" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label-sm" x="720" y="282" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- Usage arrow: Services → Controller -->
+    <line x1="485" y1="291" x2="375" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label-sm" x="430" y="282" text-anchor="middle" fill="#047857">NonEmptyString</text>
+
+    <!-- Usage arrow: Controller → Response -->
+    <line x1="195" y1="291" x2="175" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+
+    <!-- Note -->
+    <text class="note" x="35" y="342">The type travels all the way back out — the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#047857">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
   </g>
 </svg>

--- a/docs/diagrams/maybe-composition.svg
+++ b/docs/diagrams/maybe-composition.svg
@@ -1,0 +1,132 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+  <style>
+    .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .op-hint   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .track-tag { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+  </style>
+
+  <defs>
+    <marker id="mc-g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="mc-n" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="640" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="899" height="639" fill="none" stroke="#E5E7EB" rx="10"/>
+
+  <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
+  <g>
+    <text class="op-name" x="30" y="40">Map</text>
+    <text class="op-sig"  x="85" y="40">f : T → U</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">result is auto-wrapped back into Maybe</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Some track -->
+    <text class="track-tag" x="30" y="90" fill="#047857">Some</text>
+    <rect x="90"  y="74" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="155" y="95" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <line x1="220" y1="90" x2="400" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <text class="op-label" x="310" y="82" text-anchor="middle">Map(f)</text>
+    <rect x="400" y="74" width="160" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="480" y="95" text-anchor="middle" fill="#065F46">Some(f(x))</text>
+    <text class="note" x="580" y="95">f returned a T; Maybe wraps it automatically</text>
+
+    <!-- None track -->
+    <text class="track-tag" x="30" y="140" fill="#6B7280">None</text>
+    <rect x="90"  y="124" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="155" y="145" text-anchor="middle" fill="#374151">None</text>
+    <line x1="220" y1="140" x2="400" y2="140" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label" x="310" y="132" text-anchor="middle" fill="#6B7280">Map(f)</text>
+    <rect x="400" y="124" width="160" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="480" y="145" text-anchor="middle" fill="#374151">None</text>
+    <text class="note" x="580" y="145">f never called — short-circuits</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 2: FlatMap ═══════════════════ -->
+  <g transform="translate(0, 180)">
+    <text class="op-name" x="30" y="40">FlatMap</text>
+    <text class="op-sig"  x="125" y="40">f : T → Maybe&lt;U&gt;</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Maybe&lt;U&gt; — unwrapped directly to avoid Maybe&lt;Maybe&lt;U&gt;&gt;</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Some track: branches -->
+    <text class="track-tag" x="30" y="107" fill="#047857">Some</text>
+    <rect x="90"  y="91" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="155" y="112" text-anchor="middle" fill="#065F46">Some(x)</text>
+
+    <!-- Arrow to intermediate -->
+    <line x1="220" y1="107" x2="290" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <text class="op-label" x="255" y="99" text-anchor="middle">FlatMap(f)</text>
+
+    <!-- Intermediate "f(x) : Maybe<U>" -->
+    <rect x="290" y="91" width="170" height="32" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono" x="375" y="112" text-anchor="middle" fill="#4338CA">f(x) : Maybe&lt;U&gt;</text>
+
+    <!-- Branch arrows out of intermediate -->
+    <path d="M 460 100 C 495 95, 505 82, 540 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <path d="M 460 115 C 495 120, 505 133, 540 135" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+
+    <!-- Outcome pills (top: Some, bottom: None) -->
+    <rect x="540" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="610" y="85" text-anchor="middle" fill="#065F46">Some(y)</text>
+    <text class="note" x="690" y="85">f returned Some</text>
+
+    <rect x="540" y="120" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="610" y="141" text-anchor="middle" fill="#374151">None</text>
+    <text class="note" x="690" y="141">f returned None</text>
+
+    <!-- None track -->
+    <text class="track-tag" x="30" y="185" fill="#6B7280">None</text>
+    <rect x="90"  y="169" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="155" y="190" text-anchor="middle" fill="#374151">None</text>
+    <line x1="220" y1="185" x2="540" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label" x="380" y="177" text-anchor="middle" fill="#6B7280">FlatMap(f)</text>
+    <rect x="540" y="169" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="610" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="note" x="690" y="190">f never called — short-circuits</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 3: Where ═══════════════════ -->
+  <g transform="translate(0, 400)">
+    <text class="op-name" x="30" y="40">Where</text>
+    <text class="op-sig"  x="110" y="40">p : T → bool</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">predicate decides whether to keep the value</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Some track: branches -->
+    <text class="track-tag" x="30" y="107" fill="#047857">Some</text>
+    <rect x="90"  y="91" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="155" y="112" text-anchor="middle" fill="#065F46">Some(x)</text>
+
+    <!-- Arrow with "Where(p)" label, splits -->
+    <path d="M 220 100 C 300 95, 340 82, 400 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <path d="M 220 115 C 300 120, 340 133, 400 135" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label" x="290" y="112" text-anchor="middle">Where(p)</text>
+
+    <!-- Outcome pills -->
+    <rect x="400" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="470" y="85" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <text class="note" x="550" y="85">p(x) = true</text>
+
+    <rect x="400" y="120" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="470" y="141" text-anchor="middle" fill="#374151">None</text>
+    <text class="note" x="550" y="141">p(x) = false</text>
+
+    <!-- None track -->
+    <text class="track-tag" x="30" y="185" fill="#6B7280">None</text>
+    <rect x="90"  y="169" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="155" y="190" text-anchor="middle" fill="#374151">None</text>
+    <line x1="220" y1="185" x2="400" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label" x="310" y="177" text-anchor="middle" fill="#6B7280">Where(p)</text>
+    <rect x="400" y="169" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="470" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="note" x="550" y="190">p never called — short-circuits</text>
+  </g>
+</svg>

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 340" role="img" aria-label="StrongTypes NuGet package layout">
+  <style>
+    .card-title { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .body       { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .body-mono  { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
+    .sub-body   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .sub-mono   { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .bullet     { fill: #6366F1; }
+    .sub-bullet { fill: none; stroke: #9CA3AF; stroke-width: 1.2; }
+    .sm-bullet  { fill: #9CA3AF; }
+  </style>
+
+  <defs>
+    <marker id="pl-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <rect width="700" height="340" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="699" height="339" fill="none" stroke="#E5E7EB" rx="10"/>
+
+  <!-- Core card (top, centered) -->
+  <rect x="130" y="15" width="440" height="190" rx="8" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+  <text class="core-title" x="148" y="42">Kalicz.StrongTypes</text>
+
+  <!-- Bullet 1: Maybe + JSON Converter -->
+  <circle class="bullet" cx="156" cy="70" r="2.5"/>
+  <text class="body-mono" x="166" y="74">Maybe&lt;T&gt;<tspan class="body" fill="#374151"> + JSON converter</tspan></text>
+
+  <!-- Bullet 2: Result -->
+  <circle class="bullet" cx="156" cy="93" r="2.5"/>
+  <text class="body-mono" x="166" y="97">Result&lt;T&gt; / Result&lt;T, TError&gt;</text>
+
+  <!-- Bullet 3: Useful Types with JSON converters -->
+  <circle class="bullet" cx="156" cy="116" r="2.5"/>
+  <text class="body" x="166" y="120">Validated value types<tspan fill="#6B7280"> (with JSON converters)</tspan></text>
+
+  <!-- Sub-bullets -->
+  <circle class="sub-bullet" cx="185" cy="139" r="2.3"/>
+  <text class="sub-mono" x="196" y="143">NonEmptyString</text>
+
+  <circle class="sub-bullet" cx="185" cy="160" r="2.3"/>
+  <text class="sub-mono" x="196" y="164">NonEmptyEnumerable&lt;T&gt;</text>
+
+  <circle class="sub-bullet" cx="185" cy="181" r="2.3"/>
+  <text class="sub-body" x="196" y="185">Numeric wrappers <tspan font-family="ui-monospace, Menlo, Consolas, monospace">(Positive&lt;T&gt;, …)</tspan></text>
+
+  <!-- EfCore card (bottom-left) -->
+  <rect x="15" y="245" width="330" height="80" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text class="card-title" x="31" y="269">Kalicz.StrongTypes.EfCore</text>
+  <circle class="sm-bullet" cx="37" cy="289" r="2"/>
+  <text class="body" x="45" y="293">EF Core value converters</text>
+  <circle class="sm-bullet" cx="37" cy="309" r="2"/>
+  <text class="body" x="45" y="313">Convention + DbContext extension</text>
+
+  <!-- FsCheck card (bottom-right) -->
+  <rect x="355" y="245" width="330" height="56" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text class="card-title" x="371" y="269">Kalicz.StrongTypes.FsCheck</text>
+  <circle class="sm-bullet" cx="377" cy="289" r="2"/>
+  <text class="body" x="385" y="293">FsCheck Arbitrary generators</text>
+
+  <!-- Arrows from bottom cards to core card (no labels, short diagonals) -->
+  <line x1="180" y1="245" x2="220" y2="207" stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line x1="520" y1="245" x2="480" y2="207" stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+</svg>

--- a/docs/diagrams/patch-three-state.svg
+++ b/docs/diagrams/patch-three-state.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+  <style>
+    .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .col-head   { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono       { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .mono-lg    { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .intent     { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+  </style>
+
+  <defs>
+    <marker id="p3-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="440" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="899" height="439" fill="none" stroke="#E5E7EB" rx="12"/>
+
+  <!-- Title -->
+  <text class="title-text" x="40" y="38">PATCH three-state model</text>
+  <text class="subtitle"   x="40" y="58">Wrapping <tspan font-family="ui-monospace, Menlo, monospace">Maybe&lt;T&gt;</tspan> in <tspan font-family="ui-monospace, Menlo, monospace">T?</tspan> distinguishes <tspan font-style="italic">untouched</tspan> from <tspan font-style="italic">explicitly cleared</tspan>.</text>
+
+  <!-- Column headers -->
+  <text class="col-head" x="40"  y="105">Incoming JSON</text>
+  <text class="col-head" x="330" y="105">Property value</text>
+  <text class="col-head" x="640" y="105">Intent</text>
+
+  <!-- Row 1: Untouched (gray) -->
+  <rect x="40"  y="125" width="260" height="70" rx="10" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text class="mono" x="60" y="152">field omitted</text>
+  <text class="mono" x="60" y="172">— or —</text>
+  <text class="mono" x="60" y="188">"field": null</text>
+
+  <line x1="300" y1="160" x2="330" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="330" y="125" width="260" height="70" rx="10" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="168" text-anchor="middle">(Maybe&lt;T&gt;?)null</text>
+
+  <line x1="590" y1="160" x2="620" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="620" y="125" width="240" height="70" rx="10" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
+  <circle cx="640" cy="160" r="6" fill="#9CA3AF"/>
+  <text class="intent" x="656" y="166" fill="#374151">leave untouched</text>
+
+  <!-- Row 2: Clear to null (amber) -->
+  <rect x="40"  y="210" width="260" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <text class="mono" x="60" y="237">"field": {}</text>
+  <text class="mono" x="60" y="257">— or —</text>
+  <text class="mono" x="60" y="273">"field": { "Value": null }</text>
+
+  <line x1="300" y1="245" x2="330" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="330" y="210" width="260" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="253" text-anchor="middle">Maybe&lt;T&gt;.None</text>
+
+  <line x1="590" y1="245" x2="620" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="620" y="210" width="240" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <circle cx="640" cy="245" r="6" fill="#F59E0B"/>
+  <text class="intent" x="656" y="251" fill="#B45309">clear to null</text>
+
+  <!-- Row 3: Set to value (green) -->
+  <rect x="40"  y="295" width="260" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <text class="mono" x="60" y="338" text-anchor="start">"field": { "Value": x }</text>
+
+  <line x1="300" y1="330" x2="330" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="330" y="295" width="260" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="338" text-anchor="middle">Maybe&lt;T&gt;.Some(x)</text>
+
+  <line x1="590" y1="330" x2="620" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect x="620" y="295" width="240" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <circle cx="640" cy="330" r="6" fill="#10B981"/>
+  <text class="intent" x="656" y="336" fill="#047857">set to x</text>
+
+  <!-- Footer note -->
+  <text class="subtitle" x="40" y="410">A plain <tspan font-family="ui-monospace, Menlo, monospace">T?</tspan> collapses rows 1 and 2 into a single <tspan font-family="ui-monospace, Menlo, monospace">null</tspan> — the outer <tspan font-family="ui-monospace, Menlo, monospace">?</tspan> around <tspan font-family="ui-monospace, Menlo, monospace">Maybe&lt;T&gt;</tspan> is what buys the third state.</text>
+</svg>

--- a/docs/diagrams/result-composition.svg
+++ b/docs/diagrams/result-composition.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+  <style>
+    .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .op-hint   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .track-tag { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+  </style>
+
+  <defs>
+    <marker id="rc-g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="rc-r" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#EF4444"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="600" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="899" height="599" fill="none" stroke="#E5E7EB" rx="10"/>
+
+  <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
+  <g>
+    <text class="op-name" x="30" y="40">Map</text>
+    <text class="op-sig"  x="85" y="40">f : T → U</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">transforms Success; Error passes through unchanged</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Success track -->
+    <text class="track-tag" x="30" y="90" fill="#047857">Success</text>
+    <rect x="90"  y="74" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="160" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label" x="320" y="82" text-anchor="middle">Map(f)</text>
+    <rect x="410" y="74" width="170" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="495" y="95" text-anchor="middle" fill="#065F46">Success(f(x))</text>
+    <text class="note" x="600" y="95">f returned a T; Result wraps it automatically</text>
+
+    <!-- Error track -->
+    <text class="track-tag" x="30" y="140" fill="#B91C1C">Error</text>
+    <rect x="90"  y="124" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono" x="160" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label" x="320" y="132" text-anchor="middle" fill="#B91C1C">Map(f)</text>
+    <rect x="410" y="124" width="170" height="32" rx="16" fill="#FEF7F7" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="495" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="note" x="600" y="145">f never called — pass-through</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 2: MapError ═══════════════════ -->
+  <g transform="translate(0, 180)">
+    <text class="op-name" x="30" y="40">MapError</text>
+    <text class="op-sig"  x="135" y="40">g : TError → TError2</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">transforms Error; Success passes through unchanged</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Success track (pass-through) -->
+    <text class="track-tag" x="30" y="90" fill="#047857">Success</text>
+    <rect x="90"  y="74" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="160" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label" x="320" y="82" text-anchor="middle" fill="#047857">MapError(g)</text>
+    <rect x="410" y="74" width="170" height="32" rx="16" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="495" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <text class="note" x="600" y="95">g never called — pass-through</text>
+
+    <!-- Error track (transformed) -->
+    <text class="track-tag" x="30" y="140" fill="#B91C1C">Error</text>
+    <rect x="90"  y="124" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono" x="160" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label" x="320" y="132" text-anchor="middle" fill="#B91C1C">MapError(g)</text>
+    <rect x="410" y="124" width="170" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono" x="495" y="145" text-anchor="middle" fill="#991B1B">Error(g(e))</text>
+    <text class="note" x="600" y="145">g returned a TError2; Result wraps it</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 3: FlatMap ═══════════════════ -->
+  <g transform="translate(0, 360)">
+    <text class="op-name" x="30" y="40">FlatMap</text>
+    <text class="op-sig"  x="125" y="40">f : T → Result&lt;U, TError&gt;</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Result&lt;U, TError&gt; — unwrapped directly to avoid nested Result&lt;Result&lt;U, TError&gt;, TError&gt;</text>
+    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+
+    <!-- Success track: branches -->
+    <text class="track-tag" x="30" y="107" fill="#047857">Success</text>
+    <rect x="90"  y="91" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="160" y="112" text-anchor="middle" fill="#065F46">Success(x)</text>
+
+    <line x1="230" y1="107" x2="310" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label" x="270" y="99" text-anchor="middle">FlatMap(f)</text>
+
+    <!-- Intermediate: f(x) : Result<U, TError> -->
+    <rect x="310" y="91" width="200" height="32" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono" x="410" y="112" text-anchor="middle" fill="#4338CA">f(x) : Result&lt;U, TError&gt;</text>
+
+    <!-- Branches from intermediate -->
+    <path d="M 510 100 C 545 95, 555 82, 590 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <path d="M 510 115 C 545 120, 555 133, 590 135" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+
+    <rect x="590" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono" x="660" y="85" text-anchor="middle" fill="#065F46">Success(y)</text>
+    <text class="note" x="740" y="85">f returned Success</text>
+
+    <rect x="590" y="120" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono" x="660" y="141" text-anchor="middle" fill="#991B1B">Error(e′)</text>
+    <text class="note" x="740" y="141">f returned Error</text>
+
+    <!-- Error track -->
+    <text class="track-tag" x="30" y="185" fill="#B91C1C">Error</text>
+    <rect x="90"  y="169" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono" x="160" y="190" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <line x1="230" y1="185" x2="590" y2="185" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label" x="410" y="177" text-anchor="middle" fill="#B91C1C">FlatMap(f)</text>
+    <rect x="590" y="169" width="140" height="32" rx="16" fill="#FEF7F7" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono" x="660" y="190" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="note" x="740" y="190">f never called — short-circuits</text>
+  </g>
+</svg>

--- a/docs/diagrams/trycreate-create-flow.svg
+++ b/docs/diagrams/trycreate-create-flow.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
+  <style>
+    .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .mono             { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .mono-outcome     { font: 700 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .branch-label     { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .methods-head     { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.06em; text-transform: uppercase; }
+    .method-name      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .bullet           { fill: #D1D5DB; }
+  </style>
+
+  <defs>
+    <marker id="tc-arrow-gray" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+    <marker id="tc-arrow-green" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="tc-arrow-red" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#EF4444"/>
+    </marker>
+    <marker id="tc-arrow-indigo" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#6366F1"/>
+    </marker>
+  </defs>
+
+  <rect width="900" height="410" fill="#FFFFFF"/>
+  <rect x="0.5" y="0.5" width="899" height="409" fill="none" stroke="#E5E7EB" rx="10"/>
+
+  <!-- ============ LEFT COLUMN: TryCreate / As… ============ -->
+  <g transform="translate(20, 0)">
+    <!-- Column header bar -->
+    <rect x="0" y="20" width="420" height="32" rx="6" fill="#F3F4F6" stroke="#D1D5DB" stroke-width="1.5"/>
+    <text class="col-header" x="210" y="41" text-anchor="middle" fill="#374151">TryCreate / As…</text>
+
+    <!-- Input pill -->
+    <rect x="150" y="72" width="120" height="34" rx="17" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
+    <text class="node-label" x="210" y="94" text-anchor="middle" fill="#111827">input</text>
+
+    <!-- Arrow down to validate -->
+    <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
+
+    <!-- Validate box (decision) -->
+    <rect x="150" y="130" width="120" height="38" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5"/>
+    <text class="node-label" x="210" y="154" text-anchor="middle" fill="#4338CA">valid?</text>
+
+    <!-- Branch arrows -->
+    <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
+    <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#tc-arrow-gray)"/>
+
+    <!-- Branch labels -->
+    <text class="branch-label" x="148" y="185" text-anchor="middle" fill="#047857">yes</text>
+    <text class="branch-label" x="272" y="185" text-anchor="middle" fill="#6B7280">no</text>
+
+    <!-- Success outcome -->
+    <rect x="70" y="210" width="120" height="40" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono-outcome" x="130" y="236" text-anchor="middle" fill="#065F46">T</text>
+
+    <!-- Failure outcome: null -->
+    <rect x="230" y="210" width="120" height="40" rx="8" fill="#F3F4F6" stroke="#9CA3AF" stroke-width="1.5"/>
+    <text class="mono-outcome" x="290" y="236" text-anchor="middle" fill="#374151">null</text>
+
+    <!-- Divider -->
+    <line x1="10" y1="285" x2="410" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- Methods list -->
+    <text class="methods-head" x="20" y="310">Methods in this family</text>
+    <g transform="translate(20, 330)">
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">TryCreate / TryParse<tspan fill="#9CA3AF">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">AsNonEmpty / AsPositive / AsNegative / AsEnum&lt;T&gt; / …</text>
+      <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">AsInt / AsGuid / AsTimeSpan / …</text>
+    </g>
+  </g>
+
+  <!-- ============ RIGHT COLUMN: Create / To… ============ -->
+  <g transform="translate(460, 0)">
+    <!-- Column header bar -->
+    <rect x="0" y="20" width="420" height="32" rx="6" fill="#FEF2F2" stroke="#FCA5A5" stroke-width="1.5"/>
+    <text class="col-header" x="210" y="41" text-anchor="middle" fill="#991B1B">Create / To…</text>
+
+    <!-- Input pill -->
+    <rect x="150" y="72" width="120" height="34" rx="17" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
+    <text class="node-label" x="210" y="94" text-anchor="middle" fill="#111827">input</text>
+
+    <!-- Arrow down to validate -->
+    <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
+
+    <!-- Validate box (decision) -->
+    <rect x="150" y="130" width="120" height="38" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5"/>
+    <text class="node-label" x="210" y="154" text-anchor="middle" fill="#4338CA">valid?</text>
+
+    <!-- Branch arrows -->
+    <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
+    <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#tc-arrow-red)"/>
+
+    <!-- Branch labels -->
+    <text class="branch-label" x="148" y="185" text-anchor="middle" fill="#047857">yes</text>
+    <text class="branch-label" x="272" y="185" text-anchor="middle" fill="#B91C1C">no</text>
+
+    <!-- Success outcome -->
+    <rect x="70" y="210" width="120" height="40" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+    <text class="mono-outcome" x="130" y="236" text-anchor="middle" fill="#065F46">T</text>
+
+    <!-- Failure outcome: throws -->
+    <rect x="230" y="210" width="120" height="40" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
+    <text class="mono-outcome" x="290" y="236" text-anchor="middle" fill="#991B1B">throws</text>
+
+    <!-- Divider -->
+    <line x1="10" y1="285" x2="410" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- Methods list -->
+    <text class="methods-head" x="20" y="310">Methods in this family</text>
+    <g transform="translate(20, 330)">
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">Create / Parse<tspan fill="#9CA3AF">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">ToNonEmpty / ToPositive / ToNegative / ToEnum&lt;T&gt; / …</text>
+      <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">ToInt / ToGuid / ToTimeSpan / …</text>
+    </g>
+  </g>
+</svg>

--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,14 @@ The library ships as three NuGet packages. The core package has no third-party d
 
 ```mermaid
 flowchart LR
-    Core["Kalicz.StrongTypes<br/>core types<br/>System.Text.Json converters"]
-    EfCore["Kalicz.StrongTypes.EfCore<br/>EF Core value converters<br/>convention + DbContext extension"]
-    FsCheck["Kalicz.StrongTypes.FsCheck<br/>FsCheck Arbitrary generators"]
+    Core["`**Kalicz.StrongTypes**
+    - core types
+    - System.Text.Json converters`"]
+    EfCore["`**Kalicz.StrongTypes.EfCore**
+    - EF Core value converters
+    - convention + DbContext extension`"]
+    FsCheck["`**Kalicz.StrongTypes.FsCheck**
+    - FsCheck Arbitrary generators`"]
     EfCore -->|depends on| Core
     FsCheck -->|depends on| Core
 ```

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,17 @@ StrongTypes is not an attempt to build a full algebraic type system on top of C#
 
 Every type ships with `System.Text.Json` converters out of the box (except `Result`), so invalid JSON fails at deserialization — in ASP.NET Core, that's before your endpoint method even runs.
 
+The library ships as three NuGet packages. The core package has no third-party dependencies; the other two are opt-in:
+
+```mermaid
+flowchart LR
+    Core["Kalicz.StrongTypes<br/>core types<br/>System.Text.Json converters"]
+    EfCore["Kalicz.StrongTypes.EfCore<br/>EF Core value converters<br/>convention + DbContext extension"]
+    FsCheck["Kalicz.StrongTypes.FsCheck<br/>FsCheck Arbitrary generators"]
+    EfCore -->|depends on| Core
+    FsCheck -->|depends on| Core
+```
+
 ## Contents
 
 - [Helpful Types](#helpful-types)
@@ -39,6 +50,16 @@ NonEmptyString? name = NonEmptyString.TryCreate(input);
 NonEmptyString name = NonEmptyString.Create(input);
 ```
 
+The `TryCreate` / `Create` split (and the `As…` / `To…` extensions that mirror it) is used across every validated type in the library — pick the factory that matches how you want to handle bad input at the call site:
+
+```mermaid
+flowchart LR
+    In([input]) --> V{valid?}
+    V -->|yes| Ok["T"]
+    V -->|no, TryCreate / As…| Null["null"]
+    V -->|no, Create / To…| Throw["throws<br/>ArgumentException"]
+```
+
 Or via the `AsNonEmpty()` extension on any `string?`:
 
 ```csharp
@@ -57,6 +78,23 @@ Four generic wrappers that enforce a sign invariant on any `INumber<T>` — `int
 | `NonNegative<T>`  | greater than or equal to zero |
 | `Negative<T>`     | strictly less than zero    |
 | `NonPositive<T>`  | less than or equal to zero |
+
+Visually, on the number line:
+
+```mermaid
+flowchart LR
+    neg["x &lt; 0"]
+    zero(("0"))
+    pos["x &gt; 0"]
+    neg --- zero --- pos
+
+    Negative["Negative&lt;T&gt;<br/>default = -1"] -.-> neg
+    NonPositive["NonPositive&lt;T&gt;<br/>default = 0"] -.-> neg
+    NonPositive -.-> zero
+    NonNegative["NonNegative&lt;T&gt;<br/>default = 0"] -.-> zero
+    NonNegative -.-> pos
+    Positive["Positive&lt;T&gt;<br/>default = 1"] -.-> pos
+```
 
 Same factory pattern:
 
@@ -168,6 +206,11 @@ int avg  = list.Average();
 ```csharp
 NonEmptyEnumerable<Dog>      dogs    = [new Dog()];
 INonEmptyEnumerable<Animal>  animals = dogs;  // allowed thanks to `out T`
+```
+
+```mermaid
+flowchart LR
+    Dogs["NonEmptyEnumerable&lt;Dog&gt;"] -->|implicit conversion<br/>(out T covariance)| Animals["INonEmptyEnumerable&lt;Animal&gt;"]
 ```
 
 All extensions (`Select`, `Concat`, `Max`, `Last`, …) have overloads on both the concrete type and the interface, so either receiver type works in a chain.
@@ -310,6 +353,13 @@ HTTP `PATCH` has a long-standing modelling problem for nullable fields: a reques
 | `{}` or `{"Value":null}` | `Maybe<T>.None`    | clear field to `null` |
 | `{"Value":x}`            | `Maybe<T>.Some(x)` | set field to `x`      |
 
+```mermaid
+flowchart LR
+    J1["field omitted<br/>or null"]       --> V1["(Maybe&lt;T&gt;?)null"]  --> I1["leave untouched"]
+    J2["{}<br/>or {&quot;Value&quot;:null}"] --> V2["Maybe&lt;T&gt;.None"]    --> I2["clear to null"]
+    J3["{&quot;Value&quot;:x}"]           --> V3["Maybe&lt;T&gt;.Some(x)"] --> I3["set to x"]
+```
+
 The request DTO and PATCH handler then read straight off pattern matching, with no out-of-band sentinel values:
 
 ```csharp
@@ -375,6 +425,17 @@ var label = maybe.Match(
 #### Composition
 
 `Maybe<T>` composes monadically through `Map`, `FlatMap`, and `Where`. Each operation is a no-op on `None`, so chains short-circuit cleanly without explicit null checks:
+
+```mermaid
+flowchart LR
+    S1["Some(x)"] -->|Map f|     S2["Some(f(x))"]
+    N1["None"]    -->|Map f|     N2["None (short-circuit)"]
+    S3["Some(x)"] -->|FlatMap f| R["f(x) : Maybe&lt;U&gt;"]
+    N3["None"]    -->|FlatMap f| N4["None (short-circuit)"]
+    S4["Some(x)"] -->|Where p|   W{"p(x)?"}
+    W -->|true|  S5["Some(x)"]
+    W -->|false| N5["None"]
+```
 
 ```csharp
 // Map — transform the inner value when present.
@@ -486,7 +547,18 @@ public Result<Order, OrderError> CreateOrder(OrderData data)
 
 #### Transformation
 
-`Map`, `MapError`, `Match`, and `FlatMap` let you chain without explicit branching:
+`Map`, `MapError`, `Match`, and `FlatMap` let you chain without explicit branching. Success and error values flow down independent tracks — `Map` only touches the success side, `MapError` only touches the error side, and `FlatMap` short-circuits on error:
+
+```mermaid
+flowchart LR
+    S1["Success(x)"] -->|Map f|      S2["Success(f(x))"]
+    E1["Error(e)"]   -->|Map f|      E2["Error(e) (pass-through)"]
+    S3["Success(x)"] -->|MapError g| S4["Success(x) (pass-through)"]
+    E3["Error(e)"]   -->|MapError g| E4["Error(g(e))"]
+    S5["Success(x)"] -->|FlatMap f|  R["f(x) : Result&lt;U, TError&gt;"]
+    E5["Error(e)"]   -->|FlatMap f|  E6["Error(e) (short-circuit)"]
+```
+
 
 ```csharp
 Result<int, string> r = Parse("42");

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Every type ships with `System.Text.Json` converters out of the box (except `Resu
 
 You can also store the types directly in your EF Core entities with the use of the EfCore package.
 
-<img src="docs/diagrams/impact.svg" alt="Impact of StrongTypes on validation boundaries" width="1100" />
+<img src="docs/diagrams/impact.svg" alt="Impact of StrongTypes on validation boundaries" width="990" height="760" />
 
 <img src="docs/diagrams/package-layout.svg" alt="Package layout" width="680" />
 

--- a/readme.md
+++ b/readme.md
@@ -4,28 +4,15 @@
 [![StrongTypes.EfCore downloads](https://img.shields.io/nuget/dt/Kalicz.StrongTypes.EfCore?label=downloads%20%28StrongTypes.EfCore%29)](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/)
 [![StrongTypes.FsCheck downloads](https://img.shields.io/nuget/dt/Kalicz.StrongTypes.FsCheck?label=downloads%20%28StrongTypes.FsCheck%29)](https://www.nuget.org/packages/Kalicz.StrongTypes.FsCheck/)
 
-StrongTypes is not an attempt to build a full algebraic type system on top of C#. It adds small, focused value types that make everyday code safer and more expressive — things like "a string that is never empty" or "an integer that is always positive".
+StrongTypes is not an attempt to build a full algebraic type system on top of C#. It adds small, focused types that make everyday code safer and more expressive — things like "a string that is never empty" or "an integer that is always positive".
 
 Every type ships with `System.Text.Json` converters out of the box (except `Result`), so invalid JSON fails at deserialization — in ASP.NET Core, that's before your endpoint method even runs.
 
-The library ships as three NuGet packages. The core package has no third-party dependencies; the other two are opt-in:
+You can also store the types directly in your EF Core entities with the use of the EfCore package.
 
-```mermaid
-flowchart LR
-    subgraph Core[Kalicz.StrongTypes]
-        CoreBody["`- core types
-        - System.Text.Json converters`"]
-    end
-    subgraph EfCore[Kalicz.StrongTypes.EfCore]
-        EfCoreBody["`- EF Core value converters
-        - convention + DbContext extension`"]
-    end
-    subgraph FsCheck[Kalicz.StrongTypes.FsCheck]
-        FsCheckBody["`- FsCheck Arbitrary generators`"]
-    end
-    EfCore -->|depends on| Core
-    FsCheck -->|depends on| Core
-```
+<img src="docs/diagrams/impact.svg" alt="Impact of StrongTypes on validation boundaries" width="1100" />
+
+<img src="docs/diagrams/package-layout.svg" alt="Package layout" width="680" />
 
 ## Contents
 
@@ -60,13 +47,7 @@ NonEmptyString name = NonEmptyString.Create(input);
 
 The `TryCreate` / `Create` split (and the `As…` / `To…` extensions that mirror it) is used across every validated type in the library — pick the factory that matches how you want to handle bad input at the call site:
 
-```mermaid
-flowchart LR
-    In([input]) --> V{valid?}
-    V -->|yes| Ok["T"]
-    V -->|no, TryCreate / As…| Null["null"]
-    V -->|no, Create / To…| Throw["throws<br/>ArgumentException"]
-```
+<img src="docs/diagrams/trycreate-create-flow.svg" alt="TryCreate vs Create flow" width="900" />
 
 Or via the `AsNonEmpty()` extension on any `string?`:
 
@@ -86,23 +67,6 @@ Four generic wrappers that enforce a sign invariant on any `INumber<T>` — `int
 | `NonNegative<T>`  | greater than or equal to zero |
 | `Negative<T>`     | strictly less than zero    |
 | `NonPositive<T>`  | less than or equal to zero |
-
-Visually, on the number line:
-
-```mermaid
-flowchart LR
-    neg["x &lt; 0"]
-    zero(("0"))
-    pos["x &gt; 0"]
-    neg --- zero --- pos
-
-    Negative["Negative&lt;T&gt;<br/>default = -1"] -.-> neg
-    NonPositive["NonPositive&lt;T&gt;<br/>default = 0"] -.-> neg
-    NonPositive -.-> zero
-    NonNegative["NonNegative&lt;T&gt;<br/>default = 0"] -.-> zero
-    NonNegative -.-> pos
-    Positive["Positive&lt;T&gt;<br/>default = 1"] -.-> pos
-```
 
 Same factory pattern:
 
@@ -152,7 +116,7 @@ All strong types ship with `System.Text.Json` converters attached via `[JsonConv
 
 ### EF Core persistence
 
-If you want to store strong types directly on your EF Core entities, add the companion package [`Kalicz.StrongTypes.EfCore`](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/). It provides the value converters needed to map `NonEmptyString`, `Positive<T>`, and friends to their underlying column types. See the package [readme](https://github.com/KaliCZ/StrongTypes/blob/main/src/StrongTypes.EfCore/readme.md) for setup details.
+If you want to store strong types directly on your EF Core entities, add the companion package [`Kalicz.StrongTypes.EfCore`](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/). It provides the value converters needed to map `NonEmptyString`, `Positive<T>`, and other numeric types to their underlying column types. See the package [readme](https://github.com/KaliCZ/StrongTypes/blob/main/src/StrongTypes.EfCore/readme.md) for setup details.
 
 ## `NonEmptyEnumerable<T>`
 
@@ -216,10 +180,7 @@ NonEmptyEnumerable<Dog>      dogs    = [new Dog()];
 INonEmptyEnumerable<Animal>  animals = dogs;  // allowed thanks to `out T`
 ```
 
-```mermaid
-flowchart LR
-    Dogs["NonEmptyEnumerable&lt;Dog&gt;"] -->|implicit conversion<br/>(out T covariance)| Animals["INonEmptyEnumerable&lt;Animal&gt;"]
-```
+<img src="docs/diagrams/covariance.svg" alt="Covariant out T upcast" width="900" />
 
 All extensions (`Select`, `Concat`, `Max`, `Last`, …) have overloads on both the concrete type and the interface, so either receiver type works in a chain.
 
@@ -355,18 +316,7 @@ The generic constraint is `where T : notnull` — `Maybe<int?>` and `Maybe<strin
 
 HTTP `PATCH` has a long-standing modelling problem for nullable fields: a request needs to distinguish three intents — *don't touch this field*, *clear this field to null*, and *set it to a new value*. A plain `T?` collapses the first two cases. `Maybe<T>?` keeps them apart, because `Maybe<T>` itself is a value, so wrapping it in `T?` adds a real third state:
 
-| JSON                     | Property value     | Intent                |
-| ------------------------ |--------------------| --------------------- |
-| field omitted, or `null` | `(Maybe<T>?)null`  | leave field untouched |
-| `{}` or `{"Value":null}` | `Maybe<T>.None`    | clear field to `null` |
-| `{"Value":x}`            | `Maybe<T>.Some(x)` | set field to `x`      |
-
-```mermaid
-flowchart LR
-    J1["field omitted<br/>or null"]       --> V1["(Maybe&lt;T&gt;?)null"]  --> I1["leave untouched"]
-    J2["{}<br/>or {&quot;Value&quot;:null}"] --> V2["Maybe&lt;T&gt;.None"]    --> I2["clear to null"]
-    J3["{&quot;Value&quot;:x}"]           --> V3["Maybe&lt;T&gt;.Some(x)"] --> I3["set to x"]
-```
+<img src="docs/diagrams/patch-three-state.svg" alt="PATCH three-state model" width="900" />
 
 The request DTO and PATCH handler then read straight off pattern matching, with no out-of-band sentinel values:
 
@@ -434,16 +384,7 @@ var label = maybe.Match(
 
 `Maybe<T>` composes monadically through `Map`, `FlatMap`, and `Where`. Each operation is a no-op on `None`, so chains short-circuit cleanly without explicit null checks:
 
-```mermaid
-flowchart LR
-    S1["Some(x)"] -->|Map f|     S2["Some(f(x))"]
-    N1["None"]    -->|Map f|     N2["None (short-circuit)"]
-    S3["Some(x)"] -->|FlatMap f| R["f(x) : Maybe&lt;U&gt;"]
-    N3["None"]    -->|FlatMap f| N4["None (short-circuit)"]
-    S4["Some(x)"] -->|Where p|   W{"p(x)?"}
-    W -->|true|  S5["Some(x)"]
-    W -->|false| N5["None"]
-```
+<img src="docs/diagrams/maybe-composition.svg" alt="Maybe composition pipeline" width="900" />
 
 ```csharp
 // Map — transform the inner value when present.
@@ -557,15 +498,7 @@ public Result<Order, OrderError> CreateOrder(OrderData data)
 
 `Map`, `MapError`, `Match`, and `FlatMap` let you chain without explicit branching. Success and error values flow down independent tracks — `Map` only touches the success side, `MapError` only touches the error side, and `FlatMap` short-circuits on error:
 
-```mermaid
-flowchart LR
-    S1["Success(x)"] -->|Map f|      S2["Success(f(x))"]
-    E1["Error(e)"]   -->|Map f|      E2["Error(e) (pass-through)"]
-    S3["Success(x)"] -->|MapError g| S4["Success(x) (pass-through)"]
-    E3["Error(e)"]   -->|MapError g| E4["Error(g(e))"]
-    S5["Success(x)"] -->|FlatMap f|  R["f(x) : Result&lt;U, TError&gt;"]
-    E5["Error(e)"]   -->|FlatMap f|  E6["Error(e) (short-circuit)"]
-```
+<img src="docs/diagrams/result-composition.svg" alt="Result composition pipeline" width="900" />
 
 
 ```csharp

--- a/readme.md
+++ b/readme.md
@@ -12,14 +12,17 @@ The library ships as three NuGet packages. The core package has no third-party d
 
 ```mermaid
 flowchart LR
-    Core["`**Kalicz.StrongTypes**
-    - core types
-    - System.Text.Json converters`"]
-    EfCore["`**Kalicz.StrongTypes.EfCore**
-    - EF Core value converters
-    - convention + DbContext extension`"]
-    FsCheck["`**Kalicz.StrongTypes.FsCheck**
-    - FsCheck Arbitrary generators`"]
+    subgraph Core[Kalicz.StrongTypes]
+        CoreBody["`- core types
+        - System.Text.Json converters`"]
+    end
+    subgraph EfCore[Kalicz.StrongTypes.EfCore]
+        EfCoreBody["`- EF Core value converters
+        - convention + DbContext extension`"]
+    end
+    subgraph FsCheck[Kalicz.StrongTypes.FsCheck]
+        FsCheckBody["`- FsCheck Arbitrary generators`"]
+    end
     EfCore -->|depends on| Core
     FsCheck -->|depends on| Core
 ```


### PR DESCRIPTION
## Summary

Adds seven hand-drawn SVG diagrams to `readme.md` under `docs/diagrams/`, illustrating the concepts that were hardest to convey in prose alone:

- **`impact.svg`** — side-by-side of validation boundaries with vs. without StrongTypes (write + read flow, both panels)
- **`package-layout.svg`** — core / EfCore / FsCheck package relationships
- **`trycreate-create-flow.svg`** — `TryCreate` (null) vs `Create` (throw) factory split
- **`covariance.svg`** — `INonEmptyEnumerable<out T>` upcast
- **`patch-three-state.svg`** — HTTP PATCH skip / clear / set distinction via `Maybe<T>?`
- **`maybe-composition.svg`** — `Map` / `FlatMap` / `Where` pipeline
- **`result-composition.svg`** — `Map` / `MapError` / `FlatMap` dual-track flow

SVG over mermaid because the layout (panels, badges, arrow placement) needed more control than mermaid offers, and SVG renders consistently on GitHub without a runtime.

Closes #61.

## Test plan

- [ ] Render `readme.md` on the PR page and confirm every diagram displays cleanly
- [ ] Check readability on narrow viewports (GitHub mobile / split pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)