### PR TITLE
Audit XML doc comments against conventions (#64)

### DIFF
--- a/src/StrongTypes.EfCore/NonEmptyStringValueConverter.cs
+++ b/src/StrongTypes.EfCore/NonEmptyStringValueConverter.cs
@@ -2,12 +2,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace StrongTypes.EfCore;
 
-/// <summary>
-/// EF Core value converter that round-trips <see cref="NonEmptyString"/> through
-/// a plain <see cref="string"/> column. EF Core applies this converter only to
-/// non-null values, so the same instance works for both <c>NonEmptyString</c>
-/// and <c>NonEmptyString?</c> properties.
-/// </summary>
+/// <summary>EF Core value converter that round-trips <see cref="NonEmptyString"/> through a plain <see cref="string"/> column.</summary>
+/// <remarks>The same instance serves both <c>NonEmptyString</c> and <c>NonEmptyString?</c> properties.</remarks>
 public sealed class NonEmptyStringValueConverter : ValueConverter<NonEmptyString, string>
 {
     public NonEmptyStringValueConverter()

--- a/src/StrongTypes.EfCore/NumericStrongTypeValueConverter.cs
+++ b/src/StrongTypes.EfCore/NumericStrongTypeValueConverter.cs
@@ -4,12 +4,9 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace StrongTypes.EfCore;
 
-/// <summary>
-/// Generic EF Core value converter for numeric strong-type wrappers
-/// (<see cref="Positive{T}"/>, <see cref="NonNegative{T}"/>, <see cref="Negative{T}"/>,
-/// <see cref="NonPositive{T}"/>). Maps the wrapper to its underlying <typeparamref name="T"/>
-/// column via the <c>Value</c> property and <c>Create</c> factory.
-/// </summary>
+/// <summary>EF Core value converter for numeric strong-type wrappers. Maps the wrapper to its underlying <typeparamref name="T"/> column via the wrapper's <c>Value</c> property and <c>Create</c> factory.</summary>
+/// <typeparam name="TWrapper">The strong-type wrapper (<see cref="Positive{T}"/>, <see cref="NonNegative{T}"/>, <see cref="Negative{T}"/>, or <see cref="NonPositive{T}"/>).</typeparam>
+/// <typeparam name="T">The underlying numeric type.</typeparam>
 public sealed class NumericStrongTypeValueConverter<TWrapper, T> : ValueConverter<TWrapper, T>
     where TWrapper : struct
     where T : struct

--- a/src/StrongTypes.EfCore/StrongTypesConvention.cs
+++ b/src/StrongTypes.EfCore/StrongTypesConvention.cs
@@ -7,14 +7,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace StrongTypes.EfCore;
 
-/// <summary>
-/// As each entity type is discovered, pre-declares every strong-type member
-/// as a scalar property with its value converter attached. Runs BEFORE EF
-/// Core's <c>PropertyDiscoveryConvention</c>, so by the time discovery walks
-/// the members, the strong-type properties already exist as scalars — no
-/// fallback into complex/owned-type inference, no "no suitable constructor"
-/// blow-up at model finalization.
-/// </summary>
+/// <summary>Pre-declares every strong-type member as a scalar property with its value converter attached, ahead of EF Core's property-discovery pass.</summary>
 internal sealed class StrongTypesConvention : IEntityTypeAddedConvention
 {
     public void ProcessEntityTypeAdded(

--- a/src/StrongTypes.EfCore/StrongTypesDbContextOptionsExtension.cs
+++ b/src/StrongTypes.EfCore/StrongTypesDbContextOptionsExtension.cs
@@ -7,23 +7,8 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace StrongTypes.EfCore;
 
-/// <summary>
-/// Wires StrongTypes into a DbContext's internal service provider:
-/// <list type="bullet">
-/// <item><see cref="StrongTypesConventionSetPlugin"/> auto-applies the right
-/// <c>ValueConverter</c> to every strong-type property on every mapped
-/// entity, running before EF's property-discovery convention so wrappers
-/// never get inferred as owned entity types.</item>
-/// <item><see cref="UnwrapMethodCallTranslatorPlugin"/> translates
-/// <c>strongType.Unwrap()</c> inside LINQ predicates so filters like
-/// <c>.Where(e =&gt; e.Name.Unwrap().Contains("foo"))</c> or
-/// <c>EF.Functions.Like(e.Name.Unwrap(), "%foo%")</c> run server-side.</item>
-/// </list>
-/// Callers wire it up with a single
-/// <see cref="StrongTypesDbContextOptionsBuilderExtensions.UseStrongTypes"/>
-/// call on the options builder — no <c>ConfigureConventions</c> override
-/// needed on the DbContext.
-/// </summary>
+/// <summary>Wires StrongTypes value conversions and LINQ translations into a DbContext.</summary>
+/// <remarks>Enable with <see cref="StrongTypesDbContextOptionsBuilderExtensions.UseStrongTypes"/> on the options builder; no <c>ConfigureConventions</c> override required.</remarks>
 public sealed class StrongTypesDbContextOptionsExtension : IDbContextOptionsExtension
 {
     public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
@@ -51,12 +36,8 @@ public sealed class StrongTypesDbContextOptionsExtension : IDbContextOptionsExte
 
 public static class StrongTypesDbContextOptionsBuilderExtensions
 {
-    /// <summary>
-    /// Registers <see cref="StrongTypesDbContextOptionsExtension"/> on the
-    /// options builder. After this call, any strong-type property on any
-    /// mapped entity gets its value converter applied automatically and
-    /// <c>Unwrap()</c> inside LINQ predicates translates to server-side SQL.
-    /// </summary>
+    /// <summary>Enables automatic value conversion of strong-type properties and server-side translation of <c>Unwrap()</c> in LINQ predicates.</summary>
+    /// <param name="optionsBuilder">The options builder to configure.</param>
     public static DbContextOptionsBuilder UseStrongTypes(this DbContextOptionsBuilder optionsBuilder)
     {
         var extension = optionsBuilder.Options.FindExtension<StrongTypesDbContextOptionsExtension>()

--- a/src/StrongTypes.EfCore/UnwrapMethodCallTranslator.cs
+++ b/src/StrongTypes.EfCore/UnwrapMethodCallTranslator.cs
@@ -7,15 +7,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace StrongTypes.EfCore;
 
-/// <summary>
-/// Translates <c>Unwrap()</c> calls on strong types as a pass-through to the
-/// underlying column, re-typed with the fresh mapping for the underlying CLR
-/// type. Re-mapping matters: if we returned the column expression with its
-/// strong-type value-converter mapping intact, downstream operators (string
-/// <c>Contains</c> / <c>EF.Functions.Like</c>, numeric comparison literals)
-/// would pipe their raw-type arguments through that converter at SQL-parameter
-/// bind time and fail with <c>InvalidCastException</c>.
-/// </summary>
+/// <summary>Translates <c>Unwrap()</c> calls on strong types to the underlying column in generated SQL.</summary>
 public sealed class UnwrapMethodCallTranslator(
     ISqlExpressionFactory sqlExpressionFactory,
     IRelationalTypeMappingSource typeMappingSource) : IMethodCallTranslator

--- a/src/StrongTypes.FsCheck/Generators.cs
+++ b/src/StrongTypes.FsCheck/Generators.cs
@@ -3,127 +3,82 @@ using FsCheck.Fluent;
 
 namespace StrongTypes.FsCheck;
 
-/// <summary>
-/// Shared FsCheck arbitraries for Kalicz.StrongTypes. Reference via
-/// <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c>
-/// on a test class.
-/// </summary>
+/// <summary>Shared FsCheck arbitraries for StrongTypes.</summary>
+/// <remarks>Reference via <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c> on a test class.</remarks>
 public static class Generators
 {
-    /// <summary>
-    /// <see cref="NonEmptyString"/>. FsCheck's default string generator can
-    /// produce empty/whitespace values; we filter those out so the generated
-    /// value always satisfies the type's invariant.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="NonEmptyString"/> values.</summary>
     public static Arbitrary<NonEmptyString> NonEmptyString { get; } =
         Arb.From(ArbMap.Default.ArbFor<string>().Generator
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .Select(s => s.ToNonEmpty()));
 
-    /// <summary>
-    /// <see cref="NonEmptyString"/> with ~10% chance of <c>null</c>. Tuned
-    /// so FsCheck's default 100-case run exercises the null branch several
-    /// times while keeping the majority of cases on the happy path.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="NonEmptyString"/> or <c>null</c>, with ~10% <c>null</c>.</summary>
     public static Arbitrary<NonEmptyString?> NullableNonEmptyString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant<NonEmptyString?>(null)),
             (9, NonEmptyString.Generator.Select(nes => (NonEmptyString?)nes))));
 
-    /// <summary>
-    /// <see cref="Positive{Int32}"/> — values strictly greater than zero.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Positive{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<Positive<int>> PositiveInt { get; } =
         Arb.From(ArbMap.Default.ArbFor<int>().Generator
             .Where(i => i > 0)
             .Select(i => i.ToPositive()));
 
-    /// <summary>
-    /// <see cref="Negative{Int32}"/> — values strictly less than zero.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Negative{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<Negative<int>> NegativeInt { get; } =
         Arb.From(ArbMap.Default.ArbFor<int>().Generator
             .Where(i => i < 0)
             .Select(i => i.ToNegative()));
 
-    /// <summary>
-    /// <see cref="NonNegative{Int32}"/> — values greater than or equal to zero.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="NonNegative{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<NonNegative<int>> NonNegativeInt { get; } =
         Arb.From(ArbMap.Default.ArbFor<int>().Generator
             .Where(i => i >= 0)
             .Select(i => i.ToNonNegative()));
 
-    /// <summary>
-    /// <see cref="NonPositive{Int32}"/> — values less than or equal to zero.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="NonPositive{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<NonPositive<int>> NonPositiveInt { get; } =
         Arb.From(ArbMap.Default.ArbFor<int>().Generator
             .Where(i => i <= 0)
             .Select(i => i.ToNonPositive()));
 
-    /// <summary>
-    /// <see cref="Maybe{Int32}"/> with ~20% chance of <see cref="Maybe{T}.None"/>.
-    /// Higher None rate than NullableNonEmptyString because Maybe's equality and
-    /// comparison logic has distinct None/Some branches that benefit from
-    /// denser coverage of the None case.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="int"/>, with ~20% <c>None</c>.</summary>
     public static Arbitrary<Maybe<int>> MaybeInt { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<int>.None)),
             (4, ArbMap.Default.ArbFor<int>().Generator.Select(Maybe.Some))));
 
-    /// <summary>
-    /// <see cref="Maybe{String}"/> with ~20% chance of <see cref="Maybe{T}.None"/>.
-    /// FsCheck's default <c>string</c> generator never produces <c>null</c>, so
-    /// the None branch has to be injected explicitly via <c>Gen.Frequency</c>.
-    /// Empty and whitespace strings are kept as valid <c>Some</c> values — use
-    /// <see cref="MaybeNonEmptyString"/> when you want the non-empty invariant.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="string"/>, with ~20% <c>None</c>. Empty and whitespace strings remain valid <c>Some</c> values; use <see cref="MaybeNonEmptyString"/> for the non-empty invariant.</summary>
     public static Arbitrary<Maybe<string>> MaybeString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<string>.None)),
             (4, ArbMap.Default.ArbFor<string>().Generator.Select(Maybe.Some))));
 
-    /// <summary>
-    /// <see cref="Maybe{T}"/> of <see cref="NonEmptyString"/> with ~20% None rate.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyString"/>, with ~20% <c>None</c>.</summary>
     public static Arbitrary<Maybe<NonEmptyString>> MaybeNonEmptyString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<NonEmptyString>.None)),
             (4, NonEmptyString.Generator.Select(Maybe.Some))));
 
-    /// <summary>
-    /// <see cref="Maybe{T}"/> of <see cref="Positive{Int32}"/> with ~20% None rate.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Positive{T}"/> of <see cref="int"/>, with ~20% <c>None</c>.</summary>
     public static Arbitrary<Maybe<Positive<int>>> MaybePositiveInt { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<Positive<int>>.None)),
             (4, PositiveInt.Generator.Select(Maybe.Some))));
 
-    /// <summary>
-    /// <see cref="NonEmptyEnumerable{Int32}"/>. Built on FsCheck's <c>NonEmptyListOf</c>
-    /// so every generated value automatically satisfies the non-empty invariant.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<NonEmptyEnumerable<int>> NonEmptyEnumerableInt { get; } =
         Arb.From(Gen.NonEmptyListOf(ArbMap.Default.ArbFor<int>().Generator)
             .Select(list => NonEmptyEnumerable.CreateRange(list)));
 
-    /// <summary>
-    /// <see cref="Result{T, TError}"/> of <c>int</c>/<c>string</c> with a roughly even
-    /// split between successes and errors, so property tests exercise both branches.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Result{T, TError}"/> of <c>int</c>/<c>string</c>, with a roughly even split between successes and errors.</summary>
     public static Arbitrary<Result<int, string>> ResultIntString { get; } =
         Arb.From(Gen.Frequency(
             (1, ArbMap.Default.ArbFor<int>().Generator.Select(i => (Result<int, string>)i)),
             (1, ArbMap.Default.ArbFor<string>().Generator.Select(s => (Result<int, string>)s))));
 
