### PR TITLE
Stop calling library types "value types"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,9 @@ outdated, not just what the task names. Do not port code verbatim.
 - Do not delete _Old files unless explicitly asked or unless the rule above
   applies.
 
-## Validated value types — the TryCreate / Create pattern
+## Validated types — the TryCreate / Create pattern
 
-For value types that enforce a validation rule (e.g., `NonEmptyString`,
+For types that enforce a validation rule (e.g., `NonEmptyString`,
 `PositiveInt`), follow this factory pattern:
 
 ```csharp

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -34,7 +34,7 @@
 
   <!-- Bullet 3: Useful Types with JSON converters -->
   <circle class="bullet" cx="156" cy="116" r="2.5"/>
-  <text class="body" x="166" y="120">Validated value types<tspan fill="#6B7280"> (with JSON converters)</tspan></text>
+  <text class="body" x="166" y="120">Validated types<tspan fill="#6B7280"> (with JSON converters)</tspan></text>
 
   <!-- Sub-bullets -->
   <circle class="sub-bullet" cx="185" cy="139" r="2.3"/>

--- a/readme.md
+++ b/readme.md
@@ -328,7 +328,7 @@ string? normalized = maybeName.Value is {} n
 
 ### `Maybe<T>`
 
-A `struct` that holds either a value of `T` (`Some`) or no value (`None`). Works for both reference and value types and integrates with collection expressions, LINQ, pattern matching, and `System.Text.Json`.
+A struct that holds either a value of `T` (`Some`) or no value (`None`). Works for both reference and value types and integrates with collection expressions, LINQ, pattern matching, and `System.Text.Json`.
 
 The generic constraint is `where T : notnull` — `Maybe<int?>` and `Maybe<string?>` are deliberately disallowed, because permitting a nullable `T` would collapse the `None` and `Some(null)` cases and break the `is { } v` unwrap pattern. (see more below)
 

--- a/readme.md
+++ b/readme.md
@@ -328,7 +328,7 @@ string? normalized = maybeName.Value is {} n
 
 ### `Maybe<T>`
 
-A value type that holds either a value of `T` (`Some`) or no value (`None`). Works for both reference and value types and integrates with collection expressions, LINQ, pattern matching, and `System.Text.Json`.
+A `struct` that holds either a value of `T` (`Some`) or no value (`None`). Works for both reference and value types and integrates with collection expressions, LINQ, pattern matching, and `System.Text.Json`.
 
 The generic constraint is `where T : notnull` — `Maybe<int?>` and `Maybe<string?>` are deliberately disallowed, because permitting a nullable `T` would collapse the `None` and `Some(null)` cases and break the `is { } v` unwrap pattern. (see more below)
 

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Collections/CollectionJsonTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Collections/CollectionJsonTests.cs
@@ -159,7 +159,7 @@ public sealed class CollectionJsonTests(TestWebApplicationFactory factory) : IDi
     }
 
     // ───────────────────────────────────────────────────────────────────
-    // Positive<int> — strong value type. Element null reachable for T? only.
+    // Positive<int> — strong type (struct). Element null reachable for T? only.
     // ───────────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/StrongTypes.Api/Controllers/StructTypeEntityControllerBase.cs
+++ b/src/StrongTypes.Api/Controllers/StructTypeEntityControllerBase.cs
@@ -6,7 +6,7 @@ using StrongTypes.Api.Models;
 namespace StrongTypes.Api.Controllers;
 
 /// <summary>
-/// Controller base for entities whose <typeparamref name="T"/> is a value type.
+/// Controller base for entities whose <typeparamref name="T"/> is a struct.
 /// <c>TNullable</c> is fixed to <c>T?</c> (i.e. <c>Nullable&lt;T&gt;</c>), which
 /// lets every conversion in PATCH be a direct nullable-value access — no boxing
 /// or runtime casts.

--- a/src/StrongTypes/Maybe/Maybe.cs
+++ b/src/StrongTypes/Maybe/Maybe.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace StrongTypes;
 
 /// <summary>A value that is either <c>Some(T)</c> or <c>None</c>.</summary>
-/// <typeparam name="T">The wrapped value type.</typeparam>
+/// <typeparam name="T">The wrapped type.</typeparam>
 /// <remarks>Unwrap with the extension-property pattern: <c>if (maybe.Value is {} v)</c>.</remarks>
 [JsonConverter(typeof(MaybeJsonConverterFactory))]
 public readonly struct Maybe<T> :
@@ -163,7 +163,7 @@ public readonly struct MaybeNone;
 public static class Maybe
 {
     /// <summary>Wraps <paramref name="value"/> as <see cref="Maybe{T}"/>.<c>Some</c>.</summary>
-    /// <typeparam name="T">The wrapped value type.</typeparam>
+    /// <typeparam name="T">The wrapped type.</typeparam>
     /// <param name="value">The value to wrap.</param>
     [Pure]
     public static Maybe<T> Some<T>(T value) where T : notnull => Maybe<T>.Some(value);

--- a/src/StrongTypes/Maybe/MaybeCollectionExtensions.cs
+++ b/src/StrongTypes/Maybe/MaybeCollectionExtensions.cs
@@ -76,7 +76,7 @@ public static class MaybeCollectionExtensions
 
     /// <summary>Projects each element with <paramref name="selector"/> and returns the maximum, or <c>None</c> when the sequence is empty.</summary>
     /// <typeparam name="T">The element type.</typeparam>
-    /// <typeparam name="TValue">The projected value type.</typeparam>
+    /// <typeparam name="TValue">The projected type.</typeparam>
     /// <param name="source">The sequence to scan.</param>
     /// <param name="selector">Projects each element.</param>
     [Pure]
@@ -103,7 +103,7 @@ public static class MaybeCollectionExtensions
 
     /// <summary>Projects each element with <paramref name="selector"/> and returns the minimum, or <c>None</c> when the sequence is empty.</summary>
     /// <typeparam name="T">The element type.</typeparam>
-    /// <typeparam name="TValue">The projected value type.</typeparam>
+    /// <typeparam name="TValue">The projected type.</typeparam>
     /// <param name="source">The sequence to scan.</param>
     /// <param name="selector">Projects each element.</param>
     [Pure]
@@ -133,7 +133,7 @@ public static class MaybeCollectionExtensions
     #region Values (flatten IEnumerable<Maybe<T>> to its populated values)
 
     /// <summary>Extracts the underlying values from every populated <see cref="Maybe{T}"/>, dropping empties.</summary>
-    /// <typeparam name="T">The wrapped value type.</typeparam>
+    /// <typeparam name="T">The wrapped type.</typeparam>
     /// <param name="source">The sequence of <see cref="Maybe{T}"/>.</param>
     [Pure]
     public static IEnumerable<T> Values<T>(this IEnumerable<Maybe<T>> source) where T : notnull

--- a/src/StrongTypes/Result/Result.cs
+++ b/src/StrongTypes/Result/Result.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 namespace StrongTypes;
 
 /// <summary>A value that is either a success carrying <typeparamref name="T"/> or an error carrying <typeparamref name="TError"/>.</summary>
-/// <typeparam name="T">The success value type.</typeparam>
-/// <typeparam name="TError">The error value type.</typeparam>
+/// <typeparam name="T">The success type.</typeparam>
+/// <typeparam name="TError">The error type.</typeparam>
 /// <remarks>Construct through the implicit conversions (<c>return value;</c> / <c>return error;</c>) or the <see cref="Result"/> factory. Unwrap with the extension-property pattern: <c>if (result.Success is {} s)</c> or <c>if (result.Error is {} e)</c>.</remarks>
 // Note: we can't also declare IEquatable<T> and IEquatable<TError> — the C#
 // compiler rejects that combination (CS0695) because the two interfaces unify
@@ -164,7 +164,7 @@ public class Result<T, TError> : IEquatable<Result<T, TError>>
 }
 
 /// <summary>Shorthand for <c>Result&lt;T, Exception&gt;</c>; chained <c>Map</c>/<c>FlatMap</c> calls stay as <see cref="Result{T}"/> rather than decaying to the two-parameter form.</summary>
-/// <typeparam name="T">The success value type.</typeparam>
+/// <typeparam name="T">The success type.</typeparam>
 public sealed class Result<T> : Result<T, Exception>
     where T : notnull
 {
@@ -207,28 +207,28 @@ public sealed class Result<T> : Result<T, Exception>
 public static partial class Result
 {
     /// <summary>Wraps <paramref name="value"/> as a successful <see cref="Result{T}"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <param name="value">The success payload.</param>
     [Pure]
     public static Result<T> Success<T>(T value) where T : notnull => new(value);
 
     /// <summary>Wraps <paramref name="error"/> as a failed <see cref="Result{T}"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <param name="error">The captured exception.</param>
     [Pure]
     public static Result<T> Error<T>(Exception error) where T : notnull => new(error);
 
     /// <summary>Wraps <paramref name="value"/> as a successful <see cref="Result{T, TError}"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="value">The success payload.</param>
     [Pure]
     public static Result<T, TError> Success<T, TError>(T value)
         where T : notnull where TError : notnull => new(value);
 
     /// <summary>Wraps <paramref name="error"/> as a failed <see cref="Result{T, TError}"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="error">The error payload.</param>
     [Pure]
     public static Result<T, TError> Error<T, TError>(TError error)

--- a/src/StrongTypes/Result/ResultAggregate.cs
+++ b/src/StrongTypes/Result/ResultAggregate.cs
@@ -7,8 +7,8 @@ namespace StrongTypes;
 public static partial class Result
 {
     /// <summary>Combines results into a tuple of values on all-success, or an array of every collected error otherwise.</summary>
-    /// <typeparam name="T1">The first success value type.</typeparam>
-    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="T1">The first success type.</typeparam>
+    /// <typeparam name="T2">The second success type.</typeparam>
     /// <typeparam name="TError">The shared error type.</typeparam>
     /// <param name="r1">The first result.</param>
     /// <param name="r2">The second result.</param>
@@ -27,8 +27,8 @@ public static partial class Result
     }
 
     /// <summary>On all-success invokes <paramref name="combine"/>; otherwise returns all collected errors.</summary>
-    /// <typeparam name="T1">The first success value type.</typeparam>
-    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="T1">The first success type.</typeparam>
+    /// <typeparam name="T2">The second success type.</typeparam>
     /// <typeparam name="R">The combined success type.</typeparam>
     /// <typeparam name="TError">The shared error type.</typeparam>
     /// <param name="r1">The first result.</param>
@@ -266,8 +266,8 @@ public static partial class Result
     }
 
     /// <summary>Aggregates any number of results, collecting every error. The sequence is fully drained whether or not an error is seen.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="results">The results to aggregate.</param>
     [Pure]
     public static Result<T[], TError[]> Aggregate<T, TError>(
@@ -287,8 +287,8 @@ public static partial class Result
     }
 
     /// <summary>On all-success invokes <paramref name="combine"/>; otherwise passes the collected errors through <paramref name="errorMap"/>.</summary>
-    /// <typeparam name="T1">The first success value type.</typeparam>
-    /// <typeparam name="T2">The second success value type.</typeparam>
+    /// <typeparam name="T1">The first success type.</typeparam>
+    /// <typeparam name="T2">The second success type.</typeparam>
     /// <typeparam name="R">The combined success type.</typeparam>
     /// <typeparam name="TError">The incoming error type.</typeparam>
     /// <typeparam name="UError">The mapped error type.</typeparam>

--- a/src/StrongTypes/Result/ResultFlattenExtensions.cs
+++ b/src/StrongTypes/Result/ResultFlattenExtensions.cs
@@ -6,7 +6,7 @@ namespace StrongTypes;
 public static class ResultFlattenExtensions
 {
     /// <summary>Collapses a nested <see cref="Result{T, TError}"/> when both levels share the same error type.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <typeparam name="TError">The shared error type.</typeparam>
     /// <param name="nested">The nested result.</param>
     [Pure]
@@ -16,7 +16,7 @@ public static class ResultFlattenExtensions
         => nested.IsSuccess ? nested.InternalValue : nested.InternalError;
 
     /// <summary>Collapses a <see cref="Result{T}"/> of <see cref="Result{T}"/>, preserving the single-parameter form.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <param name="nested">The nested result.</param>
     [Pure]
     public static Result<T> Flatten<T>(this Result<Result<T>, Exception> nested)
@@ -24,7 +24,7 @@ public static class ResultFlattenExtensions
         => nested.IsSuccess ? nested.InternalValue : nested.InternalError;
 
     /// <summary>Collapses a nested <see cref="Result{T, TError}"/> whose inner and outer error types are different <see cref="Exception"/> subtypes. Both errors upcast to <see cref="Exception"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <typeparam name="TInnerException">The inner exception type.</typeparam>
     /// <typeparam name="TOuterException">The outer exception type.</typeparam>
     /// <param name="nested">The nested result.</param>

--- a/src/StrongTypes/Result/ResultFromNullableExtensions.cs
+++ b/src/StrongTypes/Result/ResultFromNullableExtensions.cs
@@ -35,7 +35,7 @@ public static class ResultFromNullableExtensions
 
     /// <summary>Lifts a nullable reference into a <see cref="Result{T, TError}"/> with an eager custom error.</summary>
     /// <typeparam name="T">The reference type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="value">The nullable input.</param>
     /// <param name="error">The error to emit when <paramref name="value"/> is null.</param>
     /// <remarks>A lambda returning a specific <see cref="Exception"/> subtype binds here rather than to <see cref="ToResult{T}(T?, Func{Exception})"/>. Cast to <see cref="Exception"/> to force the single-parameter form.</remarks>
@@ -47,7 +47,7 @@ public static class ResultFromNullableExtensions
 
     /// <summary>Lifts a nullable reference into a <see cref="Result{T, TError}"/> with a lazy custom error.</summary>
     /// <typeparam name="T">The reference type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="value">The nullable input.</param>
     /// <param name="error">Produces the error when <paramref name="value"/> is null.</param>
     [Pure]

--- a/src/StrongTypes/Result/ResultPartitionExtensions.cs
+++ b/src/StrongTypes/Result/ResultPartitionExtensions.cs
@@ -8,8 +8,8 @@ namespace StrongTypes;
 public static class ResultPartitionExtensions
 {
     /// <summary>Splits a sequence of <see cref="Result{T, TError}"/> into successes and errors. Relative order is preserved within each partition.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="source">The sequence of results.</param>
     [Pure]
     public static (IReadOnlyList<T> Successes, IReadOnlyList<TError> Errors) Partition<T, TError>(
@@ -31,8 +31,8 @@ public static class ResultPartitionExtensions
     }
 
     /// <summary>Partitions the sequence, then invokes <paramref name="success"/> on the successes and <paramref name="error"/> on the errors. Both callbacks are invoked even when their partition is empty.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="source">The sequence of results.</param>
     /// <param name="success">Invoked with all successes.</param>
     /// <param name="error">Invoked with all errors.</param>
@@ -49,8 +49,8 @@ public static class ResultPartitionExtensions
     }
 
     /// <summary>Partitions the sequence, projects each partition through the matching callback, and returns the concatenated results in successes-then-errors order.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <typeparam name="R">The projected element type.</typeparam>
     /// <param name="source">The sequence of results.</param>
     /// <param name="success">Projects the successes.</param>

--- a/src/StrongTypes/Result/ResultThrowIfErrorExtensions.cs
+++ b/src/StrongTypes/Result/ResultThrowIfErrorExtensions.cs
@@ -8,7 +8,7 @@ namespace StrongTypes;
 public static class ResultThrowIfErrorExtensions
 {
     /// <summary>Returns the success value, or rethrows the captured exception preserving its original stack trace.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <typeparam name="TError">The error type, constrained to <see cref="Exception"/>.</typeparam>
     /// <param name="r">The result to unwrap.</param>
     public static T ThrowIfError<T, TError>(this Result<T, TError> r)
@@ -21,8 +21,8 @@ public static class ResultThrowIfErrorExtensions
     }
 
     /// <summary>Returns the success value, or throws the exception produced by <paramref name="toException"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
-    /// <typeparam name="TError">The error value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
+    /// <typeparam name="TError">The error type.</typeparam>
     /// <param name="r">The result to unwrap.</param>
     /// <param name="toException">Maps the error to an <see cref="Exception"/>.</param>
     public static T ThrowIfError<T, TError>(
@@ -37,7 +37,7 @@ public static class ResultThrowIfErrorExtensions
     }
 
     /// <summary>Returns the success value, or throws. A single captured exception is rethrown (stack preserved); multiple exceptions are wrapped in an <see cref="AggregateException"/>.</summary>
-    /// <typeparam name="T">The success value type.</typeparam>
+    /// <typeparam name="T">The success type.</typeparam>
     /// <param name="r">The result to unwrap.</param>
     public static T ThrowIfError<T>(this Result<T, IReadOnlyList<Exception>> r)
         where T : notnull


### PR DESCRIPTION
## Summary
- "Value type" already means something specific in C# (a struct), so using the same term for the library's strong types is ambiguous.
- Reworded the places that apply the term to our own types: `Maybe<T>` is now described as a `struct`; the `NonEmptyString`/`Positive<T>` family is called "validated types" instead of "validated value types" (CLAUDE.md, package-layout.svg).
- `<typeparam>` docs on `: notnull`-constrained generics (`Result<T, TError>`, `Maybe<T>`, etc.) now read "The success/error/wrapped/projected type" instead of "… value type".
- Kept the phrase where it genuinely describes the C# concept — struct overloads paired with class overloads (`BooleanMapExtensions`, `NullableMapExtensions`, `IEnumerableExtensions`), and `Nullable<T>` / reference-type contrasts in the readme.

## Test plan
- [x] `dotnet build` — green, zero warnings.
- [ ] Skim the rendered readme on GitHub and the `package-layout.svg` preview to confirm the wording reads naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)