### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,10 @@ Rules:
 
 All testing rules — unit, API integration, OpenAPI integration, and
 analyzer tests — live in [`testing.md`](testing.md). **Read that file
-before writing or modifying any test in this repo.** It is the single
-source of truth; do not infer testing conventions from existing tests
-without checking it first.
+before writing or modifying a test, and before writing any code that
+will need tests** (a new strong type, a converter, an analyzer, an API
+endpoint, …). It is the single source of truth; do not infer testing
+conventions from existing tests without checking it first.
 
 ## StrongTypes.Api — purpose
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,58 +93,11 @@ Rules:
 
 ## Tests
 
-**Default to FsCheck property tests.** Generative coverage is the first
-thing to reach for — it surfaces edge cases a handful of hand-picked rows
-will miss, and it keeps test bodies focused on a single invariant across
-the whole input space.
+All testing rules — unit, API integration, OpenAPI integration, and
+analyzer tests — live in [`testing.md`](testing.md). Read it before
+writing or modifying any test.
 
-- Write `[Property]` tests from `FsCheck.Xunit` and let an `Arbitrary<T>`
-  cover the input space. Register arbitraries on a test class via
-  `[Properties(Arbitrary = new[] { typeof(Generators) })]`.
-- All shared arbitraries live in a single `Generators` class at
-  `src/StrongTypes.Tests/Generators.cs`. Add new arbitraries there rather
-  than creating per-feature generator classes — one shelf so tests can
-  grab anything with a single `[Properties(Arbitrary = new[] { typeof(Generators) })]`
-  attribute. Weight branches with `Gen.Frequency` when one branch is the
-  common case and the other needs only occasional coverage (e.g. 90%
-  populated, 10% null).
-- When a custom generator is non-trivial, pair it with a one-off `[Fact]`
-  that samples it a few hundred times and asserts every partition branch
-  appears, so a regression in the generator can't silently mask missing
-  coverage.
-
-**Fall back to `[Theory]` + `[InlineData]` (or `[MemberData]`) only when
-property tests don't fit** — e.g. the input space doesn't generate cleanly,
-the invariant you want to express is really a small fixed set of worked
-examples, or the generator/shrinker would be more work than the test is
-worth. When you do use `[Theory]`, still prefer one parameterized method
-with several data rows over duplicated `[Fact]` methods whose bodies
-differ only in input or expected value.
-
-Use separate `[Fact]` methods when the test body genuinely differs — e.g.
-asserting a side effect like "the factory was invoked exactly once".
-
-## Integration tests (StrongTypes.Api)
-
-- **Requests** — always use anonymous objects (e.g. `new { Value = "x",
-  NullableValue = (string?)null }`), never the typed request records from
-  the API project. The tests should verify the on-the-wire JSON contract
-  the client actually sends, not the C# type graph.
-- **Responses** — for simple ID-only responses, deserializing into the
-  typed response record (e.g. `StringEntityResponse`) is fine. For richer
-  payloads (full entity bodies, `ValidationProblemDetails`, etc.) parse as
-  `JsonElement` and pull fields by name — that verifies the on-the-wire
-  HTTP contract directly.
-- **Test base class** — inherit from `IntegrationTestBase(factory)` to get
-  `Client`, `SqlDb`, `PgDb`, `Ct` (the current test's `CancellationToken`),
-  route constants/builders, HTTP wrappers (`Post`/`Put`/`Get`) that capture
-  `Client` and `Ct` implicitly and bake in `StringEntityResponse` on the
-  success path, `Body<T>(value, nullableValue)`, and `AssertStringEntity`.
-- **CancellationTokens** — xunit.v3's `xUnit1051` analyzer requires
-  `TestContext.Current.CancellationToken` be threaded into every async
-  call that accepts one (`PostAsJsonAsync`, `PutAsJsonAsync`,
-  `ReadFromJsonAsync`, `FindAsync([id], ct)`, `GetAsync`, …). Grab it at
-  the top of each test: `var ct = TestContext.Current.CancellationToken;`.
+@testing.md
 
 ## StrongTypes.Api — purpose
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,10 @@ Rules:
 ## Tests
 
 All testing rules — unit, API integration, OpenAPI integration, and
-analyzer tests — live in [`testing.md`](testing.md). Read it before
-writing or modifying any test.
-
-@testing.md
+analyzer tests — live in [`testing.md`](testing.md). **Read that file
+before writing or modifying any test in this repo.** It is the single
+source of truth; do not infer testing conventions from existing tests
+without checking it first.
 
 ## StrongTypes.Api — purpose
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ wasted work if the design needs to change.
 ## Testing — the rules for new types
 
 **Every new type must ship with tests.** What kinds of tests depend on
-where the type travels: in-process only, over JSON, into a database,
-out through an OpenAPI document, or all of the above.
-
-The matrix below tells you which test projects you need to touch.
+where the type travels — the matrix below maps capabilities to the test
+projects that must be touched. The full conventions for writing each
+kind of test live in [`testing.md`](testing.md); read that before
+writing tests or production code that will need them.
 
 | The new type… | Required test projects |
 |---|---|
@@ -40,72 +40,6 @@ The matrix below tells you which test projects you need to touch.
 | Is meant to be stored in a database | `StrongTypes.Api.IntegrationTests` (covers both SQL Server and PostgreSQL) |
 | Appears in an ASP.NET Core request/response | `StrongTypes.OpenApi.IntegrationTests` |
 | Ships an analyzer or code fix | `StrongTypes.Analyzers.Tests` |
-
-All test-writing rules (unit, API, OpenAPI, analyzer) live in
-[`testing.md`](testing.md) — that's the single source of truth, read it
-before writing tests. The subsections below only describe **what to
-cover** when you add a new type.
-
-### 1. Unit tests — `StrongTypes.Tests`
-
-Cover the type's behaviour with FsCheck property tests. `testing.md`
-explains the conventions.
-
-### 2. JSON + EF Core integration — `StrongTypes.Api.IntegrationTests`
-
-This project hosts the minimal API in `StrongTypes.Api` and runs every
-write through both SQL Server and PostgreSQL (via Testcontainers). Tests
-here verify three things at once: the JSON converter, the ASP.NET Core
-request pipeline, and the EF Core value converter against both providers.
-
-When adding a type that should round-trip over the wire and into a
-database:
-
-1. Add a controller in
-   [`StrongTypes.Api/Controllers`](src/StrongTypes.Api/Controllers) and
-   an entity in
-   [`StrongTypes.Api/Entities`](src/StrongTypes.Api/Entities) following
-   the existing `IEntity<TSelf, T, TNullable>` shape.
-2. Add a test class under
-   [`Tests/ApiTests`](src/StrongTypes.Api.IntegrationTests/Tests/ApiTests)
-   inheriting from `IntegrationTestBase` — it gives you `Client`,
-   `SqlDb`, `PgDb`, and the assertion helpers.
-3. Cover: valid round-trip (POST + GET, asserting persisted state on both
-   `SqlSet` and `PgSet`), invalid payloads return `400`, and `null`
-   handling for the nullable variant.
-4. If the type has a custom JSON converter, add converter-only tests
-   under
-   [`Tests/ConverterTests`](src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests).
-
-Use anonymous objects for request bodies — never the typed records from
-`StrongTypes.Api`. The point is to assert the on-the-wire JSON contract.
-
-### 3. OpenAPI integration — `StrongTypes.OpenApi.IntegrationTests`
-
-This project verifies the schema each type produces in both supported
-OpenAPI stacks: `Microsoft.AspNetCore.OpenApi` and Swashbuckle. The tests
-share a base class (`OpenApiDocumentTestsBase`) split across partial
-files by feature (`*.Strings.cs`, `*.Numerics.cs`, `*.Collections.cs`,
-…).
-
-When adding a type that appears in API contracts:
-
-1. Expose it via an endpoint in
-   [`StrongTypes.OpenApi.TestApi.Shared`](src/StrongTypes.OpenApi.TestApi.Shared).
-2. Add tests to the matching partial of `OpenApiDocumentTestsBase`.
-3. Cover: the rendered schema shape (type, format, constraints like
-   `minLength` / `minimum` / `exclusiveMinimum`), the nullable variant,
-   and that the schema is inlined / referenced as expected.
-
-The shared base means one set of assertions runs against both stacks —
-you do not write Microsoft and Swashbuckle tests separately.
-
-### 4. Analyzer tests — `StrongTypes.Analyzers.Tests`
-
-Diagnostics and code fixes need both a "reports the diagnostic" test and
-a "code fix produces the expected output" test. Follow the existing
-patterns in
-[`StrongTypes.Analyzers.Tests`](src/StrongTypes.Analyzers.Tests).
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,9 @@ The matrix below tells you which test projects you need to touch.
 
 ### 1. Unit tests — `StrongTypes.Tests`
 
-Default to **FsCheck property tests** (`[Property]` from
-`FsCheck.Xunit`). Hand-picked `[Theory]` rows are a fallback for cases
-the generators don't cover cleanly. See the testing section in
-[`CLAUDE.md`](CLAUDE.md) for the details.
-
-For a validated type, at minimum cover:
-- `TryCreate` returns `null` for invalid input and wraps valid input.
-- `Create` throws for invalid input and wraps valid input.
-- Equality / comparison / `ToString` / implicit conversions, where they exist.
-- Any extension methods in the same feature folder.
-
-If you add a new `Arbitrary<T>`, register it on
-[`Generators`](src/StrongTypes.Tests/Generators.cs) and pair it with a
-sampling `[Fact]` that asserts each branch of the generator is reachable.
+Default to **FsCheck property tests**. See the **Tests** section of
+[`CLAUDE.md`](CLAUDE.md) for the rules — that's the single source of
+truth.
 
 ### 2. JSON + EF Core integration — `StrongTypes.Api.IntegrationTests`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,26 @@ a "code fix produces the expected output" test. Follow the existing
 patterns in
 [`StrongTypes.Analyzers.Tests`](src/StrongTypes.Analyzers.Tests).
 
+## Documentation
+
+When you add a new type or change visible behavior, update the readmes
+as part of the same PR.
+
+- **Main [`readme.md`](readme.md)** — keep it concise. It is the first
+  thing a new user sees on NuGet and GitHub, so prefer a short, runnable
+  example over a full API reference. If a section is growing into a
+  spec, move the long form into the type's XML docs and leave a tight
+  example in the readme.
+- **Package readmes** — each package that ships its own readme
+  ([`StrongTypes.EfCore`](src/StrongTypes.EfCore/readme.md),
+  [`StrongTypes.FsCheck`](src/StrongTypes.FsCheck/readme.md),
+  [`StrongTypes.OpenApi.Microsoft`](src/StrongTypes.OpenApi.Microsoft/readme.md),
+  [`StrongTypes.OpenApi.Swashbuckle`](src/StrongTypes.OpenApi.Swashbuckle/readme.md))
+  should reflect what the package actually does after your change. Update
+  the one that matches.
+- **Examples must be real.** Copy them from a passing test if you can —
+  examples that drift from the API age into bug reports.
+
 ## Code of conduct
 
 Be respectful. Assume good faith. Keep discussion focused on the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to StrongTypes
+
+Thanks for your interest in contributing. This document covers how to
+report issues, propose changes, and — most importantly — how to make sure
+new types are properly tested.
+
+## Reporting bugs
+
+Open a GitHub issue. Include the package version, the target framework,
+and a minimal repro (a failing test is ideal).
+
+## Requesting a feature
+
+Open a GitHub issue describing the use case before sending a PR for
+anything non-trivial. That keeps the discussion in one place and avoids
+wasted work if the design needs to change.
+
+## Pull requests
+
+- Fork and branch off `main`.
+- Keep the change focused. One concern per PR.
+- Run `dotnet build` and `dotnet test` locally before pushing.
+- Match the conventions in [`CLAUDE.md`](CLAUDE.md) — it covers folder
+  layout, the `TryCreate` / `Create` pattern, comment style, and line
+  wrapping rules. Those rules apply to every contributor.
+- PRs are squash-merged.
+
+## Testing — the rules for new types
+
+**Every new type must ship with tests.** What kinds of tests depend on
+where the type travels: in-process only, over JSON, into a database,
+out through an OpenAPI document, or all of the above.
+
+The matrix below tells you which test projects you need to touch.
+
+| The new type… | Required test projects |
+|---|---|
+| Has any behavior at all | `StrongTypes.Tests` |
+| Has a `System.Text.Json` converter | `StrongTypes.Tests` + `StrongTypes.Api.IntegrationTests` |
+| Is meant to be stored in a database | `StrongTypes.Api.IntegrationTests` (covers both SQL Server and PostgreSQL) |
+| Appears in an ASP.NET Core request/response | `StrongTypes.OpenApi.IntegrationTests` |
+| Ships an analyzer or code fix | `StrongTypes.Analyzers.Tests` |
+
+### 1. Unit tests — `StrongTypes.Tests`
+
+Default to **FsCheck property tests** (`[Property]` from
+`FsCheck.Xunit`). Hand-picked `[Theory]` rows are a fallback for cases
+the generators don't cover cleanly. See the testing section in
+[`CLAUDE.md`](CLAUDE.md) for the details.
+
+For a validated type, at minimum cover:
+- `TryCreate` returns `null` for invalid input and wraps valid input.
+- `Create` throws for invalid input and wraps valid input.
+- Equality / comparison / `ToString` / implicit conversions, where they exist.
+- Any extension methods in the same feature folder.
+
+If you add a new `Arbitrary<T>`, register it on
+[`Generators`](src/StrongTypes.Tests/Generators.cs) and pair it with a
+sampling `[Fact]` that asserts each branch of the generator is reachable.
+
+### 2. JSON + EF Core integration — `StrongTypes.Api.IntegrationTests`
+
+This project hosts the minimal API in `StrongTypes.Api` and runs every
+write through both SQL Server and PostgreSQL (via Testcontainers). Tests
+here verify three things at once: the JSON converter, the ASP.NET Core
+request pipeline, and the EF Core value converter against both providers.
+
+When adding a type that should round-trip over the wire and into a
+database:
+
+1. Add a controller in
+   [`StrongTypes.Api/Controllers`](src/StrongTypes.Api/Controllers) and
+   an entity in
+   [`StrongTypes.Api/Entities`](src/StrongTypes.Api/Entities) following
+   the existing `IEntity<TSelf, T, TNullable>` shape.
+2. Add a test class under
+   [`Tests/ApiTests`](src/StrongTypes.Api.IntegrationTests/Tests/ApiTests)
+   inheriting from `IntegrationTestBase` — it gives you `Client`,
+   `SqlDb`, `PgDb`, and the assertion helpers.
+3. Cover: valid round-trip (POST + GET, asserting persisted state on both
+   `SqlSet` and `PgSet`), invalid payloads return `400`, and `null`
+   handling for the nullable variant.
+4. If the type has a custom JSON converter, add converter-only tests
+   under
+   [`Tests/ConverterTests`](src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests).
+
+Use anonymous objects for request bodies — never the typed records from
+`StrongTypes.Api`. The point is to assert the on-the-wire JSON contract.
+
+### 3. OpenAPI integration — `StrongTypes.OpenApi.IntegrationTests`
+
+This project verifies the schema each type produces in both supported
+OpenAPI stacks: `Microsoft.AspNetCore.OpenApi` and Swashbuckle. The tests
+share a base class (`OpenApiDocumentTestsBase`) split across partial
+files by feature (`*.Strings.cs`, `*.Numerics.cs`, `*.Collections.cs`,
+…).
+
+When adding a type that appears in API contracts:
+
+1. Expose it via an endpoint in
+   [`StrongTypes.OpenApi.TestApi.Shared`](src/StrongTypes.OpenApi.TestApi.Shared).
+2. Add tests to the matching partial of `OpenApiDocumentTestsBase`.
+3. Cover: the rendered schema shape (type, format, constraints like
+   `minLength` / `minimum` / `exclusiveMinimum`), the nullable variant,
+   and that the schema is inlined / referenced as expected.
+
+The shared base means one set of assertions runs against both stacks —
+you do not write Microsoft and Swashbuckle tests separately.
+
+### 4. Analyzer tests — `StrongTypes.Analyzers.Tests`
+
+Diagnostics and code fixes need both a "reports the diagnostic" test and
+a "code fix produces the expected output" test. Follow the existing
+patterns in
+[`StrongTypes.Analyzers.Tests`](src/StrongTypes.Analyzers.Tests).
+
+## Code of conduct
+
+Be respectful. Assume good faith. Keep discussion focused on the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,15 @@ The matrix below tells you which test projects you need to touch.
 | Appears in an ASP.NET Core request/response | `StrongTypes.OpenApi.IntegrationTests` |
 | Ships an analyzer or code fix | `StrongTypes.Analyzers.Tests` |
 
+All test-writing rules (unit, API, OpenAPI, analyzer) live in
+[`testing.md`](testing.md) — that's the single source of truth, read it
+before writing tests. The subsections below only describe **what to
+cover** when you add a new type.
+
 ### 1. Unit tests — `StrongTypes.Tests`
 
-Default to **FsCheck property tests**. See the **Tests** section of
-[`CLAUDE.md`](CLAUDE.md) for the rules — that's the single source of
-truth.
+Cover the type's behaviour with FsCheck property tests. `testing.md`
+explains the conventions.
 
 ### 2. JSON + EF Core integration — `StrongTypes.Api.IntegrationTests`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,21 +25,12 @@ wasted work if the design needs to change.
   wrapping rules. Those rules apply to every contributor.
 - PRs are squash-merged.
 
-## Testing — the rules for new types
+## Testing
 
-**Every new type must ship with tests.** What kinds of tests depend on
-where the type travels — the matrix below maps capabilities to the test
-projects that must be touched. The full conventions for writing each
-kind of test live in [`testing.md`](testing.md); read that before
-writing tests or production code that will need them.
-
-| The new type… | Required test projects |
-|---|---|
-| Has any behavior at all | `StrongTypes.Tests` |
-| Has a `System.Text.Json` converter | `StrongTypes.Tests` + `StrongTypes.Api.IntegrationTests` |
-| Is meant to be stored in a database | `StrongTypes.Api.IntegrationTests` (covers both SQL Server and PostgreSQL) |
-| Appears in an ASP.NET Core request/response | `StrongTypes.OpenApi.IntegrationTests` |
-| Ships an analyzer or code fix | `StrongTypes.Analyzers.Tests` |
+Every new type must ship with tests. All testing rules — which projects
+to touch, what to cover, how to write each kind of test — live in
+[`testing.md`](testing.md). Read it before writing tests or production
+code that will need them.
 
 ## Documentation
 

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,129 @@
+# Testing
+
+This is the single source of truth for how tests are written in this
+repo. It is imported into [`CLAUDE.md`](CLAUDE.md) so AI agents read it
+every session, and linked from [`CONTRIBUTING.md`](CONTRIBUTING.md) so
+human contributors see the same rules.
+
+The repo has four test projects. Which ones a change needs to touch
+depends on what the type does — see the matrix in `CONTRIBUTING.md`.
+
+## Unit tests — `StrongTypes.Tests`
+
+**Default to FsCheck property tests.** Generative coverage is the first
+thing to reach for — it surfaces edge cases a handful of hand-picked rows
+will miss, and it keeps test bodies focused on a single invariant across
+the whole input space.
+
+- Write `[Property]` tests from `FsCheck.Xunit` and let an `Arbitrary<T>`
+  cover the input space. Register arbitraries on a test class via
+  `[Properties(Arbitrary = new[] { typeof(Generators) })]`.
+- All shared arbitraries live in a single `Generators` class at
+  `src/StrongTypes.Tests/Generators.cs`. Add new arbitraries there rather
+  than creating per-feature generator classes — one shelf so tests can
+  grab anything with a single `[Properties(Arbitrary = new[] { typeof(Generators) })]`
+  attribute. Weight branches with `Gen.Frequency` when one branch is the
+  common case and the other needs only occasional coverage (e.g. 90%
+  populated, 10% null).
+- When a custom generator is non-trivial, pair it with a one-off `[Fact]`
+  that samples it a few hundred times and asserts every partition branch
+  appears, so a regression in the generator can't silently mask missing
+  coverage.
+
+**Fall back to `[Theory]` + `[InlineData]` (or `[MemberData]`) only when
+property tests don't fit** — e.g. the input space doesn't generate cleanly,
+the invariant you want to express is really a small fixed set of worked
+examples, or the generator/shrinker would be more work than the test is
+worth. When you do use `[Theory]`, still prefer one parameterized method
+with several data rows over duplicated `[Fact]` methods whose bodies
+differ only in input or expected value.
+
+Use separate `[Fact]` methods when the test body genuinely differs — e.g.
+asserting a side effect like "the factory was invoked exactly once".
+
+For a validated type, at minimum cover `TryCreate` (returns `null` for
+invalid input, wraps valid input), `Create` (throws for invalid, wraps
+valid), equality / comparison / `ToString` / implicit conversions where
+they exist, and any extension methods that live in the same feature
+folder.
+
+## API integration tests — `StrongTypes.Api.IntegrationTests`
+
+This project hosts the minimal API in `StrongTypes.Api` and runs every
+write through both SQL Server and PostgreSQL (via Testcontainers). Tests
+here verify three things at once: the JSON converter, the ASP.NET Core
+request pipeline, and the EF Core value converter against both providers.
+
+- **Requests** — always use anonymous objects (e.g. `new { Value = "x",
+  NullableValue = (string?)null }`), never the typed request records from
+  the API project. The tests should verify the on-the-wire JSON contract
+  the client actually sends, not the C# type graph.
+- **Responses** — for simple ID-only responses, deserializing into the
+  typed response record (e.g. `StringEntityResponse`) is fine. For richer
+  payloads (full entity bodies, `ValidationProblemDetails`, etc.) parse as
+  `JsonElement` and pull fields by name — that verifies the on-the-wire
+  HTTP contract directly.
+- **Test base class** — inherit from `IntegrationTestBase(factory)` to get
+  `Client`, `SqlDb`, `PgDb`, `Ct` (the current test's `CancellationToken`),
+  route constants/builders, HTTP wrappers (`Post`/`Put`/`Get`) that capture
+  `Client` and `Ct` implicitly and bake in `StringEntityResponse` on the
+  success path, `Body<T>(value, nullableValue)`, and `AssertStringEntity`.
+- **CancellationTokens** — xunit.v3's `xUnit1051` analyzer requires
+  `TestContext.Current.CancellationToken` be threaded into every async
+  call that accepts one (`PostAsJsonAsync`, `PutAsJsonAsync`,
+  `ReadFromJsonAsync`, `FindAsync([id], ct)`, `GetAsync`, …). Grab it at
+  the top of each test: `var ct = TestContext.Current.CancellationToken;`.
+
+When adding a type that should round-trip over the wire and into a
+database, add a controller in `StrongTypes.Api/Controllers`, an entity in
+`StrongTypes.Api/Entities` following the existing
+`IEntity<TSelf, T, TNullable>` shape, and a test class under
+`Tests/ApiTests`. Cover the valid round-trip (POST + GET, asserting
+persisted state on both `SqlSet` and `PgSet`), invalid payloads returning
+`400`, and `null` handling for the nullable variant. If the type has a
+custom JSON converter, add converter-only tests under `Tests/ConverterTests`.
+
+## OpenAPI integration tests — `StrongTypes.OpenApi.IntegrationTests`
+
+Verifies the schema each type produces in **both** supported OpenAPI
+stacks: `Microsoft.AspNetCore.OpenApi` and Swashbuckle. The tests share
+`OpenApiDocumentTestsBase`, an `abstract partial` class split across
+feature-scoped files (`*.Strings.cs`, `*.Numerics.cs`,
+`*.Collections.cs`, `*.Composition.cs`, `*.Annotations.cs`,
+`*.Components.cs`). Two concrete subclasses
+(`MicrosoftOpenApiDocumentTests`, `SwashbuckleOpenApiDocumentTests`) run
+the whole suite once per pipeline.
+
+When adding a type that appears in API contracts:
+
+1. Expose it via an endpoint in `StrongTypes.OpenApi.TestApi.Shared` so
+   both the Microsoft and Swashbuckle host apps pick it up.
+2. Add tests to the matching partial of `OpenApiDocumentTestsBase`. Use
+   the helpers in `Helpers/` (`SchemaNavigation`, `SchemaValueReader`,
+   `SchemaWalk`, `NullableUnwrap`, `ExclusiveBounds`,
+   `ComponentSchemas`) — don't hand-roll JSON traversal.
+3. Cover the rendered schema shape (type, format, constraints like
+   `minLength` / `minimum` / `exclusiveMinimum`), the nullable variant,
+   and whether the schema is inlined or referenced.
+4. If a pipeline genuinely emits a different keyword, encode that as a
+   `protected virtual bool Is…Broken` flag on the base and override it
+   in the affected subclass — the test still runs on both pipelines and
+   asserts the keyword is *absent* on the broken side, so the suite
+   catches it the day the framework starts honouring the annotation.
+
+Use `OpenApiVersion`-aware helpers in `Helpers/ExclusiveBounds.cs` for
+anything that differs between OpenAPI 3.0 and 3.1 (e.g. exclusive
+bounds). Don't write version-conditional asserts inline.
+
+## Analyzer tests — `StrongTypes.Analyzers.Tests`
+
+For every diagnostic and code fix, write both a "reports the diagnostic"
+test and a "code fix produces the expected output" test. Drive each
+through the real Roslyn pipeline using `AnalyzerTester` /
+`CodeFixTester` from `Infrastructure/`, with the relevant
+`TestReferences` combination (`EntityFrameworkCore`, `StrongTypesEfCore`,
+…) so the analyzer sees realistic compilation context.
+
+Cover both directions: the analyzer **fires** when the offending pattern
+is present and the required reference is missing, and is **silent** when
+the reference is present.

--- a/testing.md
+++ b/testing.md
@@ -1,12 +1,20 @@
 # Testing
 
 This is the single source of truth for how tests are written in this
-repo. It is imported into [`CLAUDE.md`](CLAUDE.md) so AI agents read it
-every session, and linked from [`CONTRIBUTING.md`](CONTRIBUTING.md) so
-human contributors see the same rules.
+repo. [`CLAUDE.md`](CLAUDE.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md)
+both point here — anything testing-related lives in this file so it
+can't drift out of sync.
 
-The repo has four test projects. Which ones a change needs to touch
-depends on what the type does — see the matrix in `CONTRIBUTING.md`.
+**Every new type must ship with tests.** Which test projects a change
+needs to touch depends on what the type does:
+
+| The new type… | Required test projects |
+|---|---|
+| Has any behavior at all | `StrongTypes.Tests` |
+| Has a `System.Text.Json` converter | `StrongTypes.Tests` + `StrongTypes.Api.IntegrationTests` |
+| Is meant to be stored in a database | `StrongTypes.Api.IntegrationTests` (covers both SQL Server and PostgreSQL) |
+| Appears in an ASP.NET Core request/response | `StrongTypes.OpenApi.IntegrationTests` |
+| Ships an analyzer or code fix | `StrongTypes.Analyzers.Tests` |
 
 ## Unit tests — `StrongTypes.Tests`
 


### PR DESCRIPTION
## Summary
- Adds a `CONTRIBUTING.md` covering issue reporting, PR workflow, and the test coverage rules for new types.
- The testing section spells out which projects to touch based on what the type does: unit (`StrongTypes.Tests`, FsCheck-first), API integration (`StrongTypes.Api.IntegrationTests` — JSON wire contract + EF Core round-trip on SQL Server *and* PostgreSQL), OpenAPI integration (`StrongTypes.OpenApi.IntegrationTests` — both Microsoft and Swashbuckle stacks), and analyzer tests where applicable.
- Cross-links to `CLAUDE.md` for code conventions rather than duplicating them.

## Test plan
- [ ] Skim the rendered Markdown on GitHub for layout / link issues.
- [ ] Confirm the matrix matches current reality (types that should be DB-stored really are covered in `StrongTypes.Api.IntegrationTests`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)