-    /// <summary>
-    /// <see cref="Result{T}"/> of <c>int</c> (error type <see cref="System.Exception"/>)
-    /// with a roughly even split between successes and errors. Errors use a fixed
-    /// <see cref="System.InvalidOperationException"/> message pulled from FsCheck's
-    /// string generator.
-    /// </summary>
+    /// <summary>Arbitrary <see cref="Result{T}"/> of <c>int</c>, with a roughly even split between successes and <see cref="System.InvalidOperationException"/> errors.</summary>
     public static Arbitrary<Result<int>> ResultInt { get; } =
         Arb.From(Gen.Frequency(
             (1, ArbMap.Default.ArbFor<int>().Generator.Select(i => (Result<int>)i)),

--- a/src/StrongTypes/Booleans/BooleanExtensions.cs
+++ b/src/StrongTypes/Booleans/BooleanExtensions.cs
@@ -6,19 +6,15 @@ namespace StrongTypes;
 
 public static class BooleanExtensions
 {
-    /// <summary>
-    /// Logical implication: returns <c>true</c> when <paramref name="condition"/>
-    /// is <c>false</c>, or when both operands are <c>true</c>. Both operands are
-    /// evaluated eagerly; use the <see cref="Func{TResult}"/> overload to defer
-    /// evaluation of the consequence.
-    /// </summary>
+    /// <summary>Logical implication (<c>!condition || consequence</c>).</summary>
+    /// <param name="condition">The antecedent.</param>
+    /// <param name="consequence">The consequent. Evaluated eagerly.</param>
+    /// <returns><c>true</c> when <paramref name="condition"/> is <c>false</c>, or when both operands are <c>true</c>.</returns>
     public static bool Implies(this bool condition, bool consequence) => !condition || consequence;
 
-    /// <summary>
-    /// Logical implication: returns <c>true</c> when <paramref name="condition"/>
-    /// is <c>false</c>, or when both operands are <c>true</c>. Short-circuits —
-    /// <paramref name="consequence"/> is only invoked when
-    /// <paramref name="condition"/> is <c>true</c>.
-    /// </summary>
+    /// <summary>Logical implication with a deferred consequent.</summary>
+    /// <param name="condition">The antecedent.</param>
+    /// <param name="consequence">Invoked only when <paramref name="condition"/> is <c>true</c>.</param>
+    /// <returns><c>true</c> when <paramref name="condition"/> is <c>false</c>, or when <paramref name="consequence"/> returns <c>true</c>.</returns>
     public static bool Implies(this bool condition, Func<bool> consequence) => !condition || consequence();
 }

--- a/src/StrongTypes/Booleans/BooleanMapExtensions.cs
+++ b/src/StrongTypes/Booleans/BooleanMapExtensions.cs
@@ -7,110 +7,96 @@ namespace StrongTypes;
 
 public static class BooleanMapToStructExtensions
 {
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// </summary>
+    /// <summary>Projects <c>true</c> into a value; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>true</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>true</c>; otherwise <c>null</c>.</returns>
     public static T? MapTrue<T>(this bool value, Func<T> map) where T : struct
         => value ? map() : null;
 
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Projects <c>true</c> into a value that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>true</c>; may return <c>null</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>true</c>; otherwise <c>null</c>.</returns>
     public static T? MapTrue<T>(this bool value, Func<T?> map) where T : struct
         => value ? map() : null;
 
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// </summary>
+    /// <summary>Projects <c>false</c> into a value; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>false</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>false</c>; otherwise <c>null</c>.</returns>
     public static T? MapFalse<T>(this bool value, Func<T> map) where T : struct
         => value ? null : map();
 
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Projects <c>false</c> into a value that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>false</c>; may return <c>null</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>false</c>; otherwise <c>null</c>.</returns>
     public static T? MapFalse<T>(this bool value, Func<T?> map) where T : struct
         => value ? null : map();
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>true</c> into a value; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>true</c>.</param>
     public static async Task<T?> MapTrueAsync<T>(this bool value, Func<Task<T>> map) where T : struct
         => value ? await map() : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>true</c> into a value that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>true</c>; may yield <c>null</c>.</param>
     public static async Task<T?> MapTrueAsync<T>(this bool value, Func<Task<T?>> map) where T : struct
         => value ? await map() : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>false</c> into a value; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>false</c>.</param>
     public static async Task<T?> MapFalseAsync<T>(this bool value, Func<Task<T>> map) where T : struct
         => value ? null : await map();
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>false</c> into a value that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The value type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>false</c>; may yield <c>null</c>.</param>
     public static async Task<T?> MapFalseAsync<T>(this bool value, Func<Task<T?>> map) where T : struct
         => value ? null : await map();
 }
 
 public static class BooleanMapToClassExtensions
 {
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Projects <c>true</c> into a reference that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The reference type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>true</c>; may return <c>null</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>true</c>; otherwise <c>null</c>.</returns>
     public static T? MapTrue<T>(this bool value, Func<T?> map) where T : class
         => value ? map() : null;
 
-    /// <summary>
-    /// Invokes <paramref name="map"/> and returns its result when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Projects <c>false</c> into a reference that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The reference type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is <c>false</c>; may return <c>null</c>.</param>
+    /// <returns>The result of <paramref name="map"/> when <paramref name="value"/> is <c>false</c>; otherwise <c>null</c>.</returns>
     public static T? MapFalse<T>(this bool value, Func<T?> map) where T : class
         => value ? null : map();
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="true"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>true</c> into a reference that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The reference type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>true</c>; may yield <c>null</c>.</param>
     public static async Task<T?> MapTrueAsync<T>(this bool value, Func<Task<T?>> map) where T : class
         => value ? await map() : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when
-    /// <paramref name="value"/> is <see langword="false"/>; returns
-    /// <see langword="null"/> otherwise without invoking <paramref name="map"/>.
-    /// The mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Asynchronously projects <c>false</c> into a reference that may itself be <c>null</c>.</summary>
+    /// <typeparam name="T">The reference type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="value">The flag being mapped.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is <c>false</c>; may yield <c>null</c>.</param>
     public static async Task<T?> MapFalseAsync<T>(this bool value, Func<Task<T?>> map) where T : class
         => value ? null : await map();
 }

--- a/src/StrongTypes/Collections/IEnumerableExtensions.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions.cs
@@ -7,25 +7,30 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
-    /// <summary>
-    /// Returns the non-null values from <paramref name="source"/>, unwrapping each
-    /// nullable into its underlying value.
-    /// </summary>
+    /// <summary>Drops <c>null</c> entries and unwraps the remaining values.</summary>
+    /// <typeparam name="T">The underlying value type.</typeparam>
+    /// <param name="source">The sequence to filter.</param>
+    /// <returns>The non-null values from <paramref name="source"/> as a <typeparamref name="T"/> sequence.</returns>
     public static IEnumerable<T> ExceptNulls<T>(this IEnumerable<T?> source)
         where T : struct
     {
         return source.Where(item => item.HasValue).Select(item => item!.Value);
     }
 
-    /// <summary>
-    /// Returns the non-null references from <paramref name="source"/>.
-    /// </summary>
+    /// <summary>Drops <c>null</c> references from the sequence.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <param name="source">The sequence to filter.</param>
+    /// <returns>The non-null references from <paramref name="source"/>.</returns>
     public static IEnumerable<T> ExceptNulls<T>(this IEnumerable<T?> source)
         where T : class
     {
         return source.Where(item => item is not null)!;
     }
 
+    /// <summary>Returns <paramref name="source"/> with <paramref name="excludedItems"/> removed.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to filter.</param>
+    /// <param name="excludedItems">The values to exclude.</param>
     public static IEnumerable<T> Except<T>(this IEnumerable<T> source, params T[] excludedItems)
         => Enumerable.Except(source, excludedItems);
 }

--- a/src/StrongTypes/Collections/IEnumerableExtensions_Concatenating.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions_Concatenating.cs
@@ -7,9 +7,17 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
+    /// <summary>Appends <paramref name="items"/> to <paramref name="first"/>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="first">The starting sequence.</param>
+    /// <param name="items">Elements appended after <paramref name="first"/>.</param>
     public static IEnumerable<T> Concat<T>(this IEnumerable<T> first, params T[] items)
         => Enumerable.Concat(first, items);
 
+    /// <summary>Appends each of <paramref name="others"/> to <paramref name="first"/> in order.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="first">The starting sequence.</param>
+    /// <param name="others">Sequences concatenated after <paramref name="first"/>.</param>
     public static IEnumerable<T> Concat<T>(this IEnumerable<T> first, params IEnumerable<T>[] others)
         => Enumerable.Concat(first, others.SelectMany(o => o));
 }

--- a/src/StrongTypes/Collections/IEnumerableExtensions_Flattening.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions_Flattening.cs
@@ -7,6 +7,9 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
+    /// <summary>Concatenates the inner sequences of <paramref name="source"/>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The outer sequence.</param>
     public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> source)
         => source.SelectMany(i => i);
 }

--- a/src/StrongTypes/Collections/IEnumerableExtensions_Null.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions_Null.cs
@@ -8,18 +8,33 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
+    /// <summary>Returns <paramref name="source"/>, or an empty sequence when it is <c>null</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence that may be <c>null</c>.</param>
     public static IEnumerable<T> OrEmptyIfNull<T>(this IEnumerable<T>? source)
         => source ?? Enumerable.Empty<T>();
 
+    /// <summary>Returns <paramref name="source"/>, or an empty array when it is <c>null</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The array that may be <c>null</c>.</param>
     public static T[] OrEmptyIfNull<T>(this T[]? source)
         => source ?? Array.Empty<T>();
 
+    /// <summary>Returns <paramref name="source"/>, or a new empty list when it is <c>null</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The list that may be <c>null</c>.</param>
     public static List<T> OrEmptyIfNull<T>(this List<T>? source)
         => source ?? new List<T>();
 
+    /// <summary>Returns <paramref name="source"/>, or an empty list when it is <c>null</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The list that may be <c>null</c>.</param>
     public static IReadOnlyList<T> OrEmptyIfNull<T>(this IReadOnlyList<T>? source)
         => source ?? Array.Empty<T>();
 
+    /// <summary>Returns <paramref name="source"/>, or an empty collection when it is <c>null</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The collection that may be <c>null</c>.</param>
     public static ICollection<T> OrEmptyIfNull<T>(this ICollection<T>? source)
         => source ?? Array.Empty<T>();
 }

--- a/src/StrongTypes/Collections/IEnumerableExtensions_Partition.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions_Partition.cs
@@ -7,12 +7,11 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
-    /// <summary>
-    /// Splits <paramref name="source"/> into two lists: items for which
-    /// <paramref name="predicate"/> returns true (<c>Passing</c>) and items
-    /// for which it returns false (<c>Violating</c>). Relative order is
-    /// preserved within each partition.
-    /// </summary>
+    /// <summary>Splits <paramref name="source"/> by <paramref name="predicate"/>, preserving relative order within each partition.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to partition.</param>
+    /// <param name="predicate">Tested against each element.</param>
+    /// <returns><c>Passing</c> holds items for which <paramref name="predicate"/> returned <c>true</c>; <c>Violating</c> holds the rest.</returns>
     public static (IReadOnlyList<T> Passing, IReadOnlyList<T> Violating) Partition<T>(
         this IEnumerable<T> source,
         Func<T, bool> predicate)

--- a/src/StrongTypes/Collections/IEnumerableExtensions_Types.cs
+++ b/src/StrongTypes/Collections/IEnumerableExtensions_Types.cs
@@ -10,27 +10,48 @@ namespace StrongTypes;
 
 public static partial class IEnumerableExtensions
 {
+    /// <summary>Materializes <paramref name="source"/> as a read-only list (by copying).</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to materialize.</param>
     [Pure]
     public static IReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> source) => source.ToArray();
 
+    /// <summary>Returns <paramref name="source"/> as a read-only list, copying only when it is not already one.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this IEnumerable<T> source) => source as IReadOnlyList<T> ?? source.ToArray();
 
+    /// <summary>Returns <paramref name="source"/> typed as a read-only list.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The array to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this T[] source) => source;
 
+    /// <summary>Returns <paramref name="source"/> typed as a read-only list.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The list to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this List<T> source) => source;
 
+    /// <summary>Returns <paramref name="source"/> typed as a read-only list.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The non-empty sequence to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this INonEmptyEnumerable<T> source) => source;
 
     [Obsolete("This already is of type ReadOnlyList.", error: true)]
     public static IReadOnlyList<T> AsReadOnlyList<T>(this IReadOnlyList<T> source) => source;
 
+    /// <summary>Returns <paramref name="source"/> as a <see cref="List{T}"/>, copying only when it is not already one.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static List<T> AsList<T>(this IEnumerable<T> source) => source as List<T> ?? source.ToList();
 
+    /// <summary>Returns <paramref name="source"/> as an array, copying only when it is not already one.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to adapt.</param>
     [DebuggerStepThrough, Pure]
     public static T[] AsArray<T>(this IEnumerable<T> source) => source as T[] ?? source.ToArray();
 }

--- a/src/StrongTypes/Collections/INonEmptyEnumerable.cs
+++ b/src/StrongTypes/Collections/INonEmptyEnumerable.cs
@@ -5,13 +5,14 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A read-only sequence guaranteed to contain at least one element.
-/// </summary>
+/// <summary>A read-only sequence guaranteed to contain at least one element.</summary>
+/// <typeparam name="T">The element type.</typeparam>
 [JsonConverter(typeof(NonEmptyEnumerableJsonConverterFactory))]
 public interface INonEmptyEnumerable<out T> : IReadOnlyList<T>
 {
+    /// <summary>The first element.</summary>
     T Head { get; }
 
+    /// <summary>The elements after <see cref="Head"/>. May be empty.</summary>
     IReadOnlyList<T> Tail { get; }
 }

