### PR TITLE
Pin NuGet readme diagram URLs to the release tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -602,3 +602,5 @@ Result<Positive<int>[], string> ParseOrderQuantities(IEnumerable<int> inputs)
 This library is vaguely based on [FuncSharp](https://github.com/MewsSystems/FuncSharp) by [Honza Siroky](https://github.com/siroky), bringing some of the concepts into modern C# and .NET.
 
 Licensed under the [MIT License](license.txt).
+
+[↑ Back to top](#contents)

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,9 @@ Every type ships with `System.Text.Json` converters out of the box (except `Resu
 
 You can also store the types directly in your EF Core entities with the use of the EfCore package.
 
-<img src="docs/diagrams/impact.svg" alt="Impact of StrongTypes on validation boundaries" width="990" height="760" />
+![Impact of StrongTypes on validation boundaries](docs/diagrams/impact.svg)
 
-<img src="docs/diagrams/package-layout.svg" alt="Package layout" width="680" />
+![Package layout](docs/diagrams/package-layout.svg)
 
 ## Contents
 
@@ -33,6 +33,10 @@ You can also store the types directly in your EF Core entities with the use of t
 
 ## Helpful Types
 
+The `TryCreate` / `Create` split (and the `As…` / `To…` extensions that mirror it) is used across every validated type in the library — pick the factory that matches how you want to handle bad input at the call site:
+
+![TryCreate vs Create flow](docs/diagrams/trycreate-create-flow.svg)
+
 ### `NonEmptyString`
 
 A string guaranteed to be non-null, non-empty, and not just whitespace. Construct it via the factory pair:
@@ -45,10 +49,6 @@ NonEmptyString? name = NonEmptyString.TryCreate(input);
 NonEmptyString name = NonEmptyString.Create(input);
 ```
 
-The `TryCreate` / `Create` split (and the `As…` / `To…` extensions that mirror it) is used across every validated type in the library — pick the factory that matches how you want to handle bad input at the call site:
-
-<img src="docs/diagrams/trycreate-create-flow.svg" alt="TryCreate vs Create flow" width="900" />
-
 Or via the `AsNonEmpty()` extension on any `string?`:
 
 ```csharp
@@ -56,6 +56,8 @@ NonEmptyString? name = userInput.AsNonEmpty();
 ```
 
 `NonEmptyString` exposes the common `string` surface (`Length`, `Contains`, `StartsWith`, `Substring`, `ToUpper`, …) and implicitly converts to `string`.
+
+[↑ Back to top](#contents)
 
 ### Numeric wrappers
 
@@ -97,6 +99,8 @@ NonPositive<decimal> loss = pnl.ToNonPositive();
 
 `default(Positive<T>)` still satisfies the invariant (e.g. `default(Positive<int>)` is `1`, not an invalid `0`), so the structs survive zero-initialization without breaking their guarantee.
 
+[↑ Back to top](#contents)
+
 ### What you get for free
 
 Every strong type in this library implements the full set of equality and comparison interfaces, so you can drop them into dictionaries, sorted collections, LINQ `OrderBy`, and equality checks without writing any boilerplate:
@@ -106,6 +110,8 @@ Every strong type in this library implements the full set of equality and compar
 - `GetHashCode` and `Equals(object?)` overrides consistent with value-based equality
 - A sensible `ToString()` that returns the underlying value
 
+[↑ Back to top](#contents)
+
 ### JSON serialization
 
 All strong types ship with `System.Text.Json` converters attached via `[JsonConverter]` — no converter registration and no custom `JsonSerializerOptions` required. The format is the same as the underlying primitive (`"hello"`, `42`, …), and invalid input surfaces as a `JsonException`.
@@ -114,9 +120,13 @@ All strong types ship with `System.Text.Json` converters attached via `[JsonConv
 
 `Result<T, TError>` (and `Result<T>`) has no JSON converter I don't think you want to serialize that.
 
+[↑ Back to top](#contents)
+
 ### EF Core persistence
 
 If you want to store strong types directly on your EF Core entities, add the companion package [`Kalicz.StrongTypes.EfCore`](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/). It provides the value converters needed to map `NonEmptyString`, `Positive<T>`, and other numeric types to their underlying column types. See the package [readme](https://github.com/KaliCZ/StrongTypes/blob/main/src/StrongTypes.EfCore/readme.md) for setup details.
+
+[↑ Back to top](#contents)
 
 ## `NonEmptyEnumerable<T>`
 
@@ -180,9 +190,11 @@ NonEmptyEnumerable<Dog>      dogs    = [new Dog()];
 INonEmptyEnumerable<Animal>  animals = dogs;  // allowed thanks to `out T`
 ```
 
-<img src="docs/diagrams/covariance.svg" alt="Covariant out T upcast" width="900" />
+![Covariant out T upcast](docs/diagrams/covariance.svg)
 
 All extensions (`Select`, `Concat`, `Max`, `Last`, …) have overloads on both the concrete type and the interface, so either receiver type works in a chain.
+
+[↑ Back to top](#contents)
 
 ### JSON
 
@@ -191,6 +203,8 @@ Serializes as a JSON array; an empty JSON array is rejected with `JsonException`
 > ⚠ **Null elements in reference-typed collections** — a JSON array like `[null]` deserializes successfully into `NonEmptyEnumerable<string>` or `NonEmptyEnumerable<NonEmptyString>` even though the element type isn't annotated nullable. The same would happen with a plain `List<string>`.
 
 The same converter also serves `INonEmptyEnumerable<T>`, so properties typed as the interface round-trip the same way — deserialization still produces a concrete `NonEmptyEnumerable<T>` behind the interface reference.
+
+[↑ Back to top](#contents)
 
 ## Parsing helpers
 
@@ -238,6 +252,8 @@ foreach (var flag in user.GetFlags())
 
 The flag helpers throw `InvalidOperationException` if the enum isn't marked `[Flags]`, so a typo at the declaration fails loudly at the first call instead of silently returning the wrong thing.
 
+[↑ Back to top](#contents)
+
 ### Strings
 
 A small set of extension methods over `string?` for safe, nullable-returning parses:
@@ -259,6 +275,8 @@ Roles          role = header.ToEnum<Roles>();   // throws ArgumentException
 ```
 
 `AsEnum<TEnum>` / `ToEnum<TEnum>` work through an open generic `TEnum` parameter, which the `Roles.TryParse(...)` extension member can't — use them when you only know the enum type generically.
+
+[↑ Back to top](#contents)
 
 ## Algebraic types
 
@@ -306,6 +324,8 @@ string? normalized = maybeName.Value is {} n
 > [!WARNING]
 > `Map` / `MapTrue` / `MapFalse` are slower than the equivalent ternary. The mapper is passed as a delegate, so the JIT has to go through a function-pointer invocation instead of the direct branch it gets from a `?:`. Prefer the ternary on hot paths; reach for `Map` where readability matters more than the nanoseconds.
 
+[↑ Back to top](#contents)
+
 ### `Maybe<T>`
 
 A value type that holds either a value of `T` (`Some`) or no value (`None`). Works for both reference and value types and integrates with collection expressions, LINQ, pattern matching, and `System.Text.Json`.
@@ -316,7 +336,7 @@ The generic constraint is `where T : notnull` — `Maybe<int?>` and `Maybe<strin
 
 HTTP `PATCH` has a long-standing modelling problem for nullable fields: a request needs to distinguish three intents — *don't touch this field*, *clear this field to null*, and *set it to a new value*. A plain `T?` collapses the first two cases. `Maybe<T>?` keeps them apart, because `Maybe<T>` itself is a value, so wrapping it in `T?` adds a real third state:
 
-<img src="docs/diagrams/patch-three-state.svg" alt="PATCH three-state model" width="900" />
+![PATCH three-state model](docs/diagrams/patch-three-state.svg)
 
 The request DTO and PATCH handler then read straight off pattern matching, with no out-of-band sentinel values:
 
@@ -384,7 +404,7 @@ var label = maybe.Match(
 
 `Maybe<T>` composes monadically through `Map`, `FlatMap`, and `Where`. Each operation is a no-op on `None`, so chains short-circuit cleanly without explicit null checks:
 
-<img src="docs/diagrams/maybe-composition.svg" alt="Maybe composition pipeline" width="900" />
+![Maybe composition pipeline](docs/diagrams/maybe-composition.svg)
 
 ```csharp
 // Map — transform the inner value when present.
@@ -421,6 +441,8 @@ var missing =
 #### JSON
 
 `Maybe<T>` serializes via `System.Text.Json` as `{ "Value": x }` for `Some` and `{ "Value": null }` for `None` — no converter registration or custom `JsonSerializerOptions` needed. Deserialization also accepts `{}` for `None`, so callers can omit the property entirely.
+
+[↑ Back to top](#contents)
 
 ### `Result<T, TError>`
 
@@ -498,7 +520,7 @@ public Result<Order, OrderError> CreateOrder(OrderData data)
 
 `Map`, `MapError`, `Match`, and `FlatMap` let you chain without explicit branching. Success and error values flow down independent tracks — `Map` only touches the success side, `MapError` only touches the error side, and `FlatMap` short-circuits on error:
 
-<img src="docs/diagrams/result-composition.svg" alt="Result composition pipeline" width="900" />
+![Result composition pipeline](docs/diagrams/result-composition.svg)
 
 
 ```csharp
@@ -572,6 +594,8 @@ Result<Positive<int>[], string> ParseOrderQuantities(IEnumerable<int> inputs)
         invalidNumbers => $"Some numbers are not positive: [{string.Join(", ", invalidNumbers)}]");
 }
 ```
+
+[↑ Back to top](#contents)
 
 ## Acknowledgments
 

--- a/src/StrongTypes/StrongTypes.csproj
+++ b/src/StrongTypes/StrongTypes.csproj
@@ -58,7 +58,7 @@
                               PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
-  <!-- Rewrite the readme's diagram <img src="docs/diagrams/..."> paths to absolute
+  <!-- Rewrite the readme's diagram `![alt](docs/diagrams/...)` paths to absolute
        URLs pinned to the release tag before packing. The source readme.md keeps
        relative paths so GitHub browsing (both HEAD and per-tag views) resolves
        diagrams against the corresponding commit; the packed copy points at a
@@ -74,7 +74,7 @@
     <Task>
       <Code Type="Fragment" Language="cs"><![CDATA[
         var content = System.IO.File.ReadAllText(SourcePath);
-        content = content.Replace("src=\"docs/diagrams/", "src=\"" + BaseUrl);
+        content = content.Replace("](docs/diagrams/", "](" + BaseUrl);
         System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(DestinationPath));
         System.IO.File.WriteAllText(DestinationPath, content);
       ]]></Code>

--- a/src/StrongTypes/StrongTypes.csproj
+++ b/src/StrongTypes/StrongTypes.csproj
@@ -58,7 +58,39 @@
                               PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
-  <ItemGroup>
-    <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
+  <!-- Rewrite the readme's diagram <img src="docs/diagrams/..."> paths to absolute
+       URLs pinned to the release tag before packing. The source readme.md keeps
+       relative paths so GitHub browsing (both HEAD and per-tag views) resolves
+       diagrams against the corresponding commit; the packed copy points at a
+       fixed tag so nuget.org renders the diagrams that shipped with that version,
+       even if the diagrams change on main later. Dev builds (Version=0.0.0-dev)
+       fall back to the main branch. -->
+  <UsingTask TaskName="_RewriteDiagramUrls" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <SourcePath ParameterType="System.String" Required="true" />
+      <DestinationPath ParameterType="System.String" Required="true" />
+      <BaseUrl ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var content = System.IO.File.ReadAllText(SourcePath);
+        content = content.Replace("src=\"docs/diagrams/", "src=\"" + BaseUrl);
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(DestinationPath));
+        System.IO.File.WriteAllText(DestinationPath, content);
+      ]]></Code>
+    </Task>
+  </UsingTask>
+  <Target Name="_GeneratePackedReadme" BeforeTargets="_GetPackageFiles">
+    <PropertyGroup>
+      <_ReadmeSourcePath>$(MSBuildThisFileDirectory)..\..\readme.md</_ReadmeSourcePath>
+      <_PackedReadmePath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)readme.md'))</_PackedReadmePath>
+      <_DiagramRef Condition="'$(Version)' != '' and '$(Version)' != '0.0.0-dev'">v$(Version)</_DiagramRef>
+      <_DiagramRef Condition="'$(_DiagramRef)' == ''">main</_DiagramRef>
+      <_DiagramBaseUrl>https://raw.githubusercontent.com/KaliCZ/StrongTypes/$(_DiagramRef)/docs/diagrams/</_DiagramBaseUrl>
+    </PropertyGroup>
+    <_RewriteDiagramUrls SourcePath="$(_ReadmeSourcePath)" DestinationPath="$(_PackedReadmePath)" BaseUrl="$(_DiagramBaseUrl)" />
+    <ItemGroup>
+      <None Include="$(_PackedReadmePath)" Pack="true" PackagePath="\" Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- The source `readme.md` keeps relative paths (`docs/diagrams/...`) so that GitHub browsing — both the HEAD view and per-tag views — resolves each diagram against the matching commit.
- Before packing, an inline MSBuild task in `src/StrongTypes/StrongTypes.csproj` rewrites those `<img src="docs/diagrams/...">` paths to absolute `raw.githubusercontent.com` URLs pinned to `v$(Version)`, so nuget.org renders whichever diagrams shipped with that version even if the diagrams later change on `main`.
- Dev builds (`Version=0.0.0-dev`) fall back to the `main` branch so local packaging still produces a readme with resolvable image URLs.

## Test plan
- [x] `dotnet build src/StrongTypes/StrongTypes.csproj -c Release -p:Version=1.2.3` — unpacked nupkg readme references `https://raw.githubusercontent.com/KaliCZ/StrongTypes/v1.2.3/docs/diagrams/...` for all 7 diagrams.
- [x] `dotnet build src/StrongTypes/StrongTypes.csproj -c Release` (no Version) — unpacked nupkg readme falls back to the `main` ref for all 7 diagrams.
- [ ] CI green.
- [ ] After merge, cut a test prerelease tag and confirm the nuget.org readme renders the SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)