### PR TITLE
Extend FsCheck generators; lower None frequencies to ~5%

### DIFF
--- a/src/StrongTypes.FsCheck/Generators.cs
+++ b/src/StrongTypes.FsCheck/Generators.cs
@@ -4,9 +4,11 @@ using FsCheck.Fluent;
 namespace StrongTypes.FsCheck;
 
 /// <summary>Shared FsCheck arbitraries for StrongTypes.</summary>
-/// <remarks>Reference via <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c> on a test class.</remarks>
+/// <remarks>Reference via <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c> on a test class. Every strong type ships three shapes: the type itself, its nullable form (~5% <c>null</c>), and <c>Maybe&lt;T&gt;</c> (~5% <c>None</c>).</remarks>
 public static class Generators
 {
+    #region NonEmptyString
+
     /// <summary>Arbitrary <see cref="NonEmptyString"/> values.</summary>
     public static Arbitrary<NonEmptyString> NonEmptyString { get; } =
         Arb.From(ArbMap.Default.ArbFor<string>().Generator
@@ -19,57 +21,25 @@ public static class Generators
             (1, Gen.Constant<NonEmptyString?>(null)),
             (19, NonEmptyString.Generator.Select(nes => (NonEmptyString?)nes))));
 
-    /// <summary>Arbitrary <see cref="Digit"/> values, uniformly over <c>0</c>–<c>9</c>.</summary>
-    public static Arbitrary<Digit> Digit { get; } =
-        Arb.From(Gen.Choose(0, 9).Select(n => StrongTypes.Digit.Create((char)('0' + n))));
-
-    /// <summary>Arbitrary <see cref="Positive{T}"/> of <see cref="int"/>.</summary>
-    public static Arbitrary<Positive<int>> PositiveInt { get; } =
-        Arb.From(ArbMap.Default.ArbFor<int>().Generator
-            .Where(i => i > 0)
-            .Select(i => i.ToPositive()));
-
-    /// <summary>Arbitrary <see cref="Negative{T}"/> of <see cref="int"/>.</summary>
-    public static Arbitrary<Negative<int>> NegativeInt { get; } =
-        Arb.From(ArbMap.Default.ArbFor<int>().Generator
-            .Where(i => i < 0)
-            .Select(i => i.ToNegative()));
-
-    /// <summary>Arbitrary <see cref="NonNegative{T}"/> of <see cref="int"/>.</summary>
-    public static Arbitrary<NonNegative<int>> NonNegativeInt { get; } =
-        Arb.From(ArbMap.Default.ArbFor<int>().Generator
-            .Where(i => i >= 0)
-            .Select(i => i.ToNonNegative()));
-
-    /// <summary>Arbitrary <see cref="NonPositive{T}"/> of <see cref="int"/>.</summary>
-    public static Arbitrary<NonPositive<int>> NonPositiveInt { get; } =
-        Arb.From(ArbMap.Default.ArbFor<int>().Generator
-            .Where(i => i <= 0)
-            .Select(i => i.ToNonPositive()));
-
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
-    public static Arbitrary<Maybe<int>> MaybeInt { get; } =
-        Arb.From(Gen.Frequency(
-            (1, Gen.Constant(Maybe<int>.None)),
-            (19, ArbMap.Default.ArbFor<int>().Generator.Select(Maybe.Some))));
-
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="string"/>, with ~5% <c>None</c>. Empty and whitespace strings remain valid <c>Some</c> values; use <see cref="MaybeNonEmptyString"/> for the non-empty invariant.</summary>
-    public static Arbitrary<Maybe<string>> MaybeString { get; } =
-        Arb.From(Gen.Frequency(
-            (1, Gen.Constant(Maybe<string>.None)),
-            (19, ArbMap.Default.ArbFor<string>().Generator.Select(Maybe.Some))));
-
     /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyString"/>, with ~5% <c>None</c>.</summary>
     public static Arbitrary<Maybe<NonEmptyString>> MaybeNonEmptyString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<NonEmptyString>.None)),
             (19, NonEmptyString.Generator.Select(Maybe.Some))));
 
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Positive{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
-    public static Arbitrary<Maybe<Positive<int>>> MaybePositiveInt { get; } =
+    #endregion
+
+    #region Digit
+
+    /// <summary>Arbitrary <see cref="Digit"/> values, uniformly over <c>0</c>–<c>9</c>.</summary>
+    public static Arbitrary<Digit> Digit { get; } =
+        Arb.From(Gen.Choose(0, 9).Select(n => StrongTypes.Digit.Create((char)('0' + n))));
+
+    /// <summary>Arbitrary <see cref="Digit"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<Digit?> NullableDigit { get; } =
         Arb.From(Gen.Frequency(
-            (1, Gen.Constant(Maybe<Positive<int>>.None)),
-            (19, PositiveInt.Generator.Select(Maybe.Some))));
+            (1, Gen.Constant<Digit?>(null)),
+            (19, Digit.Generator.Select(d => (Digit?)d))));
 
     /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="StrongTypes.Digit"/>, with ~5% <c>None</c>.</summary>
     public static Arbitrary<Maybe<Digit>> MaybeDigit { get; } =