--- a/src/StrongTypes/Collections/NonEmptyEnumerable.cs
+++ b/src/StrongTypes/Collections/NonEmptyEnumerable.cs
@@ -11,16 +11,12 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Factory helpers for <see cref="NonEmptyEnumerable{T}"/>.
-/// </summary>
+/// <summary>Factory helpers for <see cref="NonEmptyEnumerable{T}"/>.</summary>
 public static class NonEmptyEnumerable
 {
-    /// <summary>
-    /// Returns a <see cref="NonEmptyEnumerable{T}"/> wrapping <paramref name="values"/>, or
-    /// <c>null</c> if <paramref name="values"/> is null or empty. Wrapping is idempotent —
-    /// passing an existing <see cref="NonEmptyEnumerable{T}"/> returns it as-is.
-    /// </summary>
+    /// <summary>Wraps <paramref name="values"/> as a <see cref="NonEmptyEnumerable{T}"/>, or returns <c>null</c> when the sequence is null or empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="values">The source sequence.</param>
     public static NonEmptyEnumerable<T>? TryCreateRange<T>(IEnumerable<T>? values) =>
         values switch
         {
@@ -43,20 +39,18 @@ public static class NonEmptyEnumerable
         return NonEmptyEnumerable<T>.FromValidatedArray(buffer);
     }
 
-    /// <summary>
-    /// Returns a <see cref="NonEmptyEnumerable{T}"/> wrapping <paramref name="values"/>.
-    /// Throws <see cref="ArgumentException"/> if <paramref name="values"/> is null or empty.
-    /// </summary>
+    /// <summary>Wraps <paramref name="values"/> as a <see cref="NonEmptyEnumerable{T}"/>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="values">The source sequence.</param>
+    /// <exception cref="ArgumentException"><paramref name="values"/> is <c>null</c> or empty.</exception>
     public static NonEmptyEnumerable<T> CreateRange<T>(IEnumerable<T>? values)
         => TryCreateRange(values)
            ?? throw new ArgumentException("You cannot create NonEmptyEnumerable from a null or empty sequence.", nameof(values));
 
-    /// <summary>
-    /// Returns a <see cref="NonEmptyEnumerable{T}"/> wrapping <paramref name="values"/>.
-    /// Throws <see cref="ArgumentException"/> if <paramref name="values"/> is empty. Also
-    /// backs the collection-expression syntax (<c>NonEmptyEnumerable&lt;int&gt; list = [1, 2, 3];</c>);
-    /// an empty collection expression throws at runtime.
-    /// </summary>
+    /// <summary>Creates a <see cref="NonEmptyEnumerable{T}"/> from the supplied elements. Also backs the collection-expression syntax (<c>NonEmptyEnumerable&lt;int&gt; list = [1, 2, 3];</c>).</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="values">The elements to wrap.</param>
+    /// <exception cref="ArgumentException"><paramref name="values"/> is empty.</exception>
     public static NonEmptyEnumerable<T> Create<T>(params ReadOnlySpan<T> values)
     {
         if (values.IsEmpty)
@@ -65,12 +59,9 @@ public static class NonEmptyEnumerable
     }
 }
 
-/// <summary>
-/// A read-only list of <typeparamref name="T"/> guaranteed to contain at least one element.
-/// Construct via <see cref="NonEmptyEnumerable.Create{T}(ReadOnlySpan{T})"/>,
-/// <see cref="NonEmptyEnumerable.CreateRange{T}(IEnumerable{T})"/>, or a collection expression
-/// (<c>NonEmptyEnumerable&lt;int&gt; list = [1, 2, 3];</c>).
-/// </summary>
+/// <summary>A read-only list of <typeparamref name="T"/> guaranteed to contain at least one element.</summary>
+/// <typeparam name="T">The element type.</typeparam>
+/// <remarks>Construct via <see cref="NonEmptyEnumerable.Create{T}(ReadOnlySpan{T})"/>, <see cref="NonEmptyEnumerable.CreateRange{T}(IEnumerable{T})"/>, or a collection expression (<c>NonEmptyEnumerable&lt;int&gt; list = [1, 2, 3];</c>).</remarks>
 [JsonConverter(typeof(NonEmptyEnumerableJsonConverterFactory))]
 [CollectionBuilder(typeof(NonEmptyEnumerable), nameof(NonEmptyEnumerable.Create))]
 [DebuggerTypeProxy(typeof(NonEmptyEnumerableDebugView<>))]
@@ -99,19 +90,14 @@ public sealed class NonEmptyEnumerable<T> : INonEmptyEnumerable<T>, ICollection<
 
     public T this[int index] => _values[index];
 
-    /// <summary>
-    /// Returns an allocation-free struct enumerator for <c>foreach</c>.
-    /// </summary>
     public Enumerator GetEnumerator() => new(_values);
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    /// <summary>
-    /// Returns the underlying buffer as a <see cref="ReadOnlySpan{T}"/>. The span must not
-    /// outlive the enumerable.
-    /// </summary>
+    /// <summary>Returns the elements as a <see cref="ReadOnlySpan{T}"/>.</summary>
+    /// <remarks>The span must not outlive the enumerable.</remarks>
     public ReadOnlySpan<T> AsSpan() => _values;
 
     #region ICollection<T> — read-only implementation

--- a/src/StrongTypes/Collections/NonEmptyEnumerableExtensions.cs
+++ b/src/StrongTypes/Collections/NonEmptyEnumerableExtensions.cs
@@ -7,22 +7,19 @@ using System.Numerics;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Extension methods that produce or consume <see cref="NonEmptyEnumerable{T}"/>.
-/// </summary>
+/// <summary>Extension methods that produce or consume <see cref="NonEmptyEnumerable{T}"/>.</summary>
 public static class NonEmptyEnumerableExtensions
 {
-    /// <summary>
-    /// Wraps <paramref name="source"/> as a <see cref="NonEmptyEnumerable{T}"/>, or returns
-    /// <c>null</c> when the sequence is null or empty.
-    /// </summary>
+    /// <summary>Wraps <paramref name="source"/> as a <see cref="NonEmptyEnumerable{T}"/>, or returns <c>null</c> when the sequence is null or empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to wrap.</param>
     public static NonEmptyEnumerable<T>? AsNonEmpty<T>(this IEnumerable<T>? source)
         => NonEmptyEnumerable.TryCreateRange(source);
 
-    /// <summary>
-    /// Wraps <paramref name="source"/> as a <see cref="NonEmptyEnumerable{T}"/>, throwing
-    /// <see cref="ArgumentException"/> when the sequence is null or empty.
-    /// </summary>
+    /// <summary>Wraps <paramref name="source"/> as a <see cref="NonEmptyEnumerable{T}"/>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to wrap.</param>
+    /// <exception cref="ArgumentException"><paramref name="source"/> is <c>null</c> or empty.</exception>
     public static NonEmptyEnumerable<T> ToNonEmpty<T>(this IEnumerable<T>? source)
         => NonEmptyEnumerable.CreateRange(source);
 
@@ -137,11 +134,11 @@ public static class NonEmptyEnumerableExtensions
         return source.SelectMany(inner => inner);
     }
 
-    /// <summary>
-    /// Prepends <paramref name="head"/> to the concatenation of <paramref name="tails"/>
-    /// in order. Throws <see cref="ArgumentNullException"/> if <paramref name="tails"/>
-    /// or any element of it is null.
-    /// </summary>
+    /// <summary>Prepends <paramref name="head"/> to the concatenation of <paramref name="tails"/> in order.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="head">The leading element.</param>
+    /// <param name="tails">Sequences concatenated after <paramref name="head"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="tails"/> or any element of it is <c>null</c>.</exception>
     public static NonEmptyEnumerable<T> Concat<T>(this T head, params IEnumerable<T>[] tails)
     {
         ArgumentNullException.ThrowIfNull(tails);
@@ -185,11 +182,10 @@ public static class NonEmptyEnumerableExtensions
         return NonEmptyEnumerable<T>.FromValidatedArray(buffer);
     }
 
-    /// <summary>
-    /// Takes the first <paramref name="count"/> elements. The result is guaranteed non-empty
-    /// because <paramref name="count"/> is positive. If <paramref name="count"/> exceeds
-    /// <c>source.Count</c>, the full source is returned.
-    /// </summary>
+    /// <summary>Takes the first <paramref name="count"/> elements, or the full source when <paramref name="count"/> exceeds <c>source.Count</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to take from.</param>
+    /// <param name="count">The positive number of elements to take.</param>
     public static NonEmptyEnumerable<T> Take<T>(this INonEmptyEnumerable<T> source, Positive<int> count)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -202,11 +198,11 @@ public static class NonEmptyEnumerableExtensions
         return NonEmptyEnumerable<T>.FromValidatedArray(buffer);
     }
 
-    /// <summary>
-    /// Takes the first <paramref name="count"/> elements. Throws <see cref="ArgumentException"/>
-    /// when <paramref name="count"/> is not positive; use the <see cref="Positive{T}"/> overload
-    /// when the count is known to be valid.
-    /// </summary>
+    /// <summary>Takes the first <paramref name="count"/> elements, or the full source when <paramref name="count"/> exceeds <c>source.Count</c>.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to take from.</param>
+    /// <param name="count">The number of elements to take.</param>
+    /// <exception cref="ArgumentException"><paramref name="count"/> is not positive.</exception>
     public static NonEmptyEnumerable<T> Take<T>(this INonEmptyEnumerable<T> source, int count)
         => source.Take(count.ToPositive());
 
@@ -251,12 +247,10 @@ public static class NonEmptyEnumerableExtensions
         return Enumerable.Aggregate(source, func);
     }
 