@@ -77,10 +47,164 @@ public static class Generators
             (1, Gen.Constant(Maybe<Digit>.None)),
             (19, Digit.Generator.Select(Maybe.Some))));
 
+    #endregion
+
+    #region Positive<int>
+
+    /// <summary>Arbitrary <see cref="Positive{T}"/> of <see cref="int"/>.</summary>
+    public static Arbitrary<Positive<int>> PositiveInt { get; } =
+        Arb.From(ArbMap.Default.ArbFor<int>().Generator
+            .Where(i => i > 0)
+            .Select(i => i.ToPositive()));
+
+    /// <summary>Arbitrary <see cref="Positive{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<Positive<int>?> NullablePositiveInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant<Positive<int>?>(null)),
+            (19, PositiveInt.Generator.Select(p => (Positive<int>?)p))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Positive{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<Positive<int>>> MaybePositiveInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<Positive<int>>.None)),
+            (19, PositiveInt.Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region Negative<int>
+
+    /// <summary>Arbitrary <see cref="Negative{T}"/> of <see cref="int"/>.</summary>
+    public static Arbitrary<Negative<int>> NegativeInt { get; } =
+        Arb.From(ArbMap.Default.ArbFor<int>().Generator
+            .Where(i => i < 0)
+            .Select(i => i.ToNegative()));
+
+    /// <summary>Arbitrary <see cref="Negative{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<Negative<int>?> NullableNegativeInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant<Negative<int>?>(null)),
+            (19, NegativeInt.Generator.Select(n => (Negative<int>?)n))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Negative{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<Negative<int>>> MaybeNegativeInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<Negative<int>>.None)),
+            (19, NegativeInt.Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region NonNegative<int>
+
+    /// <summary>Arbitrary <see cref="NonNegative{T}"/> of <see cref="int"/>.</summary>
+    public static Arbitrary<NonNegative<int>> NonNegativeInt { get; } =
+        Arb.From(ArbMap.Default.ArbFor<int>().Generator
+            .Where(i => i >= 0)
+            .Select(i => i.ToNonNegative()));
+
+    /// <summary>Arbitrary <see cref="NonNegative{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<NonNegative<int>?> NullableNonNegativeInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant<NonNegative<int>?>(null)),
+            (19, NonNegativeInt.Generator.Select(n => (NonNegative<int>?)n))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonNegative{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<NonNegative<int>>> MaybeNonNegativeInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<NonNegative<int>>.None)),
+            (19, NonNegativeInt.Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region NonPositive<int>
+
+    /// <summary>Arbitrary <see cref="NonPositive{T}"/> of <see cref="int"/>.</summary>
+    public static Arbitrary<NonPositive<int>> NonPositiveInt { get; } =
+        Arb.From(ArbMap.Default.ArbFor<int>().Generator
+            .Where(i => i <= 0)
+            .Select(i => i.ToNonPositive()));
+
+    /// <summary>Arbitrary <see cref="NonPositive{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<NonPositive<int>?> NullableNonPositiveInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant<NonPositive<int>?>(null)),
+            (19, NonPositiveInt.Generator.Select(n => (NonPositive<int>?)n))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonPositive{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<NonPositive<int>>> MaybeNonPositiveInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<NonPositive<int>>.None)),
+            (19, NonPositiveInt.Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region NonEmptyEnumerable<int>
+
     /// <summary>Arbitrary <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<NonEmptyEnumerable<int>> NonEmptyEnumerableInt { get; } =
         Arb.From(Gen.NonEmptyListOf(ArbMap.Default.ArbFor<int>().Generator)
             .Select(list => NonEmptyEnumerable.CreateRange(list)));
+
+    /// <summary>Arbitrary <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
+    public static Arbitrary<NonEmptyEnumerable<int>?> NullableNonEmptyEnumerableInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant<NonEmptyEnumerable<int>?>(null)),
+            (19, NonEmptyEnumerableInt.Generator.Select(n => (NonEmptyEnumerable<int>?)n))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<NonEmptyEnumerable<int>>> MaybeNonEmptyEnumerableInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<NonEmptyEnumerable<int>>.None)),
+            (19, NonEmptyEnumerableInt.Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region Maybe<primitive>
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="bool"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<bool>> MaybeBool { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<bool>.None)),
+            (19, ArbMap.Default.ArbFor<bool>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<int>> MaybeInt { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<int>.None)),
+            (19, ArbMap.Default.ArbFor<int>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="long"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<long>> MaybeLong { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<long>.None)),
+            (19, ArbMap.Default.ArbFor<long>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="double"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<double>> MaybeDouble { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<double>.None)),
+            (19, ArbMap.Default.ArbFor<double>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="char"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<char>> MaybeChar { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<char>.None)),
+            (19, ArbMap.Default.ArbFor<char>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="string"/>, with ~5% <c>None</c>. Empty and whitespace strings remain valid <c>Some</c> values; use <see cref="MaybeNonEmptyString"/> for the non-empty invariant.</summary>
+    public static Arbitrary<Maybe<string>> MaybeString { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<string>.None)),
+            (19, ArbMap.Default.ArbFor<string>().Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="System.Guid"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<System.Guid>> MaybeGuid { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<System.Guid>.None)),
+            (19, ArbMap.Default.ArbFor<System.Guid>().Generator.Select(Maybe.Some))));
+
+    #endregion
+
+    #region Result
 
     /// <summary>Arbitrary <see cref="Result{T, TError}"/> of <c>int</c>/<c>string</c>, with a roughly even split between successes and errors.</summary>
     public static Arbitrary<Result<int, string>> ResultIntString { get; } =
@@ -94,4 +218,6 @@ public static class Generators
             (1, ArbMap.Default.ArbFor<int>().Generator.Select(i => (Result<int>)i)),
             (1, ArbMap.Default.ArbFor<string>().Generator
                 .Select(s => (Result<int>)new System.InvalidOperationException(s)))));
+
+    #endregion
 }

--- a/src/StrongTypes.FsCheck/Generators.cs
+++ b/src/StrongTypes.FsCheck/Generators.cs
@@ -13,11 +13,15 @@ public static class Generators
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .Select(s => s.ToNonEmpty()));
 
-    /// <summary>Arbitrary <see cref="NonEmptyString"/> or <c>null</c>, with ~10% <c>null</c>.</summary>
+    /// <summary>Arbitrary <see cref="NonEmptyString"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
     public static Arbitrary<NonEmptyString?> NullableNonEmptyString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant<NonEmptyString?>(null)),
-            (9, NonEmptyString.Generator.Select(nes => (NonEmptyString?)nes))));
+            (19, NonEmptyString.Generator.Select(nes => (NonEmptyString?)nes))));
+
+    /// <summary>Arbitrary <see cref="Digit"/> values, uniformly over <c>0</c>–<c>9</c>.</summary>
+    public static Arbitrary<Digit> Digit { get; } =
+        Arb.From(Gen.Choose(0, 9).Select(n => StrongTypes.Digit.Create((char)('0' + n))));
 
     /// <summary>Arbitrary <see cref="Positive{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<Positive<int>> PositiveInt { get; } =
@@ -43,29 +47,35 @@ public static class Generators
             .Where(i => i <= 0)
             .Select(i => i.ToNonPositive()));
 
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="int"/>, with ~20% <c>None</c>.</summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
     public static Arbitrary<Maybe<int>> MaybeInt { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<int>.None)),