-    /// <summary>
-    /// Returns the arithmetic mean of the sequence. Throws <see cref="OverflowException"/>
-    /// when the running sum overflows <typeparamref name="T"/> (e.g. a
-    /// <c>NonEmptyEnumerable&lt;int&gt;</c> whose values sum past <see cref="int.MaxValue"/>) —
-    /// widen <typeparamref name="T"/> or project to a wider type first.
-    /// </summary>
+    /// <summary>Returns the arithmetic mean of the sequence.</summary>
+    /// <typeparam name="T">A numeric type.</typeparam>
+    /// <param name="source">The sequence to average.</param>
+    /// <exception cref="OverflowException">The running sum overflows <typeparamref name="T"/>.</exception>
     public static T Average<T>(this INonEmptyEnumerable<T> source) where T : INumber<T>
     {
         ArgumentNullException.ThrowIfNull(source);

--- a/src/StrongTypes/Collections/NonEmptyEnumerableJsonConverter.cs
+++ b/src/StrongTypes/Collections/NonEmptyEnumerableJsonConverter.cs
@@ -9,12 +9,8 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// <see cref="JsonConverterFactory"/> for <see cref="NonEmptyEnumerable{T}"/> and
-/// <see cref="INonEmptyEnumerable{T}"/>. Reads a JSON array and fails with a
-/// <see cref="JsonException"/> when the array is empty or the JSON token is not an array;
-/// JSON null round-trips to C# null. Writes as a JSON array.
-/// </summary>
+/// <summary><see cref="JsonConverterFactory"/> for <see cref="NonEmptyEnumerable{T}"/> and <see cref="INonEmptyEnumerable{T}"/>.</summary>
+/// <remarks>Reads and writes a JSON array. JSON <c>null</c> round-trips to C# <c>null</c>. An empty JSON array or a non-array token produces a <see cref="JsonException"/>.</remarks>
 public sealed class NonEmptyEnumerableJsonConverterFactory : JsonConverterFactory
 {
     private static readonly ConcurrentDictionary<Type, JsonConverter> s_converterCache = new();

--- a/src/StrongTypes/Digits/Digit.cs
+++ b/src/StrongTypes/Digits/Digit.cs
@@ -4,19 +4,8 @@ using System;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A decimal digit in the range <c>0</c>–<c>9</c>, parsed from a single character.
-/// </summary>
-/// <remarks>
-/// <para>
-/// Construct via <see cref="TryCreate"/> or <see cref="Create"/>. A character is accepted when
-/// <see cref="char.IsDigit(char)"/> returns <c>true</c> — this includes non-ASCII Unicode decimal digits,
-/// whose numeric value is folded into a byte in the 0–9 range.
-/// </para>
-/// <para>
-/// <c>default(Digit)</c> represents the digit <c>0</c>, which satisfies the invariant.
-/// </para>
-/// </remarks>
+/// <summary>A decimal digit in the range <c>0</c>–<c>9</c>, parsed from a single character.</summary>
+/// <remarks>A character is accepted when <see cref="char.IsDigit(char)"/> returns <c>true</c>, which includes non-ASCII Unicode decimal digits whose numeric value folds into 0–9. <c>default(Digit)</c> represents <c>0</c>.</remarks>
 public readonly struct Digit :
     IEquatable<Digit>,
     IEquatable<byte>,
@@ -36,10 +25,8 @@ public readonly struct Digit :
     public static implicit operator byte(Digit d) => d.Value;
     public static implicit operator int(Digit d) => d.Value;
 
-    /// <summary>
-    /// Returns a <see cref="Digit"/> wrapping the decimal value of <paramref name="value"/>,
-    /// or <c>null</c> if <paramref name="value"/> is not a decimal digit character.
-    /// </summary>
+    /// <summary>Wraps the decimal value of <paramref name="value"/>, or returns <c>null</c> when it is not a decimal digit character.</summary>
+    /// <param name="value">The character to parse.</param>
     public static Digit? TryCreate(char value)
     {
         if (!char.IsDigit(value))
@@ -50,10 +37,9 @@ public readonly struct Digit :
         return new Digit((byte)char.GetNumericValue(value));
     }
 
-    /// <summary>
-    /// Returns a <see cref="Digit"/> wrapping the decimal value of <paramref name="value"/>.
-    /// Throws <see cref="ArgumentException"/> if <paramref name="value"/> is not a decimal digit character.
-    /// </summary>
+    /// <summary>Wraps the decimal value of <paramref name="value"/>.</summary>
+    /// <param name="value">The character to parse.</param>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a decimal digit character.</exception>
     public static Digit Create(char value)
     {
         return TryCreate(value)

--- a/src/StrongTypes/Digits/DigitExtensions.cs
+++ b/src/StrongTypes/Digits/DigitExtensions.cs
@@ -7,16 +7,12 @@ namespace StrongTypes;
 
 public static class DigitExtensions
 {
-    /// <summary>
-    /// Returns a <see cref="Digit"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is not a decimal digit character.
-    /// </summary>
+    /// <summary>Returns a <see cref="Digit"/> wrapping <paramref name="value"/>, or <c>null</c> when it is not a decimal digit character.</summary>
+    /// <param name="value">The character to parse.</param>
     public static Digit? AsDigit(this char value) => Digit.TryCreate(value);
 
-    /// <summary>
-    /// Returns the decimal digits in <paramref name="value"/>, in order.
-    /// A <c>null</c> input yields an empty sequence.
-    /// </summary>
+    /// <summary>Returns the decimal digits in <paramref name="value"/>, in order. A <c>null</c> input yields an empty sequence.</summary>
+    /// <param name="value">The string to scan.</param>
     public static IEnumerable<Digit> FilterDigits(this string? value)
     {
         if (value is null)

--- a/src/StrongTypes/Enums/EnumExtensions.cs
+++ b/src/StrongTypes/Enums/EnumExtensions.cs
@@ -9,57 +9,53 @@ using System.Threading;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Extensions over <see cref="Enum"/> types. Exposes factories
-/// (<c>Parse</c>, <c>TryParse</c>, <c>Create</c>, <c>TryCreate</c>), cached
-/// metadata (<c>AllValues</c>, <c>AllFlagValues</c>, <c>AllFlagsCombined</c>),
-/// and a per-value <c>GetFlags</c> decomposition.
-/// </summary>
+/// <summary>Extensions over <see cref="Enum"/> types: factories, declared-values metadata, and flag decomposition.</summary>
 public static class EnumExtensions
 {
     extension<TEnum>(TEnum source) where TEnum : struct, Enum
     {
-        /// <summary>Thin wrapper over <see cref="Enum.Parse{TEnum}(string)"/>. Throws on failure.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
+        /// <exception cref="ArgumentException"><paramref name="value"/> does not match a defined name or value.</exception>
         public static TEnum Parse(string value) => Enum.Parse<TEnum>(value);
 
-        /// <summary>Thin wrapper over <see cref="Enum.Parse{TEnum}(string, bool)"/>. Throws on failure.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
+        /// <param name="ignoreCase">When <c>true</c>, the name comparison is case-insensitive.</param>
+        /// <exception cref="ArgumentException"><paramref name="value"/> does not match a defined name or value.</exception>
         public static TEnum Parse(string value, bool ignoreCase) => Enum.Parse<TEnum>(value, ignoreCase);
 
-        /// <summary>Thin wrapper over <see cref="Enum.TryParse{TEnum}(string, out TEnum)"/>. Returns <c>null</c> on failure.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>, or returns <c>null</c> when parsing fails.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
         public static TEnum? TryParse(string? value) => Enum.TryParse<TEnum>(value, out var v) ? v : null;
 
-        /// <summary>Thin wrapper over <see cref="Enum.TryParse{TEnum}(string, bool, out TEnum)"/>. Returns <c>null</c> on failure.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>, or returns <c>null</c> when parsing fails.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
+        /// <param name="ignoreCase">When <c>true</c>, the name comparison is case-insensitive.</param>
         public static TEnum? TryParse(string? value, bool ignoreCase) => Enum.TryParse<TEnum>(value, ignoreCase, out var v) ? v : null;
 
-        /// <summary>Alias for Parse, matching the repo's validated-type factory naming.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
+        /// <exception cref="ArgumentException"><paramref name="value"/> does not match a defined name or value.</exception>
         public static TEnum Create(string value) => Enum.Parse<TEnum>(value);
 
-        /// <summary>Alias for TryParse, matching the repo's validated-type factory naming.</summary>
+        /// <summary>Parses <paramref name="value"/> into a <typeparamref name="TEnum"/>, or returns <c>null</c> when parsing fails.</summary>
+        /// <param name="value">The name or numeric value to parse.</param>
         public static TEnum? TryCreate(string? value) => Enum.TryParse<TEnum>(value, out var v) ? v : null;
 
-        /// <summary>All declared values of <typeparamref name="TEnum"/>, cached on first type use.</summary>
+        /// <summary>All declared values of <typeparamref name="TEnum"/>.</summary>
         public static TEnum[] AllValues => EnumMeta<TEnum>.Values;
 
-        /// <summary>
-        /// Members of <typeparamref name="TEnum"/> whose underlying bits form
-        /// a single power of two. Computed and cached the first time it's
-        /// read. Throws if <typeparamref name="TEnum"/> lacks <c>[Flags]</c>.
-        /// </summary>
+        /// <summary>Members of <typeparamref name="TEnum"/> whose underlying bits form a single power of two.</summary>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TEnum"/> lacks <c>[Flags]</c>.</exception>
         public static TEnum[] AllFlagValues => FlagEnumMeta<TEnum>.FlagValues;
 
-        /// <summary>
-        /// Every single-bit flag OR-ed into one value — suitable for
-        /// persisting the complete flag set as a single integer. Cached the
-        /// first time it's read. Throws if <typeparamref name="TEnum"/>
-        /// lacks <c>[Flags]</c>.
-        /// </summary>
+        /// <summary>Every single-bit flag OR-ed into one value.</summary>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TEnum"/> lacks <c>[Flags]</c>.</exception>
         public static TEnum AllFlagsCombined => FlagEnumMeta<TEnum>.FlagsCombined;
 
-        /// <summary>
-        /// Splits the receiver into the individual single-bit flags it
-        /// contains, in declaration order. Returns an empty list for zero.
-        /// Throws if <typeparamref name="TEnum"/> lacks <c>[Flags]</c>.
-        /// </summary>
+        /// <summary>Splits the receiver into the individual single-bit flags it contains, in declaration order. Returns an empty list for zero.</summary>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TEnum"/> lacks <c>[Flags]</c>.</exception>
         public IReadOnlyList<TEnum> GetFlags()
         {
             // Access FlagValues first so non-[Flags] enums throw even when

--- a/src/StrongTypes/Exceptions/ExceptionEnumerableExtensions.cs
+++ b/src/StrongTypes/Exceptions/ExceptionEnumerableExtensions.cs
@@ -7,17 +7,11 @@ using System.Linq;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Extensions that collapse a sequence of exceptions into a single one.
-/// A single exception passes through unwrapped; multiple exceptions are wrapped
-/// in an <see cref="AggregateException"/>.
-/// </summary>
+/// <summary>Extensions that collapse a sequence of exceptions into a single one. A single exception passes through unwrapped; multiple exceptions are wrapped in an <see cref="AggregateException"/>.</summary>
 public static class ExceptionEnumerableExtensions
 {
-    /// <summary>
-    /// Returns a single <see cref="Exception"/> aggregating <paramref name="source"/>,
-    /// or <c>null</c> when the sequence is empty.
-    /// </summary>
+    /// <summary>Returns a single <see cref="Exception"/> aggregating <paramref name="source"/>, or <c>null</c> when the sequence is empty.</summary>
+    /// <param name="source">The exceptions to aggregate.</param>
     public static Exception? Aggregate(this IEnumerable<Exception> source)
         => source switch
         {
@@ -28,10 +22,8 @@ public static class ExceptionEnumerableExtensions
             _ => Aggregate((IReadOnlyList<Exception>)source.ToArray())
         };
 
-    /// <summary>
-    /// Returns a single <see cref="Exception"/> aggregating <paramref name="source"/>,
-    /// or <c>null</c> when the list is empty.
-    /// </summary>
+    /// <summary>Returns a single <see cref="Exception"/> aggregating <paramref name="source"/>, or <c>null</c> when the list is empty.</summary>
+    /// <param name="source">The exceptions to aggregate.</param>
     [Pure]
     public static Exception? Aggregate(this IReadOnlyList<Exception> source)
         => source.Count switch
@@ -41,6 +33,8 @@ public static class ExceptionEnumerableExtensions
             _ => new AggregateException(source)
         };
 
+    /// <summary>Returns a single <see cref="Exception"/> aggregating <paramref name="source"/>.</summary>
+    /// <param name="source">The exceptions to aggregate.</param>
     [Pure]
     public static Exception Aggregate(this INonEmptyEnumerable<Exception> source)
         => source.Count switch

--- a/src/StrongTypes/Maybe/Maybe.cs
+++ b/src/StrongTypes/Maybe/Maybe.cs
@@ -7,16 +7,9 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A value type that either holds a value of <typeparamref name="T"/> (Some) or has no value (None).
-/// <para>
-/// The typical "has value" check is the extension-property pattern
-/// <c>if (maybe.Value is {} v)</c>, which unwraps to the underlying value in a single
-/// expression. <c>Value</c> is provided via extension members split between the
-/// struct- and class-constrained branches so the returned nullable type is
-/// <c>Nullable&lt;T&gt;</c> for value types and <c>T?</c> for reference types.
-/// </para>
-/// </summary>
+/// <summary>A value that is either <c>Some(T)</c> or <c>None</c>.</summary>
+/// <typeparam name="T">The wrapped value type.</typeparam>
+/// <remarks>Unwrap with the extension-property pattern: <c>if (maybe.Value is {} v)</c>.</remarks>
 [JsonConverter(typeof(MaybeJsonConverterFactory))]
 public readonly struct Maybe<T> :
     IEquatable<Maybe<T>>,
@@ -148,23 +141,17 @@ public readonly struct Maybe<T> :
     public override string ToString() => IsSome ? $"Some({InternalValue})" : "None";
 }
 
-/// <summary>
-/// Marker struct backing the untyped <see cref="Maybe.None"/> singleton. It carries
-/// no state; its only job is to be implicitly convertible to <see cref="Maybe{T}"/>
-/// for any T, so callers can write <c>Maybe.None</c> wherever a typed
-/// <c>Maybe&lt;T&gt;</c> is expected without naming T.
-/// </summary>
+/// <summary>Untyped <c>None</c> literal that converts to any <see cref="Maybe{T}"/>.</summary>
 public readonly struct MaybeNone;
 
-/// <summary>
-/// Factory helpers for <see cref="Maybe{T}"/> that let callers skip the explicit
-/// generic argument: <c>Maybe.Some(5)</c> infers <c>Maybe&lt;int&gt;</c> from the
-/// argument; <c>Maybe.None</c> binds to whatever <c>Maybe&lt;T&gt;</c> the
-/// surrounding context expects.
-/// </summary>
+/// <summary>Factory helpers for <see cref="Maybe{T}"/> with inferred type arguments.</summary>
 public static class Maybe
 {
+    /// <summary>Wraps <paramref name="value"/> as <see cref="Maybe{T}"/>.<c>Some</c>.</summary>
+    /// <typeparam name="T">The wrapped value type.</typeparam>
+    /// <param name="value">The value to wrap.</param>
     public static Maybe<T> Some<T>(T value) where T : notnull => Maybe<T>.Some(value);
 
+    /// <summary>The untyped <c>None</c> literal.</summary>
     public static MaybeNone None => default;
 }

--- a/src/StrongTypes/Maybe/MaybeCollectionExtensions.cs
+++ b/src/StrongTypes/Maybe/MaybeCollectionExtensions.cs
@@ -6,27 +6,22 @@ using System.Linq;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Extensions over <see cref="Maybe{T}"/> that interact with collections and vice-versa:
-/// pulling a single <see cref="Maybe{T}"/> out of an <see cref="IEnumerable{T}"/>, and
-/// flattening a sequence of <see cref="Maybe{T}"/> down to its populated values.
-/// </summary>
+/// <summary>Extensions bridging <see cref="IEnumerable{T}"/> and <see cref="Maybe{T}"/>.</summary>
 public static class MaybeCollectionExtensions
 {
     #region IEnumerable<T> → Maybe<T>
 
-    /// <summary>
-    /// Returns the first element satisfying <paramref name="predicate"/>, or
-    /// <see cref="Maybe{T}.None"/> if no element matches.
-    /// </summary>
+    /// <summary>Returns the first element satisfying <paramref name="predicate"/>, or <c>None</c> when no element matches.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
+    /// <param name="predicate">Tested against each element.</param>
     public static Maybe<T> SafeFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         where T : notnull
         => source.Where(predicate).SafeFirst();
 
-    /// <summary>
-    /// Returns the first element of <paramref name="source"/>, or
-    /// <see cref="Maybe{T}.None"/> if the sequence is empty.
-    /// </summary>
+    /// <summary>Returns the first element of <paramref name="source"/>, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
     public static Maybe<T> SafeFirst<T>(this IEnumerable<T> source) where T : notnull
     {
         if (source is IReadOnlyList<T> list)
@@ -36,10 +31,17 @@ public static class MaybeCollectionExtensions
         return enumerator.MoveNext() ? Maybe<T>.Some(enumerator.Current) : default;
     }
 
+    /// <summary>Returns the last element satisfying <paramref name="predicate"/>, or <c>None</c> when no element matches.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
+    /// <param name="predicate">Tested against each element.</param>
     public static Maybe<T> SafeLast<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         where T : notnull
         => source.Where(predicate).SafeLast();
 
+    /// <summary>Returns the last element of <paramref name="source"/>, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
     public static Maybe<T> SafeLast<T>(this IEnumerable<T> source) where T : notnull
     {
         if (source is IReadOnlyList<T> list)
@@ -48,14 +50,17 @@ public static class MaybeCollectionExtensions
         return source.Reverse().SafeFirst();
     }
 
+    /// <summary>Returns the single element satisfying <paramref name="predicate"/>, or <c>None</c> when zero or more than one match.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
+    /// <param name="predicate">Tested against each element.</param>
     public static Maybe<T> SafeSingle<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         where T : notnull
         => source.Where(predicate).SafeSingle();
 
-    /// <summary>
-    /// Returns the single element of <paramref name="source"/> if it contains exactly
-    /// one; <see cref="Maybe{T}.None"/> for zero OR more than one.
-    /// </summary>
+    /// <summary>Returns the single element of <paramref name="source"/>, or <c>None</c> when the sequence has zero or more than one element.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
     public static Maybe<T> SafeSingle<T>(this IEnumerable<T> source) where T : notnull
     {
         using var enumerator = source.GetEnumerator();
@@ -64,10 +69,18 @@ public static class MaybeCollectionExtensions
         return enumerator.MoveNext() ? default : Maybe<T>.Some(candidate);
     }
 
+    /// <summary>Projects each element with <paramref name="selector"/> and returns the maximum, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TValue">The projected value type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
+    /// <param name="selector">Projects each element.</param>
     public static Maybe<TValue> SafeMax<T, TValue>(this IEnumerable<T> source, Func<T, TValue> selector)
         where TValue : notnull
         => source.Select(selector).SafeMax();
 
+    /// <summary>Returns the maximum element, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
     public static Maybe<T> SafeMax<T>(this IEnumerable<T> source) where T : notnull
     {
         using var enumerator = source.GetEnumerator();
@@ -81,10 +94,18 @@ public static class MaybeCollectionExtensions
         return Maybe<T>.Some(max);
     }
 
+    /// <summary>Projects each element with <paramref name="selector"/> and returns the minimum, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <typeparam name="TValue">The projected value type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
+    /// <param name="selector">Projects each element.</param>
     public static Maybe<TValue> SafeMin<T, TValue>(this IEnumerable<T> source, Func<T, TValue> selector)
         where TValue : notnull
         => source.Select(selector).SafeMin();
 
+    /// <summary>Returns the minimum element, or <c>None</c> when the sequence is empty.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="source">The sequence to scan.</param>
     public static Maybe<T> SafeMin<T>(this IEnumerable<T> source) where T : notnull
     {
         using var enumerator = source.GetEnumerator();
@@ -102,10 +123,9 @@ public static class MaybeCollectionExtensions
 
     #region Values (flatten IEnumerable<Maybe<T>> to its populated values)
 
-    /// <summary>
-    /// Extracts the underlying values from every populated <see cref="Maybe{T}"/>,
-    /// dropping empties.
-    /// </summary>
+    /// <summary>Extracts the underlying values from every populated <see cref="Maybe{T}"/>, dropping empties.</summary>
+    /// <typeparam name="T">The wrapped value type.</typeparam>
+    /// <param name="source">The sequence of <see cref="Maybe{T}"/>.</param>
     public static IEnumerable<T> Values<T>(this IEnumerable<Maybe<T>> source) where T : notnull
         => source.Where(m => m.HasValue).Select(m => m.InternalValue);
 

--- a/src/StrongTypes/Maybe/MaybeJsonConverter.cs
+++ b/src/StrongTypes/Maybe/MaybeJsonConverter.cs
@@ -7,17 +7,11 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// <see cref="JsonConverterFactory"/> for <see cref="Maybe{T}"/> that accepts any of
-/// the following JSON shapes as inputs:
-/// <list type="bullet">
-///   <item><description><c>{}</c> — empty Maybe</description></item>
-///   <item><description><c>{ "Value": null }</c> — empty Maybe</description></item>
-///   <item><description><c>{ "Value": x }</c> — <see cref="Maybe{T}.Some"/> with the parsed value</description></item>
-/// </list>
-/// Writes an empty Maybe as <c>{ "Value": null }</c> and a populated Maybe as
-/// <c>{ "Value": x }</c>.
-/// </summary>
+/// <summary><see cref="JsonConverterFactory"/> for <see cref="Maybe{T}"/>.</summary>
+/// <remarks>
+/// Accepts <c>{}</c>, <c>{ "Value": null }</c> (both empty), or <c>{ "Value": x }</c> (populated).
+/// Writes empty as <c>{ "Value": null }</c> and populated as <c>{ "Value": x }</c>.
+/// </remarks>
 public sealed class MaybeJsonConverterFactory : JsonConverterFactory
 {
     private static readonly ConcurrentDictionary<Type, JsonConverter> s_converterCache = new();

--- a/src/StrongTypes/Nullables/NullableMapExtensions.cs
+++ b/src/StrongTypes/Nullables/NullableMapExtensions.cs
@@ -7,85 +7,81 @@ namespace StrongTypes;
 
 public static class NullableMapToStructExtensions
 {
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns its
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> has a value.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult> map)
         where T : struct
         where TResult : struct
         => value.HasValue ? map(value.Value) : null;
 
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns its
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>. The mapper may itself return <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> has a value; may return <c>null</c>.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult?> map)
         where T : struct
         where TResult : struct
         => value.HasValue ? map(value.Value) : null;
 
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns its
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is non-null.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult> map)
         where T : class
         where TResult : struct
         => value is not null ? map(value) : null;
 
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns its
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>. The mapper may itself return <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is non-null; may return <c>null</c>.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult?> map)
         where T : class
         where TResult : struct
         => value is not null ? map(value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> has a value.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult>> map)
         where T : struct
         where TResult : struct
         => value.HasValue ? await map(value.Value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>. The mapper may itself yield <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> has a value; may yield <c>null</c>.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult?>> map)
         where T : struct
         where TResult : struct
         => value.HasValue ? await map(value.Value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is non-null.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult>> map)
         where T : class
         where TResult : struct
         => value is not null ? await map(value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>. The mapper may itself yield <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is non-null; may yield <c>null</c>.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult?>> map)
         where T : class
         where TResult : struct
@@ -94,45 +90,41 @@ public static class NullableMapToStructExtensions
 
 public static class NullableMapToClassExtensions
 {
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns the
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>. The mapper may itself return <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> has a value; may return <c>null</c>.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult?> map)
         where T : struct
         where TResult : class
         => value.HasValue ? map(value.Value) : null;
 
-    /// <summary>
-    /// Applies <paramref name="map"/> to the value when present and returns the
-    /// result; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Applies <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>. The mapper may itself return <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Invoked only when <paramref name="value"/> is non-null; may return <c>null</c>.</param>
     public static TResult? Map<T, TResult>(this T? value, Func<T, TResult?> map)
         where T : class
         where TResult : class
         => value is not null ? map(value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is present; otherwise returns <c>null</c>. The mapper may itself yield <c>null</c>.</summary>
+    /// <typeparam name="T">The source value type.</typeparam>
+    /// <typeparam name="TResult">The result reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> has a value; may yield <c>null</c>.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult?>> map)
         where T : struct
         where TResult : class
         => value.HasValue ? await map(value.Value) : null;
 
-    /// <summary>
-    /// Awaits and returns the result of <paramref name="map"/> when the value
-    /// is present; returns <see langword="null"/> without invoking
-    /// <paramref name="map"/> when the input is <see langword="null"/>. The
-    /// mapper may itself return <see langword="null"/>.
-    /// </summary>
+    /// <summary>Awaits <paramref name="map"/> when <paramref name="value"/> is non-null; otherwise returns <c>null</c>. The mapper may itself yield <c>null</c>.</summary>
+    /// <typeparam name="T">The source reference type.</typeparam>
+    /// <typeparam name="TResult">The result reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="map">Awaited only when <paramref name="value"/> is non-null; may yield <c>null</c>.</param>
     public static async Task<TResult?> MapAsync<T, TResult>(this T? value, Func<T, Task<TResult?>> map)
         where T : class
         where TResult : class

--- a/src/StrongTypes/Numbers/Negative.cs
+++ b/src/StrongTypes/Numbers/Negative.cs
@@ -5,15 +5,9 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A numeric value guaranteed to be strictly less than <c>T.Zero</c>.
-/// </summary>
-/// <remarks>
-/// Construct via <see cref="TryCreate"/> or <c>Create</c> (generated). Internally
-/// the value is stored as an offset from <c>-T.One</c> so that
-/// <c>default(Negative&lt;T&gt;)</c> represents <c>-T.One</c> — i.e. the
-/// zero-initialized struct still satisfies the negativity invariant.
-/// </remarks>
+/// <summary>A numeric value guaranteed to be strictly less than <c>T.Zero</c>.</summary>
+/// <typeparam name="T">The underlying numeric type.</typeparam>
+/// <remarks>Construct via <see cref="TryCreate"/> or <c>Create</c>. <c>default(Negative&lt;T&gt;)</c> wraps <c>-T.One</c> and satisfies the invariant.</remarks>
 [NumericWrapper(InvariantDescription = "negative", GenerateSum = true)]
 [JsonConverter(typeof(NumericStrongTypeJsonConverterFactory))]
 public readonly partial struct Negative<T>
@@ -29,10 +23,8 @@ public readonly partial struct Negative<T>
 
     public T Value => _offset - T.One;
 
-    /// <summary>
-    /// Returns a <see cref="Negative{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is not strictly less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>, or returns <c>null</c> when it is not strictly less than zero.</summary>
+    /// <param name="value">The number to validate.</param>
     public static Negative<T>? TryCreate(T value)
     {
         return value < T.Zero ? new Negative<T>(value + T.One) : null;

--- a/src/StrongTypes/Numbers/NonNegative.cs
+++ b/src/StrongTypes/Numbers/NonNegative.cs
@@ -5,15 +5,9 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A numeric value guaranteed to be greater than or equal to <c>T.Zero</c>.
-/// </summary>
-/// <remarks>
-/// Construct via <see cref="TryCreate"/> or <c>Create</c> (generated). Unlike
-/// <see cref="Positive{T}"/>, <c>default(NonNegative&lt;T&gt;)</c> wraps
-/// <c>T.Zero</c> and therefore <em>does</em> satisfy the invariant, though the
-/// factories remain the intended entry point.
-/// </remarks>
+/// <summary>A numeric value guaranteed to be greater than or equal to <c>T.Zero</c>.</summary>
+/// <typeparam name="T">The underlying numeric type.</typeparam>
+/// <remarks>Construct via <see cref="TryCreate"/> or <c>Create</c>. <c>default(NonNegative&lt;T&gt;)</c> wraps <c>T.Zero</c> and satisfies the invariant.</remarks>
 [NumericWrapper(InvariantDescription = "non-negative", GenerateSum = true)]
 [JsonConverter(typeof(NumericStrongTypeJsonConverterFactory))]
 public readonly partial struct NonNegative<T>
@@ -26,10 +20,8 @@ public readonly partial struct NonNegative<T>
 
     public T Value { get; }
 
-    /// <summary>
-    /// Returns a <see cref="NonNegative{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>, or returns <c>null</c> when it is less than zero.</summary>
+    /// <param name="value">The number to validate.</param>
     public static NonNegative<T>? TryCreate(T value)
     {
         return value >= T.Zero ? new NonNegative<T>(value) : null;

--- a/src/StrongTypes/Numbers/NonPositive.cs
+++ b/src/StrongTypes/Numbers/NonPositive.cs
@@ -5,15 +5,9 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A numeric value guaranteed to be less than or equal to <c>T.Zero</c>.
-/// </summary>
-/// <remarks>
-/// Construct via <see cref="TryCreate"/> or <c>Create</c> (generated). Unlike
-/// <see cref="Negative{T}"/>, <c>default(NonPositive&lt;T&gt;)</c> wraps
-/// <c>T.Zero</c> and therefore <em>does</em> satisfy the invariant, though the
-/// factories remain the intended entry point.
-/// </remarks>
+/// <summary>A numeric value guaranteed to be less than or equal to <c>T.Zero</c>.</summary>
+/// <typeparam name="T">The underlying numeric type.</typeparam>
+/// <remarks>Construct via <see cref="TryCreate"/> or <c>Create</c>. <c>default(NonPositive&lt;T&gt;)</c> wraps <c>T.Zero</c> and satisfies the invariant.</remarks>
 [NumericWrapper(InvariantDescription = "non-positive", GenerateSum = true)]
 [JsonConverter(typeof(NumericStrongTypeJsonConverterFactory))]
 public readonly partial struct NonPositive<T>
@@ -26,10 +20,8 @@ public readonly partial struct NonPositive<T>
 
     public T Value { get; }
 
-    /// <summary>
-    /// Returns a <see cref="NonPositive{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>, or returns <c>null</c> when it is greater than zero.</summary>
+    /// <param name="value">The number to validate.</param>
     public static NonPositive<T>? TryCreate(T value)
     {
         return value <= T.Zero ? new NonPositive<T>(value) : null;

--- a/src/StrongTypes/Numbers/NumberExtensions.cs
+++ b/src/StrongTypes/Numbers/NumberExtensions.cs
@@ -6,91 +6,81 @@ namespace StrongTypes;
 
 public static class NumberExtensions
 {
-    /// <summary>
-    /// Returns a <see cref="Positive{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> when <paramref name="value"/> is not strictly greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="Positive{T}"/>, or returns <c>null</c> when it is not strictly greater than zero.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
     public static Positive<T>? AsPositive<T>(this T value) where T : INumber<T>
         => Positive<T>.TryCreate(value);
 
-    /// <summary>
-    /// Returns a <see cref="NonNegative{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> when <paramref name="value"/> is less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="NonNegative{T}"/>, or returns <c>null</c> when it is less than zero.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
     public static NonNegative<T>? AsNonNegative<T>(this T value) where T : INumber<T>
         => NonNegative<T>.TryCreate(value);
 
-    /// <summary>
-    /// Returns a <see cref="Negative{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> when <paramref name="value"/> is not strictly less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="Negative{T}"/>, or returns <c>null</c> when it is not strictly less than zero.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
     public static Negative<T>? AsNegative<T>(this T value) where T : INumber<T>
         => Negative<T>.TryCreate(value);
 
-    /// <summary>
-    /// Returns a <see cref="NonPositive{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> when <paramref name="value"/> is greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="NonPositive{T}"/>, or returns <c>null</c> when it is greater than zero.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
     public static NonPositive<T>? AsNonPositive<T>(this T value) where T : INumber<T>
         => NonPositive<T>.TryCreate(value);
 
-    /// <summary>
-    /// Returns a <see cref="Positive{T}"/> wrapping <paramref name="value"/>.
-    /// Throws <see cref="System.ArgumentException"/> when <paramref name="value"/>
-    /// is not strictly greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="Positive{T}"/>.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
+    /// <exception cref="System.ArgumentException"><paramref name="value"/> is not strictly greater than zero.</exception>
     public static Positive<T> ToPositive<T>(this T value) where T : INumber<T>
         => Positive<T>.Create(value);
 
-    /// <summary>
-    /// Returns a <see cref="NonNegative{T}"/> wrapping <paramref name="value"/>.
-    /// Throws <see cref="System.ArgumentException"/> when <paramref name="value"/>
-    /// is less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="NonNegative{T}"/>.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
+    /// <exception cref="System.ArgumentException"><paramref name="value"/> is less than zero.</exception>
     public static NonNegative<T> ToNonNegative<T>(this T value) where T : INumber<T>
         => NonNegative<T>.Create(value);
 
-    /// <summary>
-    /// Returns a <see cref="Negative{T}"/> wrapping <paramref name="value"/>.
-    /// Throws <see cref="System.ArgumentException"/> when <paramref name="value"/>
-    /// is not strictly less than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="Negative{T}"/>.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
+    /// <exception cref="System.ArgumentException"><paramref name="value"/> is not strictly less than zero.</exception>
     public static Negative<T> ToNegative<T>(this T value) where T : INumber<T>
         => Negative<T>.Create(value);
 
-    /// <summary>
-    /// Returns a <see cref="NonPositive{T}"/> wrapping <paramref name="value"/>.
-    /// Throws <see cref="System.ArgumentException"/> when <paramref name="value"/>
-    /// is greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/> as <see cref="NonPositive{T}"/>.</summary>
+    /// <typeparam name="T">The underlying numeric type.</typeparam>
+    /// <param name="value">The number to validate.</param>
+    /// <exception cref="System.ArgumentException"><paramref name="value"/> is greater than zero.</exception>
     public static NonPositive<T> ToNonPositive<T>(this T value) where T : INumber<T>
         => NonPositive<T>.Create(value);
 
-    /// <summary>
-    /// Returns <paramref name="a"/> divided by <paramref name="b"/>, or <c>null</c>
-    /// when <paramref name="b"/> is zero.
-    /// </summary>
+    /// <summary>Divides <paramref name="a"/> by <paramref name="b"/>, or returns <c>null</c> when <paramref name="b"/> is zero.</summary>
+    /// <param name="a">The dividend.</param>
+    /// <param name="b">The divisor.</param>
     public static decimal? Divide(this int a, decimal b)
         => b == 0 ? null : a / b;
 
-    /// <summary>
-    /// Returns <paramref name="a"/> divided by <paramref name="b"/>, or <c>null</c>
-    /// when <paramref name="b"/> is zero.
-    /// </summary>
+    /// <summary>Divides <paramref name="a"/> by <paramref name="b"/>, or returns <c>null</c> when <paramref name="b"/> is zero.</summary>
+    /// <param name="a">The dividend.</param>
+    /// <param name="b">The divisor.</param>
     public static decimal? Divide(this decimal a, decimal b)
         => b == 0 ? null : a / b;
 
-    /// <summary>
-    /// Returns <paramref name="a"/> divided by <paramref name="b"/>, or
-    /// <paramref name="otherwise"/> when <paramref name="b"/> is zero.
-    /// </summary>
+    /// <summary>Divides <paramref name="a"/> by <paramref name="b"/>, or returns <paramref name="otherwise"/> when <paramref name="b"/> is zero.</summary>
+    /// <param name="a">The dividend.</param>
+    /// <param name="b">The divisor.</param>
+    /// <param name="otherwise">Fallback returned when <paramref name="b"/> is zero.</param>
     public static decimal SafeDivide(this int a, decimal b, decimal otherwise = 0)
         => a.Divide(b) ?? otherwise;
 
-    /// <summary>
-    /// Returns <paramref name="a"/> divided by <paramref name="b"/>, or
-    /// <paramref name="otherwise"/> when <paramref name="b"/> is zero.
-    /// </summary>
+    /// <summary>Divides <paramref name="a"/> by <paramref name="b"/>, or returns <paramref name="otherwise"/> when <paramref name="b"/> is zero.</summary>
+    /// <param name="a">The dividend.</param>
+    /// <param name="b">The divisor.</param>
+    /// <param name="otherwise">Fallback returned when <paramref name="b"/> is zero.</param>
     public static decimal SafeDivide(this decimal a, decimal b, decimal otherwise = 0)
         => a.Divide(b) ?? otherwise;
 }

--- a/src/StrongTypes/Numbers/NumericStrongTypeJsonConverterFactory.cs
+++ b/src/StrongTypes/Numbers/NumericStrongTypeJsonConverterFactory.cs
@@ -10,13 +10,8 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// <see cref="JsonConverterFactory"/> that handles all numeric strong-type wrappers
-/// (<see cref="Positive{T}"/>, <see cref="NonNegative{T}"/>, <see cref="Negative{T}"/>,
-/// <see cref="NonPositive{T}"/>). Serializes by writing the underlying numeric value
-/// directly; deserializes by reading the number and passing it through
-/// <c>TryCreate</c> so invalid values are rejected at the deserialization boundary.
-/// </summary>
+/// <summary><see cref="JsonConverterFactory"/> for <see cref="Positive{T}"/>, <see cref="NonNegative{T}"/>, <see cref="Negative{T}"/>, and <see cref="NonPositive{T}"/>.</summary>
+/// <remarks>Reads and writes the underlying numeric value; JSON values that fail the wrapper's invariant throw <see cref="JsonException"/>.</remarks>
 public sealed class NumericStrongTypeJsonConverterFactory : JsonConverterFactory
 {
     private static readonly HashSet<Type> SupportedDefinitions =

--- a/src/StrongTypes/Numbers/NumericWrapperAttribute.cs
+++ b/src/StrongTypes/Numbers/NumericWrapperAttribute.cs
@@ -4,35 +4,14 @@ using System;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Marks a <c>partial struct</c> as a numeric strong-type wrapper. The source
-/// generator fills in the standard equality, comparison, operator, conversion,
-/// and <c>Create</c>-factory boilerplate, as well as LINQ-style extension methods
-/// on <c>IEnumerable&lt;Self&gt;</c>.
-/// </summary>
-/// <remarks>
-/// The target must declare:
-/// <list type="bullet">
-/// <item>a public <c>Value</c> instance property exposing the underlying numeric
-/// value;</item>
-/// <item>a public static <c>TryCreate</c> method returning <c>Self?</c> that
-/// encodes the validation rule.</item>
-/// </list>
-/// </remarks>
+/// <summary>Marks a <c>partial struct</c> as a numeric strong-type wrapper for the source generator.</summary>
+/// <remarks>The target must declare a public <c>Value</c> instance property and a public static <c>TryCreate</c> returning <c>Self?</c>.</remarks>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
 public sealed class NumericWrapperAttribute : Attribute
 {
-    /// <summary>
-    /// Short adjective phrase used in the <c>Create</c>-throws message, e.g.
-    /// <c>"positive"</c> or <c>"non-negative"</c>. The final message reads
-    /// <c>$"Value must be {InvariantDescription}, but was '{value}'."</c>.
-    /// </summary>
+    /// <summary>Short adjective phrase embedded in the <c>Create</c> throw message, e.g. <c>"positive"</c>.</summary>
     public string InvariantDescription { get; set; } = "valid";
 
-    /// <summary>
-    /// Emit a <c>Sum</c> extension on <c>IEnumerable&lt;Self&gt;</c>. Only set
-    /// to <c>true</c> when the wrapper's invariant is closed under addition —
-    /// e.g. <c>NonNegative</c> yes, bounded ranges no.
-    /// </summary>
+    /// <summary>When <c>true</c>, the generator emits a <c>Sum</c> extension on <c>IEnumerable&lt;Self&gt;</c>. Only safe when the invariant is closed under addition.</summary>
     public bool GenerateSum { get; set; }
 }

--- a/src/StrongTypes/Numbers/Positive.cs
+++ b/src/StrongTypes/Numbers/Positive.cs
@@ -5,15 +5,9 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A numeric value guaranteed to be strictly greater than <c>T.Zero</c>.
-/// </summary>
-/// <remarks>
-/// Construct via <see cref="TryCreate"/> or <c>Create</c> (generated). Internally
-/// the value is stored as an offset from <c>T.One</c> so that
-/// <c>default(Positive&lt;T&gt;)</c> represents <c>T.One</c> — i.e. the
-/// zero-initialized struct still satisfies the positivity invariant.
-/// </remarks>
+/// <summary>A numeric value guaranteed to be strictly greater than <c>T.Zero</c>.</summary>
+/// <typeparam name="T">The underlying numeric type.</typeparam>
+/// <remarks>Construct via <see cref="TryCreate"/> or <c>Create</c>. <c>default(Positive&lt;T&gt;)</c> wraps <c>T.One</c> and satisfies the invariant.</remarks>
 [NumericWrapper(InvariantDescription = "positive", GenerateSum = true)]
 [JsonConverter(typeof(NumericStrongTypeJsonConverterFactory))]
 public readonly partial struct Positive<T>
@@ -29,10 +23,8 @@ public readonly partial struct Positive<T>
 
     public T Value => _offset + T.One;
 
-    /// <summary>
-    /// Returns a <see cref="Positive{T}"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is not strictly greater than zero.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>, or returns <c>null</c> when it is not strictly greater than zero.</summary>
+    /// <param name="value">The number to validate.</param>
     public static Positive<T>? TryCreate(T value)
     {
         return value > T.Zero ? new Positive<T>(value - T.One) : null;

--- a/src/StrongTypes/Result/Result.cs
+++ b/src/StrongTypes/Result/Result.cs
@@ -6,17 +6,10 @@ using System.Threading.Tasks;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A value that is either a success carrying a <typeparamref name="T"/> or an error
-/// carrying a <typeparamref name="TError"/>. Construct through the implicit conversions
-/// (<c>return value;</c> / <c>return error;</c>) or the <see cref="Result"/> factory.
-/// <para>
-/// The typical branch check is <c>if (result.Success is {} s)</c> / <c>if (result.Error is {} e)</c>,
-/// which unwraps to the underlying value in a single expression. <c>Success</c> and
-/// <c>Error</c> are surfaced via extension members so the returned nullable type is
-/// <see cref="Nullable{T}"/> for value types and <c>T?</c> for reference types.
-/// </para>
-/// </summary>
+/// <summary>A value that is either a success carrying <typeparamref name="T"/> or an error carrying <typeparamref name="TError"/>.</summary>
+/// <typeparam name="T">The success value type.</typeparam>
+/// <typeparam name="TError">The error value type.</typeparam>
+/// <remarks>Construct through the implicit conversions (<c>return value;</c> / <c>return error;</c>) or the <see cref="Result"/> factory. Unwrap with the extension-property pattern: <c>if (result.Success is {} s)</c> or <c>if (result.Error is {} e)</c>.</remarks>
 // Note: we can't also declare IEquatable<T> and IEquatable<TError> — the C#
 // compiler rejects that combination (CS0695) because the two interfaces unify
 // when T equals TError at a closed type. The Equals(T) / Equals(TError)
@@ -79,10 +72,11 @@ public class Result<T, TError> : IEquatable<Result<T, TError>>
     public async Task<Result<U, TError>> MapAsync<U>(Func<T, Task<U>> f) where U : notnull =>
         IsSuccess ? await f(InternalValue) : InternalError;
 
-    /// <summary>
-    /// Bimap: transforms both branches in one call. Equivalent to
-    /// <c>r.Map(success).MapError(error)</c> but traverses the value once.
-    /// </summary>
+    /// <summary>Transforms both branches in one call (bimap).</summary>
+    /// <typeparam name="U">The mapped success type.</typeparam>
+    /// <typeparam name="UError">The mapped error type.</typeparam>
+    /// <param name="success">Applied when this is a success.</param>
+    /// <param name="error">Applied when this is an error.</param>
     public Result<U, UError> Map<U, UError>(Func<T, U> success, Func<TError, UError> error)
         where U : notnull
         where UError : notnull =>
@@ -126,17 +120,13 @@ public class Result<T, TError> : IEquatable<Result<T, TError>>
             : EqualityComparer<TError>.Default.Equals(InternalError, other.InternalError);
     }
 
-    /// <summary>
-    /// Returns <see langword="true"/> when this Result is a success whose value
-    /// equals <paramref name="other"/>.
-    /// </summary>
+    /// <summary>Returns <c>true</c> when this is a success whose value equals <paramref name="other"/>.</summary>
+    /// <param name="other">The value to compare against.</param>
     public bool Equals(T? other) =>
         IsSuccess && other is not null && EqualityComparer<T>.Default.Equals(InternalValue, other);
 
-    /// <summary>
-    /// Returns <see langword="true"/> when this Result is an error whose value
-    /// equals <paramref name="other"/>.
-    /// </summary>
+    /// <summary>Returns <c>true</c> when this is an error whose value equals <paramref name="other"/>.</summary>
+    /// <param name="other">The error to compare against.</param>
     public bool Equals(TError? other) =>
         IsError && other is not null && EqualityComparer<TError>.Default.Equals(InternalError, other);
 
@@ -156,13 +146,8 @@ public class Result<T, TError> : IEquatable<Result<T, TError>>
     #endregion
 }
 
-/// <summary>
-/// Shorthand for <c>Result&lt;T, Exception&gt;</c>. Method signatures can read as
-/// <c>Result&lt;T&gt;</c> without naming the error type. Shadows <c>Map</c>,
-/// <c>FlatMap</c>, and their async counterparts to narrow the return type — so
-/// chained expressions stay as <c>Result&lt;T&gt;</c> instead of decaying to the
-/// two-parameter form.
-/// </summary>
+/// <summary>Shorthand for <c>Result&lt;T, Exception&gt;</c>; chained <c>Map</c>/<c>FlatMap</c> calls stay as <see cref="Result{T}"/> rather than decaying to the two-parameter form.</summary>
+/// <typeparam name="T">The success value type.</typeparam>
 public sealed class Result<T> : Result<T, Exception>
     where T : notnull
 {
@@ -197,19 +182,30 @@ public sealed class Result<T> : Result<T, Exception>
     }
 }
 
-/// <summary>
-/// Factory helpers for <see cref="Result{T}"/> and <see cref="Result{T, TError}"/>. Prefer the
-/// implicit conversions (<c>return value;</c>) in callers; use these when type inference
-/// needs a nudge or when explicit intent reads better.
-/// </summary>
+/// <summary>Factory helpers for <see cref="Result{T}"/> and <see cref="Result{T, TError}"/>.</summary>
 public static partial class Result
 {
+    /// <summary>Wraps <paramref name="value"/> as a successful <see cref="Result{T}"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <param name="value">The success payload.</param>
     public static Result<T> Success<T>(T value) where T : notnull => new(value);
+
+    /// <summary>Wraps <paramref name="error"/> as a failed <see cref="Result{T}"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <param name="error">The captured exception.</param>
     public static Result<T> Error<T>(Exception error) where T : notnull => new(error);
 
+    /// <summary>Wraps <paramref name="value"/> as a successful <see cref="Result{T, TError}"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="value">The success payload.</param>
     public static Result<T, TError> Success<T, TError>(T value)
         where T : notnull where TError : notnull => new(value);
 
+    /// <summary>Wraps <paramref name="error"/> as a failed <see cref="Result{T, TError}"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="error">The error payload.</param>
     public static Result<T, TError> Error<T, TError>(TError error)
         where T : notnull where TError : notnull => new(error);
 }

--- a/src/StrongTypes/Result/ResultAggregate.cs
+++ b/src/StrongTypes/Result/ResultAggregate.cs
@@ -7,10 +7,12 @@ namespace StrongTypes;
 
 public static partial class Result
 {
-    /// <summary>
-    /// Combines results into a tuple of values on all-success, or an array of
-    /// every collected error (not just the first) otherwise.
-    /// </summary>
+    /// <summary>Combines results into a tuple of values on all-success, or an array of every collected error otherwise.</summary>
+    /// <typeparam name="T1">The first success value type.</typeparam>
+    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="TError">The shared error type.</typeparam>
+    /// <param name="r1">The first result.</param>
+    /// <param name="r2">The second result.</param>
     public static Result<(T1, T2), TError[]> Aggregate<T1, T2, TError>(
         Result<T1, TError> r1, Result<T2, TError> r2)
         where T1 : notnull where T2 : notnull where TError : notnull
@@ -24,10 +26,14 @@ public static partial class Result
         return errors;
     }
 
-    /// <summary>
-    /// Combiner form: on all-success invokes <paramref name="combine"/>; otherwise
-    /// returns all collected errors.
-    /// </summary>
+    /// <summary>On all-success invokes <paramref name="combine"/>; otherwise returns all collected errors.</summary>
+    /// <typeparam name="T1">The first success value type.</typeparam>
+    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="R">The combined success type.</typeparam>
+    /// <typeparam name="TError">The shared error type.</typeparam>
+    /// <param name="r1">The first result.</param>
+    /// <param name="r2">The second result.</param>
+    /// <param name="combine">Invoked with both successful values.</param>
     public static Result<R, TError[]> Aggregate<T1, T2, R, TError>(
         Result<T1, TError> r1, Result<T2, TError> r2,
         Func<T1, T2, R> combine)
@@ -246,10 +252,10 @@ public static partial class Result
         return errors;
     }
 
-    /// <summary>
-    /// Aggregates any number of results, collecting every error. The sequence is
-    /// fully drained whether or not an error is seen.
-    /// </summary>
+    /// <summary>Aggregates any number of results, collecting every error. The sequence is fully drained whether or not an error is seen.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="results">The results to aggregate.</param>
     public static Result<T[], TError[]> Aggregate<T, TError>(
         IEnumerable<Result<T, TError>> results)
         where T : notnull where TError : notnull
@@ -266,13 +272,16 @@ public static partial class Result
         return successes.ToArray();
     }
 
-    /// <summary>
-    /// Combiner form that also folds the collected errors: on all-success
-    /// invokes <paramref name="combine"/>; otherwise passes the collected
-    /// <typeparamref name="TError"/> array through <paramref name="errorMap"/>
-    /// — typically used to join multiple validation messages into a single
-    /// <typeparamref name="UError"/>.
-    /// </summary>
+    /// <summary>On all-success invokes <paramref name="combine"/>; otherwise passes the collected errors through <paramref name="errorMap"/>.</summary>
+    /// <typeparam name="T1">The first success value type.</typeparam>
+    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="R">The combined success type.</typeparam>
+    /// <typeparam name="TError">The incoming error type.</typeparam>
+    /// <typeparam name="UError">The mapped error type.</typeparam>
+    /// <param name="r1">The first result.</param>
+    /// <param name="r2">The second result.</param>
+    /// <param name="combine">Invoked with both successful values.</param>
+    /// <param name="errorMap">Folds the collected errors into a single <typeparamref name="UError"/>.</param>
     public static Result<R, UError> Aggregate<T1, T2, R, TError, UError>(
         Result<T1, TError> r1, Result<T2, TError> r2,
         Func<T1, T2, R> combine,

--- a/src/StrongTypes/Result/ResultFlattenExtensions.cs
+++ b/src/StrongTypes/Result/ResultFlattenExtensions.cs
@@ -6,30 +6,27 @@ namespace StrongTypes;
 
 public static class ResultFlattenExtensions
 {
-    /// <summary>
-    /// Collapses a nested Result into a single Result when both levels share
-    /// the same error type. The outer error propagates when the outer result
-    /// is an error; otherwise the inner Result is returned as-is.
-    /// </summary>
+    /// <summary>Collapses a nested <see cref="Result{T, TError}"/> when both levels share the same error type.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The shared error type.</typeparam>
+    /// <param name="nested">The nested result.</param>
     public static Result<T, TError> Flatten<T, TError>(this Result<Result<T, TError>, TError> nested)
         where T : notnull
         where TError : notnull
         => nested.IsSuccess ? nested.InternalValue : nested.InternalError;
 
-    /// <summary>
-    /// Collapses a <see cref="Result{T}"/> of <see cref="Result{T}"/> into a single
-    /// <see cref="Result{T}"/>. Preserves the single-parameter form instead of decaying
-    /// to <c>Result&lt;T, Exception&gt;</c>.
-    /// </summary>
+    /// <summary>Collapses a <see cref="Result{T}"/> of <see cref="Result{T}"/>, preserving the single-parameter form.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <param name="nested">The nested result.</param>
     public static Result<T> Flatten<T>(this Result<Result<T>, Exception> nested)
         where T : notnull
         => nested.IsSuccess ? nested.InternalValue : nested.InternalError;
 
-    /// <summary>
-    /// Collapses a nested Result whose inner and outer error types are different
-    /// <see cref="Exception"/> subtypes. Both errors upcast to <see cref="Exception"/>,
-    /// so the flattened value takes the single-parameter <see cref="Result{T}"/> form.
-    /// </summary>
+    /// <summary>Collapses a nested <see cref="Result{T, TError}"/> whose inner and outer error types are different <see cref="Exception"/> subtypes. Both errors upcast to <see cref="Exception"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TInnerException">The inner exception type.</typeparam>
+    /// <typeparam name="TOuterException">The outer exception type.</typeparam>
+    /// <param name="nested">The nested result.</param>
     public static Result<T> Flatten<T, TInnerException, TOuterException>(
         this Result<Result<T, TInnerException>, TOuterException> nested)
         where T : notnull

--- a/src/StrongTypes/Result/ResultFromNullableExtensions.cs
+++ b/src/StrongTypes/Result/ResultFromNullableExtensions.cs
@@ -8,50 +8,45 @@ public static class ResultFromNullableExtensions
 {
     // ── Reference type receivers ───────────────────────────────────────
 
-    /// <summary>
-    /// Lifts a nullable reference into a <see cref="Result{T}"/>. A non-null
-    /// value becomes a success; a null value becomes an
-    /// <see cref="ArgumentNullException"/> with no <c>ParamName</c>. Use the
-    /// eager or lazy overloads when you want a specific exception or a custom
-    /// error value.
-    /// </summary>
+    /// <summary>Lifts a nullable reference into a <see cref="Result{T}"/>. A null value becomes an <see cref="ArgumentNullException"/> with no <c>ParamName</c>.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
     public static Result<T> ToResult<T>(this T? value)
         where T : class
         => value is { } v ? v : new ArgumentNullException();
 
-    /// <summary>
-    /// Eager exception overload. A non-null <paramref name="value"/> becomes a
-    /// success; a null value becomes <paramref name="error"/>.
-    /// </summary>
+    /// <summary>Lifts a nullable reference into a <see cref="Result{T}"/>. A null value becomes <paramref name="error"/>.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="error">The exception to emit when <paramref name="value"/> is null.</param>
     public static Result<T> ToResult<T>(this T? value, Exception error)
         where T : class
         => value is { } v ? v : error;
 
-    /// <summary>
-    /// Lazy exception overload — prefer when the exception is expensive to
-    /// construct (e.g. deep stack capture).
-    /// </summary>
+    /// <summary>Lifts a nullable reference into a <see cref="Result{T}"/>. A null value invokes <paramref name="error"/>.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="error">Produces the exception when <paramref name="value"/> is null.</param>
     public static Result<T> ToResult<T>(this T? value, Func<Exception> error)
         where T : class
         => value is { } v ? v : error();
 
-    /// <summary>
-    /// Eager custom-error overload. Use for cheap error values (enums, captured
-    /// singletons, small records) where lambda allocation is unwanted overhead.
-    /// <para>
-    /// A lambda returning a specific <see cref="Exception"/> subtype binds here
-    /// rather than to <see cref="ToResult{T}(T?, Func{Exception})"/>. To force
-    /// the single-parameter form, cast to <see cref="Exception"/>.
-    /// </para>
-    /// </summary>
+    /// <summary>Lifts a nullable reference into a <see cref="Result{T, TError}"/> with an eager custom error.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="error">The error to emit when <paramref name="value"/> is null.</param>
+    /// <remarks>A lambda returning a specific <see cref="Exception"/> subtype binds here rather than to <see cref="ToResult{T}(T?, Func{Exception})"/>. Cast to <see cref="Exception"/> to force the single-parameter form.</remarks>
     public static Result<T, TError> ToResult<T, TError>(this T? value, TError error)
         where T : class
         where TError : notnull
         => value is { } v ? v : error;
 
-    /// <summary>
-    /// Lazy custom-error overload.
-    /// </summary>
+    /// <summary>Lifts a nullable reference into a <see cref="Result{T, TError}"/> with a lazy custom error.</summary>
+    /// <typeparam name="T">The reference type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="value">The nullable input.</param>
+    /// <param name="error">Produces the error when <paramref name="value"/> is null.</param>
     public static Result<T, TError> ToResult<T, TError>(this T? value, Func<TError> error)
         where T : class
         where TError : notnull

--- a/src/StrongTypes/Result/ResultPartitionExtensions.cs
+++ b/src/StrongTypes/Result/ResultPartitionExtensions.cs
@@ -8,10 +8,10 @@ namespace StrongTypes;
 
 public static class ResultPartitionExtensions
 {
-    /// <summary>
-    /// Splits a sequence of <see cref="Result{T, TError}"/> into successes and errors.
-    /// Relative order is preserved within each partition.
-    /// </summary>
+    /// <summary>Splits a sequence of <see cref="Result{T, TError}"/> into successes and errors. Relative order is preserved within each partition.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="source">The sequence of results.</param>
     public static (IReadOnlyList<T> Successes, IReadOnlyList<TError> Errors) Partition<T, TError>(
         this IEnumerable<Result<T, TError>> source)
         where T : notnull
@@ -30,12 +30,12 @@ public static class ResultPartitionExtensions
         return (successes, errors);
     }
 
-    /// <summary>
-    /// Partitions the sequence into successes and errors, then invokes
-    /// <paramref name="success"/> on the successes and <paramref name="error"/>
-    /// on the errors. Both callbacks are invoked unconditionally, even when the
-    /// corresponding partition is empty.
-    /// </summary>
+    /// <summary>Partitions the sequence, then invokes <paramref name="success"/> on the successes and <paramref name="error"/> on the errors. Both callbacks are invoked even when their partition is empty.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="source">The sequence of results.</param>
+    /// <param name="success">Invoked with all successes.</param>
+    /// <param name="error">Invoked with all errors.</param>
     public static void PartitionMatch<T, TError>(
         this IEnumerable<Result<T, TError>> source,
         Action<IReadOnlyList<T>> success,
@@ -48,11 +48,13 @@ public static class ResultPartitionExtensions
         error(errors);
     }
 
-    /// <summary>
-    /// Partitions the sequence into successes and errors, projects each partition
-    /// through the matching callback, and returns the concatenated results in
-    /// successes-then-errors order.
-    /// </summary>
+    /// <summary>Partitions the sequence, projects each partition through the matching callback, and returns the concatenated results in successes-then-errors order.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="R">The projected element type.</typeparam>
+    /// <param name="source">The sequence of results.</param>
+    /// <param name="success">Projects the successes.</param>
+    /// <param name="error">Projects the errors.</param>
     public static R[] PartitionMatch<T, TError, R>(
         this IEnumerable<Result<T, TError>> source,
         Func<IReadOnlyList<T>, IEnumerable<R>> success,

--- a/src/StrongTypes/Result/ResultThrowIfErrorExtensions.cs
+++ b/src/StrongTypes/Result/ResultThrowIfErrorExtensions.cs
@@ -9,13 +9,10 @@ namespace StrongTypes;
 
 public static class ResultThrowIfErrorExtensions
 {
-    /// <summary>
-    /// Returns the success value, or rethrows the captured exception preserving
-    /// its original stack trace via <see cref="ExceptionDispatchInfo"/>. Applies
-    /// whenever <typeparamref name="TError"/> is already an <see cref="Exception"/>
-    /// — including the default <see cref="Result{T}"/> form and results whose error
-    /// type is a concrete exception subclass (e.g. <c>Result&lt;T, InvalidOperationException&gt;</c>).
-    /// </summary>
+    /// <summary>Returns the success value, or rethrows the captured exception preserving its original stack trace.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error type, constrained to <see cref="Exception"/>.</typeparam>
+    /// <param name="r">The result to unwrap.</param>
     public static T ThrowIfError<T, TError>(this Result<T, TError> r)
         where T : notnull
         where TError : Exception
@@ -25,11 +22,11 @@ public static class ResultThrowIfErrorExtensions
         throw new UnreachableException();
     }
 
-    /// <summary>
-    /// Returns the success value, or throws the exception produced by
-    /// <paramref name="toException"/>. Use when <typeparamref name="TError"/>
-    /// is not an <see cref="Exception"/>.
-    /// </summary>
+    /// <summary>Returns the success value, or throws the exception produced by <paramref name="toException"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <param name="r">The result to unwrap.</param>
+    /// <param name="toException">Maps the error to an <see cref="Exception"/>.</param>
     public static T ThrowIfError<T, TError>(
         this Result<T, TError> r,
         Func<TError, Exception> toException)
@@ -41,11 +38,9 @@ public static class ResultThrowIfErrorExtensions
         throw new UnreachableException();
     }
 
-    /// <summary>
-    /// Returns the success value, or throws. If the error list contains a single
-    /// exception it is rethrown directly (stack preserved); otherwise the list is
-    /// wrapped in an <see cref="AggregateException"/>.
-    /// </summary>
+    /// <summary>Returns the success value, or throws. A single captured exception is rethrown (stack preserved); multiple exceptions are wrapped in an <see cref="AggregateException"/>.</summary>
+    /// <typeparam name="T">The success value type.</typeparam>
+    /// <param name="r">The result to unwrap.</param>
     public static T ThrowIfError<T>(this Result<T, IReadOnlyList<Exception>> r)
         where T : notnull
     {

--- a/src/StrongTypes/Strings/NonEmptyString.cs
+++ b/src/StrongTypes/Strings/NonEmptyString.cs
@@ -6,13 +6,8 @@ using System.Text.Json.Serialization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// A string guaranteed to be non-null, non-empty, and not consisting solely of whitespace.
-/// </summary>
-/// <remarks>
-/// Comparison is delegated to <see cref="string.CompareTo(string?)"/> and therefore
-/// uses the current culture, matching the behavior of comparing two plain strings.
-/// </remarks>
+/// <summary>A string guaranteed to be non-null, non-empty, and not consisting solely of whitespace.</summary>
+/// <remarks>Comparison uses the current culture (it delegates to <see cref="string.CompareTo(string?)"/>).</remarks>
 [JsonConverter(typeof(NonEmptyStringJsonConverter))]
 public sealed class NonEmptyString :
     IEquatable<NonEmptyString>,
@@ -34,10 +29,8 @@ public sealed class NonEmptyString :
 
     public static explicit operator NonEmptyString(string s) => Create(s);
 
-    /// <summary>
-    /// Returns a <see cref="NonEmptyString"/> wrapping <paramref name="value"/>, or
-    /// <c>null</c> if <paramref name="value"/> is null, empty, or whitespace.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>, or returns <c>null</c> when it is null, empty, or whitespace.</summary>
+    /// <param name="value">The string to validate.</param>
     public static NonEmptyString? TryCreate(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -48,11 +41,9 @@ public sealed class NonEmptyString :
         return new NonEmptyString(value);
     }
 
-    /// <summary>
-    /// Returns a <see cref="NonEmptyString"/> wrapping <paramref name="value"/>.
-    /// Throws <see cref="ArgumentException"/> if <paramref name="value"/> is null,
-    /// empty, or whitespace.
-    /// </summary>
+    /// <summary>Wraps <paramref name="value"/>.</summary>
+    /// <param name="value">The string to validate.</param>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is null, empty, or whitespace.</exception>
     public static NonEmptyString Create(string? value)
     {
         return TryCreate(value)

--- a/src/StrongTypes/Strings/NonEmptyStringExtensions.cs
+++ b/src/StrongTypes/Strings/NonEmptyStringExtensions.cs
@@ -5,20 +5,12 @@ using System.Globalization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Parsing extensions on <see cref="NonEmptyString"/>. Each method returns a
-/// nullable result: <c>null</c> when parsing fails, a parsed value otherwise.
-/// </summary>
+/// <summary>Parsing extensions on <see cref="NonEmptyString"/>. Each <c>As…</c> method returns <c>null</c> when parsing fails; each <c>To…</c> method throws.</summary>
 public static class NonEmptyStringExtensions
 {
-    /// <summary>
-    /// Returns the underlying <see cref="string"/> value. Intended for LINQ
-    /// expressions translated by EF Core: the StrongTypes.EfCore package
-    /// registers a method call translator that rewrites this call as the
-    /// underlying string column, so callers can write
-    /// <c>e.Value.Unwrap().Contains("foo")</c> and have EF translate it to
-    /// SQL against the underlying string column.
-    /// </summary>
+    /// <summary>Returns the underlying <see cref="string"/> value.</summary>
+    /// <param name="s">The wrapper.</param>
+    /// <remarks>StrongTypes.EfCore translates this call in LINQ expressions to the underlying string column, letting callers write <c>e.Value.Unwrap().Contains("foo")</c> against SQL.</remarks>
     public static string Unwrap(this NonEmptyString s) => s.Value;
 
     public static byte? AsByte(this NonEmptyString s, IFormatProvider? format = null, NumberStyles style = NumberStyles.Integer) =>

--- a/src/StrongTypes/Strings/StringExtensions.cs
+++ b/src/StrongTypes/Strings/StringExtensions.cs
@@ -5,17 +5,11 @@ using System.Globalization;
 
 namespace StrongTypes;
 
-/// <summary>
-/// Parsing extensions on <see cref="string"/>. Each method returns a nullable
-/// result: <c>null</c> when the input is null/empty/whitespace or parsing
-/// fails, a parsed value otherwise.
-/// </summary>
+/// <summary>Parsing extensions on <see cref="string"/>. Each <c>As…</c> method returns <c>null</c> when the input is null/empty/whitespace or parsing fails; each <c>To…</c> method throws.</summary>
 public static class StringExtensions
 {
-    /// <summary>
-    /// Returns a <see cref="NonEmptyString"/> wrapping <paramref name="s"/>, or
-    /// <c>null</c> if <paramref name="s"/> is null, empty, or whitespace.
-    /// </summary>
+    /// <summary>Wraps <paramref name="s"/> as a <see cref="NonEmptyString"/>, or returns <c>null</c> when it is null, empty, or whitespace.</summary>
+    /// <param name="s">The string to validate.</param>
     public static NonEmptyString? AsNonEmpty(this string? s) => NonEmptyString.TryCreate(s);
 
     public static byte? AsByte(this string? s, IFormatProvider? format = null, NumberStyles style = NumberStyles.Integer) =>
@@ -54,13 +48,10 @@ public static class StringExtensions
     public static Guid? AsGuidExact(this string? s, string format = "D") =>
         Guid.TryParseExact(s, format, out var value) ? value : null;
 
-    /// <summary>
-    /// Parses <paramref name="s"/> as a member of <typeparamref name="TEnum"/>
-    /// via <see cref="Enum.TryParse{TEnum}(string, bool, out TEnum)"/>. Returns
-    /// <c>null</c> when parsing fails. Equivalent to <c>TEnum.TryParse(s, ignoreCase)</c>;
-    /// the indirection exists because C# does not allow calling extension-static
-    /// members through an open type parameter.
-    /// </summary>
+    /// <summary>Parses <paramref name="s"/> as a member of <typeparamref name="TEnum"/>, or returns <c>null</c> when parsing fails.</summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="s">The name or numeric value to parse.</param>
+    /// <param name="ignoreCase">When <c>true</c>, the name comparison is case-insensitive.</param>
     public static TEnum? AsEnum<TEnum>(this string? s, bool ignoreCase = false)
         where TEnum : struct, Enum =>
         Enum.TryParse<TEnum>(s, ignoreCase, out var v) ? v : null;
@@ -69,11 +60,9 @@ public static class StringExtensions
     // --- these delegate to the framework's Parse methods, which throw ---
     // --- FormatException / OverflowException / ArgumentNullException. ---
 
-    /// <summary>
-    /// Returns a <see cref="NonEmptyString"/> wrapping <paramref name="s"/>.
-    /// Throws <see cref="ArgumentException"/> when <paramref name="s"/> is null,
-    /// empty, or whitespace.
-    /// </summary>
+    /// <summary>Wraps <paramref name="s"/> as a <see cref="NonEmptyString"/>.</summary>
+    /// <param name="s">The string to validate.</param>
+    /// <exception cref="ArgumentException"><paramref name="s"/> is null, empty, or whitespace.</exception>
     public static NonEmptyString ToNonEmpty(this string? s) => NonEmptyString.Create(s);
 
     public static byte ToByte(this string? s, IFormatProvider? format = null, NumberStyles style = NumberStyles.Integer) =>
@@ -109,10 +98,11 @@ public static class StringExtensions
 
     public static Guid ToGuidExact(this string? s, string format = "D") => Guid.ParseExact(s!, format);
 
-    /// <summary>
-    /// Parses <paramref name="s"/> as a member of <typeparamref name="TEnum"/>.
-    /// Throws when parsing fails.
-    /// </summary>
+    /// <summary>Parses <paramref name="s"/> as a member of <typeparamref name="TEnum"/>.</summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="s">The name or numeric value to parse.</param>
+    /// <param name="ignoreCase">When <c>true</c>, the name comparison is case-insensitive.</param>
+    /// <exception cref="ArgumentException">Parsing fails.</exception>
     public static TEnum ToEnum<TEnum>(this string? s, bool ignoreCase = false)
         where TEnum : struct, Enum =>
         Enum.Parse<TEnum>(s!, ignoreCase);


### PR DESCRIPTION
## Summary
- Walks every documented public member in `StrongTypes`, `StrongTypes.EfCore`, and `StrongTypes.FsCheck`.
- Splits parameter semantics out of `<summary>` into `<param>`/`<typeparam>`/`<returns>`/`<exception>` tags; trims multi-paragraph rationale and implementation/design commentary that doesn't help the caller.
- Adds `<param>`/`<typeparam>`/`<exception>` metadata to members that already had summaries but no parameter documentation — so even simple summaries now carry useful caller-facing contract info.

Closes #64.

## Test plan
- [ ] `dotnet build` — 0 warnings, 0 errors
- [ ] Hover-preview a few tweaked members in an IDE to verify IntelliSense reads well
- [ ] Spot-check that no behaviour changed — this PR touches only doc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)