-            (4, ArbMap.Default.ArbFor<int>().Generator.Select(Maybe.Some))));
+            (19, ArbMap.Default.ArbFor<int>().Generator.Select(Maybe.Some))));
 
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="string"/>, with ~20% <c>None</c>. Empty and whitespace strings remain valid <c>Some</c> values; use <see cref="MaybeNonEmptyString"/> for the non-empty invariant.</summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="string"/>, with ~5% <c>None</c>. Empty and whitespace strings remain valid <c>Some</c> values; use <see cref="MaybeNonEmptyString"/> for the non-empty invariant.</summary>
     public static Arbitrary<Maybe<string>> MaybeString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<string>.None)),
-            (4, ArbMap.Default.ArbFor<string>().Generator.Select(Maybe.Some))));
+            (19, ArbMap.Default.ArbFor<string>().Generator.Select(Maybe.Some))));
 
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyString"/>, with ~20% <c>None</c>.</summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyString"/>, with ~5% <c>None</c>.</summary>
     public static Arbitrary<Maybe<NonEmptyString>> MaybeNonEmptyString { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<NonEmptyString>.None)),
-            (4, NonEmptyString.Generator.Select(Maybe.Some))));
+            (19, NonEmptyString.Generator.Select(Maybe.Some))));
 
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Positive{T}"/> of <see cref="int"/>, with ~20% <c>None</c>.</summary>
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="Positive{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
     public static Arbitrary<Maybe<Positive<int>>> MaybePositiveInt { get; } =
         Arb.From(Gen.Frequency(
             (1, Gen.Constant(Maybe<Positive<int>>.None)),
-            (4, PositiveInt.Generator.Select(Maybe.Some))));
+            (19, PositiveInt.Generator.Select(Maybe.Some))));
+
+    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="StrongTypes.Digit"/>, with ~5% <c>None</c>.</summary>
+    public static Arbitrary<Maybe<Digit>> MaybeDigit { get; } =
+        Arb.From(Gen.Frequency(
+            (1, Gen.Constant(Maybe<Digit>.None)),
+            (19, Digit.Generator.Select(Maybe.Some))));
 
     /// <summary>Arbitrary <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/>.</summary>
     public static Arbitrary<NonEmptyEnumerable<int>> NonEmptyEnumerableInt { get; } =

--- a/src/StrongTypes.FsCheck/Generators.cs
+++ b/src/StrongTypes.FsCheck/Generators.cs
@@ -4,7 +4,7 @@ using FsCheck.Fluent;
 namespace StrongTypes.FsCheck;
 
 /// <summary>Shared FsCheck arbitraries for StrongTypes.</summary>
-/// <remarks>Reference via <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c> on a test class. Every strong type ships three shapes: the type itself, its nullable form (~5% <c>null</c>), and <c>Maybe&lt;T&gt;</c> (~5% <c>None</c>).</remarks>
+/// <remarks>Reference via <c>[Properties(Arbitrary = new[] { typeof(Generators) })]</c> on a test class. Scalar strong types ship three shapes: the type itself, its nullable form (~5% <c>null</c>), and <c>Maybe&lt;T&gt;</c> (~5% <c>None</c>).</remarks>
 public static class Generators
 {
     #region NonEmptyString
@@ -143,18 +143,6 @@ public static class Generators
     public static Arbitrary<NonEmptyEnumerable<int>> NonEmptyEnumerableInt { get; } =
         Arb.From(Gen.NonEmptyListOf(ArbMap.Default.ArbFor<int>().Generator)
             .Select(list => NonEmptyEnumerable.CreateRange(list)));
-
-    /// <summary>Arbitrary <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/> or <c>null</c>, with ~5% <c>null</c>.</summary>
-    public static Arbitrary<NonEmptyEnumerable<int>?> NullableNonEmptyEnumerableInt { get; } =
-        Arb.From(Gen.Frequency(
-            (1, Gen.Constant<NonEmptyEnumerable<int>?>(null)),
-            (19, NonEmptyEnumerableInt.Generator.Select(n => (NonEmptyEnumerable<int>?)n))));
-
-    /// <summary>Arbitrary <see cref="Maybe{T}"/> of <see cref="NonEmptyEnumerable{T}"/> of <see cref="int"/>, with ~5% <c>None</c>.</summary>
-    public static Arbitrary<Maybe<NonEmptyEnumerable<int>>> MaybeNonEmptyEnumerableInt { get; } =
-        Arb.From(Gen.Frequency(
-            (1, Gen.Constant(Maybe<NonEmptyEnumerable<int>>.None)),
-            (19, NonEmptyEnumerableInt.Generator.Select(Maybe.Some))));
 
     #endregion
 

--- a/src/StrongTypes.FsCheck/readme.md
+++ b/src/StrongTypes.FsCheck/readme.md
@@ -3,9 +3,9 @@
 
 FsCheck arbitraries for [Kalicz.StrongTypes](https://www.nuget.org/packages/Kalicz.StrongTypes).
 Lets you write property tests against code that takes or returns `NonEmptyString`,
-`Positive<T>`, `NonNegative<T>`, `Negative<T>`, `NonPositive<T>`, `Maybe<T>`, and
-`NonEmptyEnumerable<T>` without hand-rolling generators that re-derive each type's
-invariants.
+`Digit`, `Positive<T>`, `NonNegative<T>`, `Negative<T>`, `NonPositive<T>`, `Maybe<T>`,
+and `NonEmptyEnumerable<T>` without hand-rolling generators that re-derive each
+type's invariants.
 
 ## Install
 
@@ -41,10 +41,11 @@ public class MyTests
 ## What ships
 
 - `NonEmptyString` — filtered to non-null, non-whitespace values
-- `NullableNonEmptyString` — ~10% null injection
+- `NullableNonEmptyString` — ~5% null injection
+- `Digit` — uniform over `0`–`9`
 - `Positive<int>`, `Negative<int>`, `NonNegative<int>`, `NonPositive<int>`
-- `Maybe<int>`, `Maybe<string>`, `Maybe<NonEmptyString>`, `Maybe<Positive<int>>` —
-  ~20% `None` injection
+- `Maybe<int>`, `Maybe<string>`, `Maybe<NonEmptyString>`, `Maybe<Positive<int>>`,
+  `Maybe<Digit>` — ~5% `None` injection
 - `NonEmptyEnumerable<int>`
 
 Version matches the core `Kalicz.StrongTypes` package you install alongside it.

--- a/src/StrongTypes.FsCheck/readme.md
+++ b/src/StrongTypes.FsCheck/readme.md
@@ -52,12 +52,9 @@ Scalar strong types ship three shapes: the type itself, its nullable form
 | `NonNegative<int>`   | `NonNegativeInt`| `NullableNonNegativeInt`| `MaybeNonNegativeInt`   |
 | `NonPositive<int>`   | `NonPositiveInt`| `NullableNonPositiveInt`| `MaybeNonPositiveInt`   |
 
-`NonEmptyString` is filtered to non-null, non-whitespace values; `Digit`
-is uniform over `0`–`9`.
+Apart from the above, you also get:
 
-Collections and `Maybe<primitive>` don't follow the three-column shape:
-
-- `NonEmptyEnumerableInt` — `NonEmptyEnumerable<int>`, plain `T` only.
+- `NonEmptyEnumerableInt` — `NonEmptyEnumerable<int>`
 - `Maybe<T>` for common primitives: `MaybeBool`, `MaybeInt`, `MaybeLong`,
   `MaybeDouble`, `MaybeChar`, `MaybeString`, `MaybeGuid` — all with ~5% `None`.
 

--- a/src/StrongTypes.FsCheck/readme.md
+++ b/src/StrongTypes.FsCheck/readme.md
@@ -40,12 +40,14 @@ public class MyTests
 
 ## What ships
 
+Every strong type ships three shapes: the type itself, its nullable form
+(`T?`, ~5% `null`), and `Maybe<T>` (~5% `None`).
+
 - `NonEmptyString` — filtered to non-null, non-whitespace values
-- `NullableNonEmptyString` — ~5% null injection
 - `Digit` — uniform over `0`–`9`
 - `Positive<int>`, `Negative<int>`, `NonNegative<int>`, `NonPositive<int>`
-- `Maybe<int>`, `Maybe<string>`, `Maybe<NonEmptyString>`, `Maybe<Positive<int>>`,
-  `Maybe<Digit>` — ~5% `None` injection
 - `NonEmptyEnumerable<int>`
+- `Maybe<T>` for common primitives: `bool`, `int`, `long`, `double`, `char`,
+  `string`, `Guid`
 
 Version matches the core `Kalicz.StrongTypes` package you install alongside it.

--- a/src/StrongTypes.FsCheck/readme.md
+++ b/src/StrongTypes.FsCheck/readme.md
@@ -43,11 +43,22 @@ public class MyTests
 Scalar strong types ship three shapes: the type itself, its nullable form
 (`T?`, ~5% `null`), and `Maybe<T>` (~5% `None`).
 
-- `NonEmptyString` — filtered to non-null, non-whitespace values
-- `Digit` — uniform over `0`–`9`
-- `Positive<int>`, `Negative<int>`, `NonNegative<int>`, `NonPositive<int>`
-- `NonEmptyEnumerable<int>` — `T` only
-- `Maybe<T>` for common primitives: `bool`, `int`, `long`, `double`, `char`,
-  `string`, `Guid`
+| Type                 | `T`             | `T?`                    | `Maybe<T>`              |
+| -------------------- | --------------- | ----------------------- | ----------------------- |
+| `NonEmptyString`     | `NonEmptyString`| `NullableNonEmptyString`| `MaybeNonEmptyString`   |
+| `Digit`              | `Digit`         | `NullableDigit`         | `MaybeDigit`            |
+| `Positive<int>`      | `PositiveInt`   | `NullablePositiveInt`   | `MaybePositiveInt`      |
+| `Negative<int>`      | `NegativeInt`   | `NullableNegativeInt`   | `MaybeNegativeInt`      |
+| `NonNegative<int>`   | `NonNegativeInt`| `NullableNonNegativeInt`| `MaybeNonNegativeInt`   |
+| `NonPositive<int>`   | `NonPositiveInt`| `NullableNonPositiveInt`| `MaybeNonPositiveInt`   |
+
+`NonEmptyString` is filtered to non-null, non-whitespace values; `Digit`
+is uniform over `0`–`9`.
+
+Collections and `Maybe<primitive>` don't follow the three-column shape:
+
+- `NonEmptyEnumerableInt` — `NonEmptyEnumerable<int>`, plain `T` only.
+- `Maybe<T>` for common primitives: `MaybeBool`, `MaybeInt`, `MaybeLong`,
+  `MaybeDouble`, `MaybeChar`, `MaybeString`, `MaybeGuid` — all with ~5% `None`.
 
 Version matches the core `Kalicz.StrongTypes` package you install alongside it.

--- a/src/StrongTypes.FsCheck/readme.md
+++ b/src/StrongTypes.FsCheck/readme.md
@@ -40,13 +40,13 @@ public class MyTests
 
 ## What ships
 
-Every strong type ships three shapes: the type itself, its nullable form
+Scalar strong types ship three shapes: the type itself, its nullable form
 (`T?`, ~5% `null`), and `Maybe<T>` (~5% `None`).
 
 - `NonEmptyString` — filtered to non-null, non-whitespace values
 - `Digit` — uniform over `0`–`9`
 - `Positive<int>`, `Negative<int>`, `NonNegative<int>`, `NonPositive<int>`
-- `NonEmptyEnumerable<int>`
+- `NonEmptyEnumerable<int>` — `T` only
 - `Maybe<T>` for common primitives: `bool`, `int`, `long`, `double`, `char`,
   `string`, `Guid`
 


### PR DESCRIPTION
## Summary
- Add `Digit` and `Maybe<Digit>` arbitraries — `Digit` was the only public strong type without a generator.
- Drop null / `None` injection from ~10–20% to ~5% on `NullableNonEmptyString` and every `Maybe<T>` arbitrary. 1-in-20 is enough to hit the empty branch under FsCheck's default run count without crowding out the populated case.
- Left `Result<int, string>` and `Result<int>` at their 50/50 split — both sides of a `Result` are first-class outcomes, not an "empty" case.
- Updated the package readme to match.

## Test plan
- [x] `dotnet build src/StrongTypes.FsCheck` — clean
- [x] `dotnet test src/StrongTypes.Tests` — 945 passed, 0 failed