### PR TITLE
Make diagram SVGs adapt to dark mode via prefers-color-scheme (closes #80)

### DIFF
--- a/docs/diagrams/covariance-dark.svg
+++ b/docs/diagrams/covariance-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 224" role="img" aria-label="INonEmptyEnumerable covariance">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }

--- a/docs/diagrams/covariance-dark.svg
+++ b/docs/diagrams/covariance-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 224" role="img" aria-label="INonEmptyEnumerable covariance">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .edge-label { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
     .hint       { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
 
     .concrete-bg     { fill: #FFFFFF; }
     .concrete-border { stroke: #E5E7EB; }
@@ -25,8 +23,6 @@
     .mono-indigo      { fill: #6366F1; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
 
       .concrete-bg     { fill: #161b22; }
       .concrete-border { stroke: #30363d; }
@@ -56,8 +52,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="300"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="299" rx="12"/>
 
   <text class="title-text" x="40" y="38">Covariant interface: out T</text>
   <text class="subtitle"   x="40" y="58">A more-derived element type flows upward to a less-derived interface.</text>

--- a/docs/diagrams/covariance-dark.svg
+++ b/docs/diagrams/covariance-dark.svg
@@ -1,0 +1,86 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
+  <style>
+    .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .mono       { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .mono-out   { font: 700 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6366F1; }
+    .tag        { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; }
+    .edge-label { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .hint       { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+
+    .concrete-bg     { fill: #FFFFFF; }
+    .concrete-border { stroke: #E5E7EB; }
+    .concrete-tag    { fill: #6B7280; }
+
+    .interface-bg     { fill: #EEF2FF; }
+    .interface-border { stroke: #6366F1; }
+    .interface-tag    { fill: #4338CA; }
+
+    .accent-cyan      { fill: #0EA5E9; }
+    .edge-label-indigo { fill: #4338CA; }
+    .mono-strong      { fill: #111827; }
+    .mono-indigo      { fill: #6366F1; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+
+      .concrete-bg     { fill: #161b22; }
+      .concrete-border { stroke: #30363d; }
+      .concrete-tag    { fill: #8b949e; }
+
+      .interface-bg     { fill: #1a1d40; }
+      .interface-border { stroke: #818CF8; }
+      .interface-tag    { fill: #C7D2FE; }
+
+      .accent-cyan      { fill: #38BDF8; }
+      .edge-label-indigo { fill: #C7D2FE; }
+      .mono-out         { fill: #A5B4FC; }
+      .mono-indigo      { fill: #A5B4FC; }
+      .mono-strong      { fill: #e6edf3; }
+
+      .title-text { fill: #e6edf3; }
+      .subtitle   { fill: #8b949e; }
+      .mono       { fill: #e6edf3; }
+      .edge-label { fill: #c9d1d9; }
+      .hint       { fill: #8b949e; }
+    }
+  </style>
+
+  <defs>
+    <marker id="cv-arrow" markerWidth="12" markerHeight="12" refX="11" refY="4" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 11,4 L 0,8 z" fill="#6366F1"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="900" height="300"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="299" rx="12"/>
+
+  <text class="title-text" x="40" y="38">Covariant interface: out T</text>
+  <text class="subtitle"   x="40" y="58">A more-derived element type flows upward to a less-derived interface.</text>
+
+  <!-- Concrete card (left) -->
+  <rect class="concrete-bg concrete-border" x="60" y="110" width="320" height="110" rx="10" stroke-width="1.5"/>
+  <text class="tag concrete-tag" x="80" y="135">concrete collection</text>
+  <text class="mono" x="80" y="172">NonEmptyEnumerable&lt;<tspan class="accent-cyan" font-weight="700">Dog</tspan>&gt;</text>
+  <text class="hint" x="80" y="197">Dog : Animal</text>
+
+  <!-- Interface card (right) -->
+  <rect class="interface-bg interface-border" x="520" y="110" width="320" height="110" rx="10" stroke-width="1.5"/>
+  <text class="tag interface-tag" x="540" y="135">covariant interface</text>
+  <text class="mono" x="540" y="172">INonEmptyEnumerable&lt;<tspan class="accent-cyan" font-weight="700">Animal</tspan>&gt;</text>
+  <text class="mono-out" x="540" y="197">out T</text>
+
+  <!-- Arrow with label -->
+  <path d="M 380 165 L 520 165" stroke="#6366F1" stroke-width="2" marker-end="url(#cv-arrow)"/>
+  <text class="edge-label edge-label-indigo" x="450" y="155" text-anchor="middle">implicit upcast</text>
+  <text class="hint" x="450" y="185" text-anchor="middle">(no conversion needed)</text>
+
+  <!-- Bottom explanation -->
+  <text class="hint" x="450" y="260" text-anchor="middle">
+    Because <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">T</tspan> is declared <tspan class="mono-indigo" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">out</tspan>, every <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">NonEmptyEnumerable&lt;TDerived&gt;</tspan> is assignable to <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">INonEmptyEnumerable&lt;TBase&gt;</tspan>.
+  </text>
+</svg>

--- a/docs/diagrams/covariance.svg
+++ b/docs/diagrams/covariance.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 224" role="img" aria-label="INonEmptyEnumerable covariance">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .edge-label { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
     .hint       { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
 
     .concrete-bg     { fill: #FFFFFF; }
     .concrete-border { stroke: #E5E7EB; }
@@ -25,8 +23,6 @@
     .mono-indigo      { fill: #6366F1; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
 
       .concrete-bg     { fill: #161b22; }
       .concrete-border { stroke: #30363d; }
@@ -56,8 +52,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="300"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="299" rx="12"/>
 
   <text class="title-text" x="40" y="38">Covariant interface: out T</text>
   <text class="subtitle"   x="40" y="58">A more-derived element type flows upward to a less-derived interface.</text>

--- a/docs/diagrams/covariance.svg
+++ b/docs/diagrams/covariance.svg
@@ -24,7 +24,7 @@
     .mono-strong      { fill: #111827; }
     .mono-indigo      { fill: #6366F1; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
 

--- a/docs/diagrams/covariance.svg
+++ b/docs/diagrams/covariance.svg
@@ -7,6 +7,47 @@
     .tag        { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.04em; text-transform: uppercase; }
     .edge-label { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
     .hint       { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+
+    .concrete-bg     { fill: #FFFFFF; }
+    .concrete-border { stroke: #E5E7EB; }
+    .concrete-tag    { fill: #6B7280; }
+
+    .interface-bg     { fill: #EEF2FF; }
+    .interface-border { stroke: #6366F1; }
+    .interface-tag    { fill: #4338CA; }
+
+    .accent-cyan      { fill: #0EA5E9; }
+    .edge-label-indigo { fill: #4338CA; }
+    .mono-strong      { fill: #111827; }
+    .mono-indigo      { fill: #6366F1; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+
+      .concrete-bg     { fill: #161b22; }
+      .concrete-border { stroke: #30363d; }
+      .concrete-tag    { fill: #8b949e; }
+
+      .interface-bg     { fill: #1a1d40; }
+      .interface-border { stroke: #818CF8; }
+      .interface-tag    { fill: #C7D2FE; }
+
+      .accent-cyan      { fill: #38BDF8; }
+      .edge-label-indigo { fill: #C7D2FE; }
+      .mono-out         { fill: #A5B4FC; }
+      .mono-indigo      { fill: #A5B4FC; }
+      .mono-strong      { fill: #e6edf3; }
+
+      .title-text { fill: #e6edf3; }
+      .subtitle   { fill: #8b949e; }
+      .mono       { fill: #e6edf3; }
+      .edge-label { fill: #c9d1d9; }
+      .hint       { fill: #8b949e; }
+    }
   </style>
 
   <defs>
@@ -15,31 +56,31 @@
     </marker>
   </defs>
 
-  <rect width="900" height="300" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="899" height="299" fill="none" stroke="#E5E7EB" rx="12"/>
+  <rect class="canvas-bg" width="900" height="300"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="299" rx="12"/>
 
   <text class="title-text" x="40" y="38">Covariant interface: out T</text>
   <text class="subtitle"   x="40" y="58">A more-derived element type flows upward to a less-derived interface.</text>
 
   <!-- Concrete card (left) -->
-  <rect x="60" y="110" width="320" height="110" rx="10" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
-  <text class="tag" x="80" y="135" fill="#6B7280">concrete collection</text>
-  <text class="mono" x="80" y="172">NonEmptyEnumerable&lt;<tspan font-weight="700" fill="#0EA5E9">Dog</tspan>&gt;</text>
+  <rect class="concrete-bg concrete-border" x="60" y="110" width="320" height="110" rx="10" stroke-width="1.5"/>
+  <text class="tag concrete-tag" x="80" y="135">concrete collection</text>
+  <text class="mono" x="80" y="172">NonEmptyEnumerable&lt;<tspan class="accent-cyan" font-weight="700">Dog</tspan>&gt;</text>
   <text class="hint" x="80" y="197">Dog : Animal</text>
 
   <!-- Interface card (right) -->
-  <rect x="520" y="110" width="320" height="110" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
-  <text class="tag" x="540" y="135" fill="#4338CA">covariant interface</text>
-  <text class="mono" x="540" y="172">INonEmptyEnumerable&lt;<tspan font-weight="700" fill="#0EA5E9">Animal</tspan>&gt;</text>
+  <rect class="interface-bg interface-border" x="520" y="110" width="320" height="110" rx="10" stroke-width="1.5"/>
+  <text class="tag interface-tag" x="540" y="135">covariant interface</text>
+  <text class="mono" x="540" y="172">INonEmptyEnumerable&lt;<tspan class="accent-cyan" font-weight="700">Animal</tspan>&gt;</text>
   <text class="mono-out" x="540" y="197">out T</text>
 
   <!-- Arrow with label -->
   <path d="M 380 165 L 520 165" stroke="#6366F1" stroke-width="2" marker-end="url(#cv-arrow)"/>
-  <text class="edge-label" x="450" y="155" text-anchor="middle" fill="#4338CA">implicit upcast</text>
+  <text class="edge-label edge-label-indigo" x="450" y="155" text-anchor="middle">implicit upcast</text>
   <text class="hint" x="450" y="185" text-anchor="middle">(no conversion needed)</text>
 
   <!-- Bottom explanation -->
   <text class="hint" x="450" y="260" text-anchor="middle">
-    Because <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">T</tspan> is declared <tspan font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#6366F1">out</tspan>, every <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">NonEmptyEnumerable&lt;TDerived&gt;</tspan> is assignable to <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" fill="#111827">INonEmptyEnumerable&lt;TBase&gt;</tspan>.
+    Because <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">T</tspan> is declared <tspan class="mono-indigo" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">out</tspan>, every <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">NonEmptyEnumerable&lt;TDerived&gt;</tspan> is assignable to <tspan class="mono-strong" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">INonEmptyEnumerable&lt;TBase&gt;</tspan>.
   </text>
 </svg>

--- a/docs/diagrams/covariance.svg
+++ b/docs/diagrams/covariance.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 224" role="img" aria-label="INonEmptyEnumerable covariance">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" role="img" aria-label="INonEmptyEnumerable covariance">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }

--- a/docs/diagrams/impact-dark.svg
+++ b/docs/diagrams/impact-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="15 15 960 730" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
   <style>
     .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
@@ -16,8 +16,6 @@
     .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
 
     /* Semantic shape classes — override inline presentation attributes via the cascade */
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .pill-bg       { fill: #FFFFFF; }
     .pill-border   { stroke: #E5E7EB; }
 
@@ -42,8 +40,6 @@
     .muted-text    { fill: #9CA3AF; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .pill-bg       { fill: #161b22; }
       .pill-border   { stroke: #30363d; }
 
@@ -83,8 +79,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="990" height="760"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="989" height="759" rx="10"/>
 
   <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
   <g>

--- a/docs/diagrams/impact-dark.svg
+++ b/docs/diagrams/impact-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="15 15 960 730" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
   <style>
     .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/docs/diagrams/impact-dark.svg
+++ b/docs/diagrams/impact-dark.svg
@@ -1,0 +1,307 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+  <style>
+    .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .layer-title  { font: 700 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .layer-title-sm { font: 700 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .mono         { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
+    .mono-sm      { font: 11px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #4B5563; }
+    .mono-xs      { font: 10px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #4B5563; }
+    .external     { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.08em; text-transform: uppercase; }
+    .flow-tag     { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.1em; text-transform: uppercase; }
+    .type-label   { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .type-label-sm { font: 600 11px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .badge-head   { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; }
+    .badge-sub    { font: 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; opacity: 0.9; }
+    .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
+
+    /* Semantic shape classes — override inline presentation attributes via the cascade */
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #E5E7EB; }
+
+    .amber-bg      { fill: #FFFBEB; }
+    .amber-border  { stroke: #F59E0B; }
+    .amber-solid   { fill: #F59E0B; }
+    .amber-line    { stroke: #FCD34D; }
+    .amber-text    { fill: #B45309; }
+    .amber-text-strong { fill: #92400E; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-solid   { fill: #10B981; }
+    .green-line    { stroke: #6EE7B7; }
+    .green-line-soft { stroke: #D1FAE5; }
+    .green-text    { fill: #047857; }
+    .green-text-strong { fill: #065F46; }
+    .green-muted   { fill: #6EE7B7; }
+
+    .divider-soft  { stroke: #F3F4F6; }
+    .divider-mid   { stroke: #E5E7EB; }
+    .muted-text    { fill: #9CA3AF; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #30363d; }
+
+      .amber-bg      { fill: #2a1f0a; }
+      .amber-line    { stroke: #78350F; }
+      .amber-text    { fill: #FCD34D; }
+      .amber-text-strong { fill: #FDE68A; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-line    { stroke: #065F46; }
+      .green-line-soft { stroke: #064E3B; }
+      .green-text    { fill: #34D399; }
+      .green-text-strong { fill: #6EE7B7; }
+      .green-muted   { fill: #065F46; }
+
+      .divider-soft  { stroke: #21262d; }
+      .divider-mid   { stroke: #30363d; }
+      .muted-text    { fill: #6e7681; }
+
+      .layer-title    { fill: #e6edf3; }
+      .layer-title-sm { fill: #e6edf3; }
+      .mono           { fill: #c9d1d9; }
+      .mono-sm        { fill: #8b949e; }
+      .mono-xs        { fill: #8b949e; }
+      .external       { fill: #8b949e; }
+      .flow-tag       { fill: #8b949e; }
+      .note           { fill: #8b949e; }
+    }
+  </style>
+
+  <defs>
+    <marker id="imp-arrow-amber" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#F59E0B"/>
+    </marker>
+    <marker id="imp-arrow-green" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="990" height="760"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="989" height="759" rx="10"/>
+
+  <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
+  <g>
+    <!-- Header bar -->
+    <rect class="amber-bg amber-border" x="15" y="15" width="960" height="32" rx="6" stroke-width="1.5"/>
+    <text class="panel-title amber-text" x="35" y="36">Without StrongTypes</text>
+    <text class="panel-sub amber-text-strong" x="970" y="36" text-anchor="end">every layer has to validate — the type carries no guarantee</text>
+
+    <!-- Write flow tag -->
+    <text class="flow-tag" x="35" y="65">Write ↓</text>
+
+    <!-- ───── JSON in column ───── -->
+    <text class="external" x="25" y="82">JSON in</text>
+    <rect class="pill-bg pill-border" x="20" y="89" width="155" height="34" rx="6" stroke-width="1.2"/>
+    <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
+
+    <rect class="pill-bg pill-border" x="20" y="146" width="155" height="55" rx="6" stroke-width="1.2"/>
+    <text class="mono" x="30" y="163">class Request {</text>
+    <text class="mono" x="42" y="180"><tspan class="amber-text" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="30" y="197">}</text>
+
+    <!-- ───── Badge: Custom validation code (above Controller) ───── -->
+    <rect class="amber-solid" x="195" y="78" width="155" height="32" rx="16"/>
+    <text class="badge-head" x="272" y="92" text-anchor="middle">✓ Custom validation code</text>
+    <text class="badge-sub" x="272" y="105" text-anchor="middle">you write the if-check</text>
+
+    <!-- Arrow 1: JSON → Controller -->
+    <line x1="175" y1="170" x2="195" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+
+    <!-- ───── Controller box ───── -->
+    <rect class="amber-bg amber-border" x="195" y="125" width="235" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="312" y="146" text-anchor="middle">Controller</text>
+    <line class="amber-line" x1="210" y1="158" x2="415" y2="158" stroke-width="1"/>
+    <text class="mono-xs" x="210" y="178">if (string.IsNullOrWhiteSpace(name))</text>
+    <text class="mono-xs" x="210" y="195" xml:space="preserve">    return BadRequest();</text>
+
+    <!-- ───── Badge: Multiple custom validations in code (above Services) ───── -->
+    <rect class="amber-solid" x="482" y="78" width="240" height="32" rx="16"/>
+    <text class="badge-head" x="602" y="92" text-anchor="middle">✓ Multiple custom validations in code</text>
+    <text class="badge-sub" x="602" y="105" text-anchor="middle">every service that touches the value re-validates</text>
+
+    <!-- Arrow 2: Controller → Services -->
+    <line x1="430" y1="170" x2="485" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label amber-text" x="457" y="160" text-anchor="middle">string</text>
+
+    <!-- ───── Services box (with shadow stack) ───── -->
+    <rect class="amber-bg amber-border" x="497" y="113" width="235" height="80" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="amber-bg amber-border" x="491" y="119" width="235" height="80" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="amber-bg amber-border" x="485" y="125" width="235" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="602" y="146" text-anchor="middle">Services</text>
+    <line class="amber-line" x1="500" y1="158" x2="705" y2="158" stroke-width="1"/>
+    <text class="mono-xs" x="500" y="178">if (string.IsNullOrWhiteSpace(name))</text>
+    <text class="mono-xs" x="500" y="195" xml:space="preserve">    throw ...;</text>
+
+    <!-- Arrow 3: Services → Entity -->
+    <line x1="720" y1="170" x2="775" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label amber-text" x="747" y="160" text-anchor="middle">string</text>
+
+    <!-- ───── Entity box ───── -->
+    <rect class="amber-bg amber-border" x="775" y="125" width="200" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="875" y="146" text-anchor="middle">Entity / DB</text>
+    <line class="amber-line" x1="790" y1="158" x2="960" y2="158" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan class="amber-text" font-weight="600">string</tspan> Name</text>
+
+    <!-- ─────── Light divider between Write and Usage ─────── -->
+    <line class="divider-soft" x1="35" y1="217" x2="955" y2="217" stroke-width="1"/>
+
+    <!-- ────────── Usage row ────────── -->
+    <text class="flow-tag" x="35" y="234">Usage ↑</text>
+
+    <!-- Re-validate badge -->
+    <rect class="amber-solid" x="482" y="242" width="240" height="32" rx="16"/>
+    <text class="badge-head" x="602" y="256" text-anchor="middle">✓ Re-validate before using the value</text>
+    <text class="badge-sub" x="602" y="269" text-anchor="middle">e.g. background jobs, business rules</text>
+
+    <!-- ─── Response box (Usage row, left) ─── -->
+    <text class="external" x="25" y="292">JSON out</text>
+    <rect class="pill-bg pill-border" x="20" y="299" width="155" height="55" rx="6" stroke-width="1.2"/>
+    <text class="mono" x="30" y="316">class Response {</text>
+    <text class="mono" x="42" y="333"><tspan class="amber-text" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="30" y="350">}</text>
+
+    <!-- ─── Controller box (Usage row, empty) ─── -->
+    <rect class="amber-bg amber-border" x="195" y="299" width="235" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="312" y="320" text-anchor="middle">Controller</text>
+    <text class="mono-xs muted-text" x="312" y="340" text-anchor="middle" font-style="italic">maps to Response</text>
+
+    <!-- ─── Services box (Usage row, with shadow stack) ─── -->
+    <rect class="amber-bg amber-border" x="497" y="287" width="235" height="55" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="amber-bg amber-border" x="491" y="293" width="235" height="55" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="amber-bg amber-border" x="485" y="299" width="235" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="602" y="320" text-anchor="middle">Services</text>
+    <text class="mono-xs" x="602" y="340" text-anchor="middle">re-check before use</text>
+
+    <!-- ─── Entity box (Usage row) ─── -->
+    <rect class="amber-bg amber-border" x="775" y="299" width="200" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="875" y="320" text-anchor="middle">Entity / DB</text>
+    <text class="mono-sm" x="875" y="342" text-anchor="middle">public <tspan class="amber-text" font-weight="600">string</tspan> Name</text>
+
+    <!-- Usage arrow: Entity → Services -->
+    <line x1="775" y1="326" x2="720" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label-sm amber-text" x="747" y="317" text-anchor="middle">string</text>
+
+    <!-- Usage arrow: Services → Controller -->
+    <line x1="485" y1="326" x2="430" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+    <text class="type-label-sm amber-text" x="457" y="317" text-anchor="middle">string</text>
+
+    <!-- Usage arrow: Controller → Response -->
+    <line x1="195" y1="326" x2="175" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
+
+    <!-- Note -->
+    <text class="note" x="35" y="375">Even on the way out, the response DTO is still <tspan class="amber-text" font-family="ui-monospace, Menlo, Consolas, monospace">string</tspan> — and any internal use of the entity must re-check.</text>
+  </g>
+
+  <!-- Divider between panels -->
+  <line class="divider-mid" x1="50" y1="392" x2="940" y2="392" stroke-width="1" stroke-dasharray="5 4"/>
+
+  <!-- ═══════════════════ PANEL 2: With StrongTypes ═══════════════════ -->
+  <g transform="translate(0, 390)">
+    <!-- Header bar -->
+    <rect class="green-bg green-border" x="15" y="15" width="960" height="32" rx="6" stroke-width="1.5"/>
+    <text class="panel-title green-text" x="35" y="36">With StrongTypes</text>
+    <text class="panel-sub green-text-strong" x="970" y="36" text-anchor="end">validated once when receiving the value; the type guarantee is understood by every layer</text>
+
+    <!-- Write flow tag -->
+    <text class="flow-tag" x="35" y="65">Write ↓</text>
+
+    <!-- ───── JSON in column ───── -->
+    <text class="external" x="25" y="82">JSON in</text>
+    <rect class="pill-bg pill-border" x="20" y="89" width="155" height="34" rx="6" stroke-width="1.2"/>
+    <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
+    <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
+
+    <rect class="pill-bg pill-border" x="20" y="146" width="155" height="55" rx="6" stroke-width="1.2"/>
+    <text class="mono" x="30" y="163">class Request {</text>
+    <text class="mono" x="42" y="180"><tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono" x="30" y="197">}</text>
+
+    <!-- ───── Badge: Automatic JSON validation ───── -->
+    <rect class="green-solid" x="195" y="78" width="180" height="32" rx="16"/>
+    <text class="badge-head" x="285" y="92" text-anchor="middle">✓ Automatic JSON validation</text>
+    <text class="badge-sub" x="285" y="105" text-anchor="middle">ASP.NET + JsonConverter</text>
+
+    <!-- Arrow 1: JSON → Controller -->
+    <line x1="175" y1="170" x2="195" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+
+    <!-- ───── Controller box ───── -->
+    <rect class="green-bg green-border" x="195" y="125" width="180" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="285" y="146" text-anchor="middle">Controller</text>
+    <line class="green-line" x1="210" y1="158" x2="360" y2="158" stroke-width="1"/>
+    <text class="mono-sm green-text" x="285" y="186" text-anchor="middle">trusts NonEmptyString</text>
+
+    <!-- Arrow 2: Controller → Services -->
+    <line x1="375" y1="170" x2="485" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label green-text" x="430" y="160" text-anchor="middle">NonEmptyString</text>
+
+    <!-- ───── Services box (with shadow stack) ───── -->
+    <rect class="green-bg green-border" x="497" y="113" width="180" height="80" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="green-bg green-border" x="491" y="119" width="180" height="80" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="green-bg green-border" x="485" y="125" width="180" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="575" y="146" text-anchor="middle">Services</text>
+    <line class="green-line" x1="500" y1="158" x2="650" y2="158" stroke-width="1"/>
+    <text class="mono-sm green-text" x="575" y="186" text-anchor="middle">trusts NonEmptyString</text>
+
+    <!-- Arrow 3: Services → Entity -->
+    <line x1="665" y1="170" x2="775" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label green-text" x="720" y="160" text-anchor="middle">NonEmptyString</text>
+
+    <!-- ───── Entity box ───── -->
+    <rect class="green-bg green-border" x="775" y="125" width="200" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="875" y="146" text-anchor="middle">Entity / DB</text>
+    <line class="green-line" x1="790" y1="158" x2="960" y2="158" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name</text>
+
+    <!-- ─────── Light divider between Write and Usage ─────── -->
+    <line class="green-line-soft" x1="35" y1="217" x2="955" y2="217" stroke-width="1"/>
+
+    <!-- ────────── Usage row ────────── -->
+    <text class="flow-tag" x="35" y="234">Usage ↑</text>
+
+    <!-- ─── Response box (Usage row, left) ─── -->
+    <text class="external" x="25" y="257">JSON out</text>
+    <rect class="pill-bg pill-border" x="20" y="264" width="155" height="55" rx="6" stroke-width="1.2"/>
+    <text class="mono-sm" x="30" y="282">class Response {</text>
+    <text class="mono-sm" x="42" y="298"><tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono-sm" x="30" y="314">}</text>
+
+    <!-- ─── Controller box (Usage row, empty) ─── -->
+    <rect class="green-bg green-border" x="195" y="264" width="180" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="285" y="285" text-anchor="middle">Controller</text>
+    <text class="mono-xs green-muted" x="285" y="305" text-anchor="middle" font-style="italic">maps to Response</text>
+
+    <!-- ─── Services box (Usage row, with shadow stack) ─── -->
+    <rect class="green-bg green-border" x="497" y="252" width="180" height="55" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="green-bg green-border" x="491" y="258" width="180" height="55" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="green-bg green-border" x="485" y="264" width="180" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="575" y="285" text-anchor="middle">Services</text>
+    <text class="mono-xs green-text" x="575" y="305" text-anchor="middle">trusts NonEmptyString</text>
+
+    <!-- ─── Entity box (Usage row) ─── -->
+    <rect class="green-bg green-border" x="775" y="264" width="200" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="875" y="285" text-anchor="middle">Entity / DB</text>
+    <text class="mono-sm" x="875" y="307" text-anchor="middle">public <tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name</text>
+
+    <!-- Usage arrow: Entity → Services -->
+    <line x1="775" y1="291" x2="665" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label-sm green-text" x="720" y="282" text-anchor="middle">NonEmptyString</text>
+
+    <!-- Usage arrow: Services → Controller -->
+    <line x1="485" y1="291" x2="375" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+    <text class="type-label-sm green-text" x="430" y="282" text-anchor="middle">NonEmptyString</text>
+
+    <!-- Usage arrow: Controller → Response -->
+    <line x1="195" y1="291" x2="175" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
+
+    <!-- Note -->
+    <text class="note" x="35" y="342">The type travels all the way back out — the response DTO is still <tspan class="green-text" font-family="ui-monospace, Menlo, Consolas, monospace">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
+  </g>
+</svg>

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 15 960 730" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
   <style>
     .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
@@ -16,8 +16,6 @@
     .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
 
     /* Semantic shape classes — override inline presentation attributes via the cascade */
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .pill-bg       { fill: #FFFFFF; }
     .pill-border   { stroke: #E5E7EB; }
 
@@ -42,8 +40,6 @@
     .muted-text    { fill: #9CA3AF; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .pill-bg       { fill: #161b22; }
       .pill-border   { stroke: #30363d; }
 
@@ -83,8 +79,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="990" height="760"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="989" height="759" rx="10"/>
 
   <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
   <g>

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -14,6 +14,64 @@
     .badge-head   { font: 700 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; }
     .badge-sub    { font: 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #FFFFFF; opacity: 0.9; }
     .note         { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #4B5563; }
+
+    /* Semantic shape classes — override inline presentation attributes via the cascade */
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #E5E7EB; }
+
+    .amber-bg      { fill: #FFFBEB; }
+    .amber-border  { stroke: #F59E0B; }
+    .amber-solid   { fill: #F59E0B; }
+    .amber-line    { stroke: #FCD34D; }
+    .amber-text    { fill: #B45309; }
+    .amber-text-strong { fill: #92400E; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-solid   { fill: #10B981; }
+    .green-line    { stroke: #6EE7B7; }
+    .green-line-soft { stroke: #D1FAE5; }
+    .green-text    { fill: #047857; }
+    .green-text-strong { fill: #065F46; }
+    .green-muted   { fill: #6EE7B7; }
+
+    .divider-soft  { stroke: #F3F4F6; }
+    .divider-mid   { stroke: #E5E7EB; }
+    .muted-text    { fill: #9CA3AF; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #30363d; }
+
+      .amber-bg      { fill: #2a1f0a; }
+      .amber-line    { stroke: #78350F; }
+      .amber-text    { fill: #FCD34D; }
+      .amber-text-strong { fill: #FDE68A; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-line    { stroke: #065F46; }
+      .green-line-soft { stroke: #064E3B; }
+      .green-text    { fill: #34D399; }
+      .green-text-strong { fill: #6EE7B7; }
+      .green-muted   { fill: #065F46; }
+
+      .divider-soft  { stroke: #21262d; }
+      .divider-mid   { stroke: #30363d; }
+      .muted-text    { fill: #6e7681; }
+
+      .layer-title    { fill: #e6edf3; }
+      .layer-title-sm { fill: #e6edf3; }
+      .mono           { fill: #c9d1d9; }
+      .mono-sm        { fill: #8b949e; }
+      .mono-xs        { fill: #8b949e; }
+      .external       { fill: #8b949e; }
+      .flow-tag       { fill: #8b949e; }
+      .note           { fill: #8b949e; }
+    }
   </style>
 
   <defs>
@@ -25,32 +83,32 @@
     </marker>
   </defs>
 
-  <rect width="990" height="760" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="989" height="759" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect class="canvas-bg" width="990" height="760"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="989" height="759" rx="10"/>
 
   <!-- ═══════════════════ PANEL 1: Without StrongTypes ═══════════════════ -->
   <g>
     <!-- Header bar -->
-    <rect x="15" y="15" width="960" height="32" rx="6" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="panel-title" x="35" y="36" fill="#B45309">Without StrongTypes</text>
-    <text class="panel-sub" x="970" y="36" text-anchor="end" fill="#92400E">every layer has to validate — the type carries no guarantee</text>
+    <rect class="amber-bg amber-border" x="15" y="15" width="960" height="32" rx="6" stroke-width="1.5"/>
+    <text class="panel-title amber-text" x="35" y="36">Without StrongTypes</text>
+    <text class="panel-sub amber-text-strong" x="970" y="36" text-anchor="end">every layer has to validate — the type carries no guarantee</text>
 
     <!-- Write flow tag -->
     <text class="flow-tag" x="35" y="65">Write ↓</text>
 
     <!-- ───── JSON in column ───── -->
     <text class="external" x="25" y="82">JSON in</text>
-    <rect x="20" y="89" width="155" height="34" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="89" width="155" height="34" rx="6" stroke-width="1.2"/>
     <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
     <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
 
-    <rect x="20" y="146" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="146" width="155" height="55" rx="6" stroke-width="1.2"/>
     <text class="mono" x="30" y="163">class Request {</text>
-    <text class="mono" x="42" y="180"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="42" y="180"><tspan class="amber-text" font-weight="600">string</tspan> Name;</text>
     <text class="mono" x="30" y="197">}</text>
 
     <!-- ───── Badge: Custom validation code (above Controller) ───── -->
-    <rect x="195" y="78" width="155" height="32" rx="16" fill="#F59E0B"/>
+    <rect class="amber-solid" x="195" y="78" width="155" height="32" rx="16"/>
     <text class="badge-head" x="272" y="92" text-anchor="middle">✓ Custom validation code</text>
     <text class="badge-sub" x="272" y="105" text-anchor="middle">you write the if-check</text>
 
@@ -58,116 +116,116 @@
     <line x1="175" y1="170" x2="195" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
 
     <!-- ───── Controller box ───── -->
-    <rect x="195" y="125" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="312" y="146" text-anchor="middle" fill="#B45309">Controller</text>
-    <line x1="210" y1="158" x2="415" y2="158" stroke="#FCD34D" stroke-width="1"/>
+    <rect class="amber-bg amber-border" x="195" y="125" width="235" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="312" y="146" text-anchor="middle">Controller</text>
+    <line class="amber-line" x1="210" y1="158" x2="415" y2="158" stroke-width="1"/>
     <text class="mono-xs" x="210" y="178">if (string.IsNullOrWhiteSpace(name))</text>
     <text class="mono-xs" x="210" y="195" xml:space="preserve">    return BadRequest();</text>
 
     <!-- ───── Badge: Multiple custom validations in code (above Services) ───── -->
-    <rect x="482" y="78" width="240" height="32" rx="16" fill="#F59E0B"/>
+    <rect class="amber-solid" x="482" y="78" width="240" height="32" rx="16"/>
     <text class="badge-head" x="602" y="92" text-anchor="middle">✓ Multiple custom validations in code</text>
     <text class="badge-sub" x="602" y="105" text-anchor="middle">every service that touches the value re-validates</text>
 
     <!-- Arrow 2: Controller → Services -->
     <line x1="430" y1="170" x2="485" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="457" y="160" text-anchor="middle" fill="#B45309">string</text>
+    <text class="type-label amber-text" x="457" y="160" text-anchor="middle">string</text>
 
     <!-- ───── Services box (with shadow stack) ───── -->
-    <rect x="497" y="113" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.45"/>
-    <rect x="491" y="119" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.7"/>
-    <rect x="485" y="125" width="235" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="602" y="146" text-anchor="middle" fill="#B45309">Services</text>
-    <line x1="500" y1="158" x2="705" y2="158" stroke="#FCD34D" stroke-width="1"/>
+    <rect class="amber-bg amber-border" x="497" y="113" width="235" height="80" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="amber-bg amber-border" x="491" y="119" width="235" height="80" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="amber-bg amber-border" x="485" y="125" width="235" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="602" y="146" text-anchor="middle">Services</text>
+    <line class="amber-line" x1="500" y1="158" x2="705" y2="158" stroke-width="1"/>
     <text class="mono-xs" x="500" y="178">if (string.IsNullOrWhiteSpace(name))</text>
     <text class="mono-xs" x="500" y="195" xml:space="preserve">    throw ...;</text>
 
     <!-- Arrow 3: Services → Entity -->
     <line x1="720" y1="170" x2="775" y2="170" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label" x="747" y="160" text-anchor="middle" fill="#B45309">string</text>
+    <text class="type-label amber-text" x="747" y="160" text-anchor="middle">string</text>
 
     <!-- ───── Entity box ───── -->
-    <rect x="775" y="125" width="200" height="80" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title" x="875" y="146" text-anchor="middle" fill="#B45309">Entity / DB</text>
-    <line x1="790" y1="158" x2="960" y2="158" stroke="#FCD34D" stroke-width="1"/>
-    <text class="mono-sm" x="790" y="186">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
+    <rect class="amber-bg amber-border" x="775" y="125" width="200" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title amber-text" x="875" y="146" text-anchor="middle">Entity / DB</text>
+    <line class="amber-line" x1="790" y1="158" x2="960" y2="158" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan class="amber-text" font-weight="600">string</tspan> Name</text>
 
     <!-- ─────── Light divider between Write and Usage ─────── -->
-    <line x1="35" y1="217" x2="955" y2="217" stroke="#F3F4F6" stroke-width="1"/>
+    <line class="divider-soft" x1="35" y1="217" x2="955" y2="217" stroke-width="1"/>
 
     <!-- ────────── Usage row ────────── -->
     <text class="flow-tag" x="35" y="234">Usage ↑</text>
 
     <!-- Re-validate badge -->
-    <rect x="482" y="242" width="240" height="32" rx="16" fill="#F59E0B"/>
+    <rect class="amber-solid" x="482" y="242" width="240" height="32" rx="16"/>
     <text class="badge-head" x="602" y="256" text-anchor="middle">✓ Re-validate before using the value</text>
     <text class="badge-sub" x="602" y="269" text-anchor="middle">e.g. background jobs, business rules</text>
 
     <!-- ─── Response box (Usage row, left) ─── -->
     <text class="external" x="25" y="292">JSON out</text>
-    <rect x="20" y="299" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="299" width="155" height="55" rx="6" stroke-width="1.2"/>
     <text class="mono" x="30" y="316">class Response {</text>
-    <text class="mono" x="42" y="333"><tspan fill="#B45309" font-weight="600">string</tspan> Name;</text>
+    <text class="mono" x="42" y="333"><tspan class="amber-text" font-weight="600">string</tspan> Name;</text>
     <text class="mono" x="30" y="350">}</text>
 
     <!-- ─── Controller box (Usage row, empty) ─── -->
-    <rect x="195" y="299" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="312" y="320" text-anchor="middle" fill="#B45309">Controller</text>
-    <text class="mono-xs" x="312" y="340" text-anchor="middle" font-style="italic" fill="#9CA3AF">maps to Response</text>
+    <rect class="amber-bg amber-border" x="195" y="299" width="235" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="312" y="320" text-anchor="middle">Controller</text>
+    <text class="mono-xs muted-text" x="312" y="340" text-anchor="middle" font-style="italic">maps to Response</text>
 
     <!-- ─── Services box (Usage row, with shadow stack) ─── -->
-    <rect x="497" y="287" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.45"/>
-    <rect x="491" y="293" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5" opacity="0.7"/>
-    <rect x="485" y="299" width="235" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="602" y="320" text-anchor="middle" fill="#B45309">Services</text>
+    <rect class="amber-bg amber-border" x="497" y="287" width="235" height="55" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="amber-bg amber-border" x="491" y="293" width="235" height="55" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="amber-bg amber-border" x="485" y="299" width="235" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="602" y="320" text-anchor="middle">Services</text>
     <text class="mono-xs" x="602" y="340" text-anchor="middle">re-check before use</text>
 
     <!-- ─── Entity box (Usage row) ─── -->
-    <rect x="775" y="299" width="200" height="55" rx="8" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="875" y="320" text-anchor="middle" fill="#B45309">Entity / DB</text>
-    <text class="mono-sm" x="875" y="342" text-anchor="middle">public <tspan fill="#B45309" font-weight="600">string</tspan> Name</text>
+    <rect class="amber-bg amber-border" x="775" y="299" width="200" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm amber-text" x="875" y="320" text-anchor="middle">Entity / DB</text>
+    <text class="mono-sm" x="875" y="342" text-anchor="middle">public <tspan class="amber-text" font-weight="600">string</tspan> Name</text>
 
     <!-- Usage arrow: Entity → Services -->
     <line x1="775" y1="326" x2="720" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label-sm" x="747" y="317" text-anchor="middle" fill="#B45309">string</text>
+    <text class="type-label-sm amber-text" x="747" y="317" text-anchor="middle">string</text>
 
     <!-- Usage arrow: Services → Controller -->
     <line x1="485" y1="326" x2="430" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
-    <text class="type-label-sm" x="457" y="317" text-anchor="middle" fill="#B45309">string</text>
+    <text class="type-label-sm amber-text" x="457" y="317" text-anchor="middle">string</text>
 
     <!-- Usage arrow: Controller → Response -->
     <line x1="195" y1="326" x2="175" y2="326" stroke="#F59E0B" stroke-width="1.5" marker-end="url(#imp-arrow-amber)"/>
 
     <!-- Note -->
-    <text class="note" x="35" y="375">Even on the way out, the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#B45309">string</tspan> — and any internal use of the entity must re-check.</text>
+    <text class="note" x="35" y="375">Even on the way out, the response DTO is still <tspan class="amber-text" font-family="ui-monospace, Menlo, Consolas, monospace">string</tspan> — and any internal use of the entity must re-check.</text>
   </g>
 
   <!-- Divider between panels -->
-  <line x1="50" y1="392" x2="940" y2="392" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="5 4"/>
+  <line class="divider-mid" x1="50" y1="392" x2="940" y2="392" stroke-width="1" stroke-dasharray="5 4"/>
 
   <!-- ═══════════════════ PANEL 2: With StrongTypes ═══════════════════ -->
   <g transform="translate(0, 390)">
     <!-- Header bar -->
-    <rect x="15" y="15" width="960" height="32" rx="6" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="panel-title" x="35" y="36" fill="#047857">With StrongTypes</text>
-    <text class="panel-sub" x="970" y="36" text-anchor="end" fill="#065F46">validated once when receiving the value; the type guarantee is understood by every layer</text>
+    <rect class="green-bg green-border" x="15" y="15" width="960" height="32" rx="6" stroke-width="1.5"/>
+    <text class="panel-title green-text" x="35" y="36">With StrongTypes</text>
+    <text class="panel-sub green-text-strong" x="970" y="36" text-anchor="end">validated once when receiving the value; the type guarantee is understood by every layer</text>
 
     <!-- Write flow tag -->
     <text class="flow-tag" x="35" y="65">Write ↓</text>
 
     <!-- ───── JSON in column ───── -->
     <text class="external" x="25" y="82">JSON in</text>
-    <rect x="20" y="89" width="155" height="34" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="89" width="155" height="34" rx="6" stroke-width="1.2"/>
     <text class="mono" x="30" y="111">{ "name": "Alice" }</text>
     <text class="mono-sm" x="97" y="138" text-anchor="middle">parses to ↓</text>
 
-    <rect x="20" y="146" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="146" width="155" height="55" rx="6" stroke-width="1.2"/>
     <text class="mono" x="30" y="163">class Request {</text>
-    <text class="mono" x="42" y="180"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono" x="42" y="180"><tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name;</text>
     <text class="mono" x="30" y="197">}</text>
 
     <!-- ───── Badge: Automatic JSON validation ───── -->
-    <rect x="195" y="78" width="180" height="32" rx="16" fill="#10B981"/>
+    <rect class="green-solid" x="195" y="78" width="180" height="32" rx="16"/>
     <text class="badge-head" x="285" y="92" text-anchor="middle">✓ Automatic JSON validation</text>
     <text class="badge-sub" x="285" y="105" text-anchor="middle">ASP.NET + JsonConverter</text>
 
@@ -175,75 +233,75 @@
     <line x1="175" y1="170" x2="195" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
 
     <!-- ───── Controller box ───── -->
-    <rect x="195" y="125" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="285" y="146" text-anchor="middle" fill="#047857">Controller</text>
-    <line x1="210" y1="158" x2="360" y2="158" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="285" y="186" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+    <rect class="green-bg green-border" x="195" y="125" width="180" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="285" y="146" text-anchor="middle">Controller</text>
+    <line class="green-line" x1="210" y1="158" x2="360" y2="158" stroke-width="1"/>
+    <text class="mono-sm green-text" x="285" y="186" text-anchor="middle">trusts NonEmptyString</text>
 
     <!-- Arrow 2: Controller → Services -->
     <line x1="375" y1="170" x2="485" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="430" y="160" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <text class="type-label green-text" x="430" y="160" text-anchor="middle">NonEmptyString</text>
 
     <!-- ───── Services box (with shadow stack) ───── -->
-    <rect x="497" y="113" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
-    <rect x="491" y="119" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.7"/>
-    <rect x="485" y="125" width="180" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="575" y="146" text-anchor="middle" fill="#047857">Services</text>
-    <line x1="500" y1="158" x2="650" y2="158" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="575" y="186" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+    <rect class="green-bg green-border" x="497" y="113" width="180" height="80" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="green-bg green-border" x="491" y="119" width="180" height="80" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="green-bg green-border" x="485" y="125" width="180" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="575" y="146" text-anchor="middle">Services</text>
+    <line class="green-line" x1="500" y1="158" x2="650" y2="158" stroke-width="1"/>
+    <text class="mono-sm green-text" x="575" y="186" text-anchor="middle">trusts NonEmptyString</text>
 
     <!-- Arrow 3: Services → Entity -->
     <line x1="665" y1="170" x2="775" y2="170" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label" x="720" y="160" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <text class="type-label green-text" x="720" y="160" text-anchor="middle">NonEmptyString</text>
 
     <!-- ───── Entity box ───── -->
-    <rect x="775" y="125" width="200" height="80" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title" x="875" y="146" text-anchor="middle" fill="#047857">Entity / DB</text>
-    <line x1="790" y1="158" x2="960" y2="158" stroke="#6EE7B7" stroke-width="1"/>
-    <text class="mono-sm" x="790" y="186">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
+    <rect class="green-bg green-border" x="775" y="125" width="200" height="80" rx="8" stroke-width="1.5"/>
+    <text class="layer-title green-text" x="875" y="146" text-anchor="middle">Entity / DB</text>
+    <line class="green-line" x1="790" y1="158" x2="960" y2="158" stroke-width="1"/>
+    <text class="mono-sm" x="790" y="186">public <tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name</text>
 
     <!-- ─────── Light divider between Write and Usage ─────── -->
-    <line x1="35" y1="217" x2="955" y2="217" stroke="#D1FAE5" stroke-width="1"/>
+    <line class="green-line-soft" x1="35" y1="217" x2="955" y2="217" stroke-width="1"/>
 
     <!-- ────────── Usage row ────────── -->
     <text class="flow-tag" x="35" y="234">Usage ↑</text>
 
     <!-- ─── Response box (Usage row, left) ─── -->
     <text class="external" x="25" y="257">JSON out</text>
-    <rect x="20" y="264" width="155" height="55" rx="6" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.2"/>
+    <rect class="pill-bg pill-border" x="20" y="264" width="155" height="55" rx="6" stroke-width="1.2"/>
     <text class="mono-sm" x="30" y="282">class Response {</text>
-    <text class="mono-sm" x="42" y="298"><tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name;</text>
+    <text class="mono-sm" x="42" y="298"><tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name;</text>
     <text class="mono-sm" x="30" y="314">}</text>
 
     <!-- ─── Controller box (Usage row, empty) ─── -->
-    <rect x="195" y="264" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="285" y="285" text-anchor="middle" fill="#047857">Controller</text>
-    <text class="mono-xs" x="285" y="305" text-anchor="middle" font-style="italic" fill="#6EE7B7">maps to Response</text>
+    <rect class="green-bg green-border" x="195" y="264" width="180" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="285" y="285" text-anchor="middle">Controller</text>
+    <text class="mono-xs green-muted" x="285" y="305" text-anchor="middle" font-style="italic">maps to Response</text>
 
     <!-- ─── Services box (Usage row, with shadow stack) ─── -->
-    <rect x="497" y="252" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.45"/>
-    <rect x="491" y="258" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5" opacity="0.7"/>
-    <rect x="485" y="264" width="180" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="575" y="285" text-anchor="middle" fill="#047857">Services</text>
-    <text class="mono-xs" x="575" y="305" text-anchor="middle" fill="#047857">trusts NonEmptyString</text>
+    <rect class="green-bg green-border" x="497" y="252" width="180" height="55" rx="8" stroke-width="1.5" opacity="0.45"/>
+    <rect class="green-bg green-border" x="491" y="258" width="180" height="55" rx="8" stroke-width="1.5" opacity="0.7"/>
+    <rect class="green-bg green-border" x="485" y="264" width="180" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="575" y="285" text-anchor="middle">Services</text>
+    <text class="mono-xs green-text" x="575" y="305" text-anchor="middle">trusts NonEmptyString</text>
 
     <!-- ─── Entity box (Usage row) ─── -->
-    <rect x="775" y="264" width="200" height="55" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="layer-title-sm" x="875" y="285" text-anchor="middle" fill="#047857">Entity / DB</text>
-    <text class="mono-sm" x="875" y="307" text-anchor="middle">public <tspan fill="#047857" font-weight="600">NonEmptyString</tspan> Name</text>
+    <rect class="green-bg green-border" x="775" y="264" width="200" height="55" rx="8" stroke-width="1.5"/>
+    <text class="layer-title-sm green-text" x="875" y="285" text-anchor="middle">Entity / DB</text>
+    <text class="mono-sm" x="875" y="307" text-anchor="middle">public <tspan class="green-text" font-weight="600">NonEmptyString</tspan> Name</text>
 
     <!-- Usage arrow: Entity → Services -->
     <line x1="775" y1="291" x2="665" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label-sm" x="720" y="282" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <text class="type-label-sm green-text" x="720" y="282" text-anchor="middle">NonEmptyString</text>
 
     <!-- Usage arrow: Services → Controller -->
     <line x1="485" y1="291" x2="375" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
-    <text class="type-label-sm" x="430" y="282" text-anchor="middle" fill="#047857">NonEmptyString</text>
+    <text class="type-label-sm green-text" x="430" y="282" text-anchor="middle">NonEmptyString</text>
 
     <!-- Usage arrow: Controller → Response -->
     <line x1="195" y1="291" x2="175" y2="291" stroke="#10B981" stroke-width="1.5" marker-end="url(#imp-arrow-green)"/>
 
     <!-- Note -->
-    <text class="note" x="35" y="342">The type travels all the way back out — the response DTO is still <tspan font-family="ui-monospace, Menlo, Consolas, monospace" fill="#047857">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
+    <text class="note" x="35" y="342">The type travels all the way back out — the response DTO is still <tspan class="green-text" font-family="ui-monospace, Menlo, Consolas, monospace">NonEmptyString</tspan>, so any downstream consumer already knows it's non-empty.</text>
   </g>
 </svg>

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -41,7 +41,7 @@
     .divider-mid   { stroke: #E5E7EB; }
     .muted-text    { fill: #9CA3AF; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
       .pill-bg       { fill: #161b22; }

--- a/docs/diagrams/impact.svg
+++ b/docs/diagrams/impact.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 15 960 730" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 990 760" role="img" aria-label="Impact of StrongTypes on application validation boundaries">
   <style>
     .panel-title  { font: 700 15px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .panel-sub    { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/docs/diagrams/maybe-composition-dark.svg
+++ b/docs/diagrams/maybe-composition-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 560" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .section-rule  { stroke: #E5E7EB; }
 
     .green-bg      { fill: #ECFDF5; }
@@ -29,8 +27,6 @@
     .op-label-muted { fill: #6B7280; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }
 
       .green-bg      { fill: #0a2618; }
@@ -64,8 +60,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="640"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="639" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>

--- a/docs/diagrams/maybe-composition-dark.svg
+++ b/docs/diagrams/maybe-composition-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 560" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }

--- a/docs/diagrams/maybe-composition-dark.svg
+++ b/docs/diagrams/maybe-composition-dark.svg
@@ -1,0 +1,178 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+  <style>
+    .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .op-hint   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .track-tag { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .section-rule  { stroke: #E5E7EB; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-text    { fill: #065F46; }
+    .green-tag     { fill: #047857; }
+
+    .none-bg       { fill: #F9FAFB; }
+    .none-border   { stroke: #9CA3AF; }
+    .none-text     { fill: #374151; }
+    .none-tag      { fill: #6B7280; }
+
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #6366F1; }
+    .pill-text     { fill: #4338CA; }
+
+    .op-label-muted { fill: #6B7280; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .section-rule  { stroke: #30363d; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-text    { fill: #6EE7B7; }
+      .green-tag     { fill: #34D399; }
+
+      .none-bg       { fill: #161b22; }
+      .none-border   { stroke: #6e7681; }
+      .none-text     { fill: #c9d1d9; }
+      .none-tag      { fill: #8b949e; }
+
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #818CF8; }
+      .pill-text     { fill: #C7D2FE; }
+
+      .op-name       { fill: #e6edf3; }
+      .op-sig        { fill: #8b949e; }
+      .op-hint       { fill: #8b949e; }
+      .op-label      { fill: #e6edf3; }
+      .op-label-muted { fill: #8b949e; }
+      .note          { fill: #8b949e; }
+    }
+  </style>
+
+  <defs>
+    <marker id="mc-g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="mc-n" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="900" height="640"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="639" rx="10"/>
+
+  <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
+  <g>
+    <text class="op-name" x="30" y="40">Map</text>
+    <text class="op-sig"  x="85" y="40">f : T → U</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">result is auto-wrapped back into Maybe</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Some track -->
+    <text class="track-tag green-tag" x="30" y="90">Some</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="95" text-anchor="middle">Some(x)</text>
+    <line x1="220" y1="90" x2="400" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <text class="op-label" x="310" y="82" text-anchor="middle">Map(f)</text>
+    <rect class="green-bg green-border" x="400" y="74" width="160" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="480" y="95" text-anchor="middle">Some(f(x))</text>
+    <text class="note" x="580" y="95">f returned a T; Maybe wraps it automatically</text>
+
+    <!-- None track -->
+    <text class="track-tag none-tag" x="30" y="140">None</text>
+    <rect class="none-bg none-border" x="90"  y="124" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="145" text-anchor="middle">None</text>
+    <line x1="220" y1="140" x2="400" y2="140" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label op-label-muted" x="310" y="132" text-anchor="middle">Map(f)</text>
+    <rect class="none-bg none-border" x="400" y="124" width="160" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="480" y="145" text-anchor="middle">None</text>
+    <text class="note" x="580" y="145">f never called — short-circuits</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 2: FlatMap ═══════════════════ -->
+  <g transform="translate(0, 180)">
+    <text class="op-name" x="30" y="40">FlatMap</text>
+    <text class="op-sig"  x="125" y="40">f : T → Maybe&lt;U&gt;</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Maybe&lt;U&gt; — unwrapped directly to avoid Maybe&lt;Maybe&lt;U&gt;&gt;</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Some track: branches -->
+    <text class="track-tag green-tag" x="30" y="107">Some</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="112" text-anchor="middle">Some(x)</text>
+
+    <!-- Arrow to intermediate -->
+    <line x1="220" y1="107" x2="290" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <text class="op-label" x="255" y="99" text-anchor="middle">FlatMap(f)</text>
+
+    <!-- Intermediate "f(x) : Maybe<U>" -->
+    <rect class="pill-bg pill-border" x="290" y="91" width="170" height="32" rx="8" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono pill-text" x="375" y="112" text-anchor="middle">f(x) : Maybe&lt;U&gt;</text>
+
+    <!-- Branch arrows out of intermediate -->
+    <path d="M 460 100 C 495 95, 505 82, 540 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <path d="M 460 115 C 495 120, 505 133, 540 135" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+
+    <!-- Outcome pills (top: Some, bottom: None) -->
+    <rect class="green-bg green-border" x="540" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="610" y="85" text-anchor="middle">Some(y)</text>
+    <text class="note" x="690" y="85">f returned Some</text>
+
+    <rect class="none-bg none-border" x="540" y="120" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="610" y="141" text-anchor="middle">None</text>
+    <text class="note" x="690" y="141">f returned None</text>
+
+    <!-- None track -->
+    <text class="track-tag none-tag" x="30" y="185">None</text>
+    <rect class="none-bg none-border" x="90"  y="169" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="190" text-anchor="middle">None</text>
+    <line x1="220" y1="185" x2="540" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label op-label-muted" x="380" y="177" text-anchor="middle">FlatMap(f)</text>
+    <rect class="none-bg none-border" x="540" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="610" y="190" text-anchor="middle">None</text>
+    <text class="note" x="690" y="190">f never called — short-circuits</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 3: Where ═══════════════════ -->
+  <g transform="translate(0, 400)">
+    <text class="op-name" x="30" y="40">Where</text>
+    <text class="op-sig"  x="110" y="40">p : T → bool</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">predicate decides whether to keep the value</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Some track: branches -->
+    <text class="track-tag green-tag" x="30" y="107">Some</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="112" text-anchor="middle">Some(x)</text>
+
+    <!-- Arrow with "Where(p)" label, splits -->
+    <path d="M 220 100 C 300 95, 340 82, 400 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
+    <path d="M 220 115 C 300 120, 340 133, 400 135" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label" x="290" y="112" text-anchor="middle">Where(p)</text>
+
+    <!-- Outcome pills -->
+    <rect class="green-bg green-border" x="400" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="470" y="85" text-anchor="middle">Some(x)</text>
+    <text class="note" x="550" y="85">p(x) = true</text>
+
+    <rect class="none-bg none-border" x="400" y="120" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="470" y="141" text-anchor="middle">None</text>
+    <text class="note" x="550" y="141">p(x) = false</text>
+
+    <!-- None track -->
+    <text class="track-tag none-tag" x="30" y="185">None</text>
+    <rect class="none-bg none-border" x="90"  y="169" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="190" text-anchor="middle">None</text>
+    <line x1="220" y1="185" x2="400" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
+    <text class="op-label op-label-muted" x="310" y="177" text-anchor="middle">Where(p)</text>
+    <rect class="none-bg none-border" x="400" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="470" y="190" text-anchor="middle">None</text>
+    <text class="note" x="550" y="190">p never called — short-circuits</text>
+  </g>
+</svg>

--- a/docs/diagrams/maybe-composition.svg
+++ b/docs/diagrams/maybe-composition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 560" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }

--- a/docs/diagrams/maybe-composition.svg
+++ b/docs/diagrams/maybe-composition.svg
@@ -28,7 +28,7 @@
 
     .op-label-muted { fill: #6B7280; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }

--- a/docs/diagrams/maybe-composition.svg
+++ b/docs/diagrams/maybe-composition.svg
@@ -7,6 +7,52 @@
     .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .section-rule  { stroke: #E5E7EB; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-text    { fill: #065F46; }
+    .green-tag     { fill: #047857; }
+
+    .none-bg       { fill: #F9FAFB; }
+    .none-border   { stroke: #9CA3AF; }
+    .none-text     { fill: #374151; }
+    .none-tag      { fill: #6B7280; }
+
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #6366F1; }
+    .pill-text     { fill: #4338CA; }
+
+    .op-label-muted { fill: #6B7280; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .section-rule  { stroke: #30363d; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-text    { fill: #6EE7B7; }
+      .green-tag     { fill: #34D399; }
+
+      .none-bg       { fill: #161b22; }
+      .none-border   { stroke: #6e7681; }
+      .none-text     { fill: #c9d1d9; }
+      .none-tag      { fill: #8b949e; }
+
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #818CF8; }
+      .pill-text     { fill: #C7D2FE; }
+
+      .op-name       { fill: #e6edf3; }
+      .op-sig        { fill: #8b949e; }
+      .op-hint       { fill: #8b949e; }
+      .op-label      { fill: #e6edf3; }
+      .op-label-muted { fill: #8b949e; }
+      .note          { fill: #8b949e; }
+    }
   </style>
 
   <defs>
@@ -18,34 +64,34 @@
     </marker>
   </defs>
 
-  <rect width="900" height="640" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="899" height="639" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect class="canvas-bg" width="900" height="640"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="639" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>
     <text class="op-name" x="30" y="40">Map</text>
     <text class="op-sig"  x="85" y="40">f : T → U</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">result is auto-wrapped back into Maybe</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Some track -->
-    <text class="track-tag" x="30" y="90" fill="#047857">Some</text>
-    <rect x="90"  y="74" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="155" y="95" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <text class="track-tag green-tag" x="30" y="90">Some</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="95" text-anchor="middle">Some(x)</text>
     <line x1="220" y1="90" x2="400" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
     <text class="op-label" x="310" y="82" text-anchor="middle">Map(f)</text>
-    <rect x="400" y="74" width="160" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="480" y="95" text-anchor="middle" fill="#065F46">Some(f(x))</text>
+    <rect class="green-bg green-border" x="400" y="74" width="160" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="480" y="95" text-anchor="middle">Some(f(x))</text>
     <text class="note" x="580" y="95">f returned a T; Maybe wraps it automatically</text>
 
     <!-- None track -->
-    <text class="track-tag" x="30" y="140" fill="#6B7280">None</text>
-    <rect x="90"  y="124" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="155" y="145" text-anchor="middle" fill="#374151">None</text>
+    <text class="track-tag none-tag" x="30" y="140">None</text>
+    <rect class="none-bg none-border" x="90"  y="124" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="145" text-anchor="middle">None</text>
     <line x1="220" y1="140" x2="400" y2="140" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
-    <text class="op-label" x="310" y="132" text-anchor="middle" fill="#6B7280">Map(f)</text>
-    <rect x="400" y="124" width="160" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="480" y="145" text-anchor="middle" fill="#374151">None</text>
+    <text class="op-label op-label-muted" x="310" y="132" text-anchor="middle">Map(f)</text>
+    <rect class="none-bg none-border" x="400" y="124" width="160" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="480" y="145" text-anchor="middle">None</text>
     <text class="note" x="580" y="145">f never called — short-circuits</text>
   </g>
 
@@ -54,42 +100,42 @@
     <text class="op-name" x="30" y="40">FlatMap</text>
     <text class="op-sig"  x="125" y="40">f : T → Maybe&lt;U&gt;</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Maybe&lt;U&gt; — unwrapped directly to avoid Maybe&lt;Maybe&lt;U&gt;&gt;</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Some track: branches -->
-    <text class="track-tag" x="30" y="107" fill="#047857">Some</text>
-    <rect x="90"  y="91" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="155" y="112" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <text class="track-tag green-tag" x="30" y="107">Some</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="112" text-anchor="middle">Some(x)</text>
 
     <!-- Arrow to intermediate -->
     <line x1="220" y1="107" x2="290" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
     <text class="op-label" x="255" y="99" text-anchor="middle">FlatMap(f)</text>
 
     <!-- Intermediate "f(x) : Maybe<U>" -->
-    <rect x="290" y="91" width="170" height="32" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5" stroke-dasharray="5 3"/>
-    <text class="mono" x="375" y="112" text-anchor="middle" fill="#4338CA">f(x) : Maybe&lt;U&gt;</text>
+    <rect class="pill-bg pill-border" x="290" y="91" width="170" height="32" rx="8" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono pill-text" x="375" y="112" text-anchor="middle">f(x) : Maybe&lt;U&gt;</text>
 
     <!-- Branch arrows out of intermediate -->
     <path d="M 460 100 C 495 95, 505 82, 540 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
     <path d="M 460 115 C 495 120, 505 133, 540 135" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
 
     <!-- Outcome pills (top: Some, bottom: None) -->
-    <rect x="540" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="610" y="85" text-anchor="middle" fill="#065F46">Some(y)</text>
+    <rect class="green-bg green-border" x="540" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="610" y="85" text-anchor="middle">Some(y)</text>
     <text class="note" x="690" y="85">f returned Some</text>
 
-    <rect x="540" y="120" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="610" y="141" text-anchor="middle" fill="#374151">None</text>
+    <rect class="none-bg none-border" x="540" y="120" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="610" y="141" text-anchor="middle">None</text>
     <text class="note" x="690" y="141">f returned None</text>
 
     <!-- None track -->
-    <text class="track-tag" x="30" y="185" fill="#6B7280">None</text>
-    <rect x="90"  y="169" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="155" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="track-tag none-tag" x="30" y="185">None</text>
+    <rect class="none-bg none-border" x="90"  y="169" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="190" text-anchor="middle">None</text>
     <line x1="220" y1="185" x2="540" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
-    <text class="op-label" x="380" y="177" text-anchor="middle" fill="#6B7280">FlatMap(f)</text>
-    <rect x="540" y="169" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="610" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="op-label op-label-muted" x="380" y="177" text-anchor="middle">FlatMap(f)</text>
+    <rect class="none-bg none-border" x="540" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="610" y="190" text-anchor="middle">None</text>
     <text class="note" x="690" y="190">f never called — short-circuits</text>
   </g>
 
@@ -98,12 +144,12 @@
     <text class="op-name" x="30" y="40">Where</text>
     <text class="op-sig"  x="110" y="40">p : T → bool</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">predicate decides whether to keep the value</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Some track: branches -->
-    <text class="track-tag" x="30" y="107" fill="#047857">Some</text>
-    <rect x="90"  y="91" width="130" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="155" y="112" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <text class="track-tag green-tag" x="30" y="107">Some</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="130" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="155" y="112" text-anchor="middle">Some(x)</text>
 
     <!-- Arrow with "Where(p)" label, splits -->
     <path d="M 220 100 C 300 95, 340 82, 400 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#mc-g)"/>
@@ -111,22 +157,22 @@
     <text class="op-label" x="290" y="112" text-anchor="middle">Where(p)</text>
 
     <!-- Outcome pills -->
-    <rect x="400" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="470" y="85" text-anchor="middle" fill="#065F46">Some(x)</text>
+    <rect class="green-bg green-border" x="400" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="470" y="85" text-anchor="middle">Some(x)</text>
     <text class="note" x="550" y="85">p(x) = true</text>
 
-    <rect x="400" y="120" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="470" y="141" text-anchor="middle" fill="#374151">None</text>
+    <rect class="none-bg none-border" x="400" y="120" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="470" y="141" text-anchor="middle">None</text>
     <text class="note" x="550" y="141">p(x) = false</text>
 
     <!-- None track -->
-    <text class="track-tag" x="30" y="185" fill="#6B7280">None</text>
-    <rect x="90"  y="169" width="130" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="155" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="track-tag none-tag" x="30" y="185">None</text>
+    <rect class="none-bg none-border" x="90"  y="169" width="130" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="155" y="190" text-anchor="middle">None</text>
     <line x1="220" y1="185" x2="400" y2="185" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#mc-n)"/>
-    <text class="op-label" x="310" y="177" text-anchor="middle" fill="#6B7280">Where(p)</text>
-    <rect x="400" y="169" width="140" height="32" rx="16" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="470" y="190" text-anchor="middle" fill="#374151">None</text>
+    <text class="op-label op-label-muted" x="310" y="177" text-anchor="middle">Where(p)</text>
+    <rect class="none-bg none-border" x="400" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono none-text" x="470" y="190" text-anchor="middle">None</text>
     <text class="note" x="550" y="190">p never called — short-circuits</text>
   </g>
 </svg>

--- a/docs/diagrams/maybe-composition.svg
+++ b/docs/diagrams/maybe-composition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 560" role="img" aria-label="Maybe composition: Map, FlatMap, Where">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .section-rule  { stroke: #E5E7EB; }
 
     .green-bg      { fill: #ECFDF5; }
@@ -29,8 +27,6 @@
     .op-label-muted { fill: #6B7280; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }
 
       .green-bg      { fill: #0a2618; }
@@ -64,8 +60,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="640"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="639" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>

--- a/docs/diagrams/package-layout-dark.svg
+++ b/docs/diagrams/package-layout-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" role="img" aria-label="StrongTypes NuGet package layout">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="15 15 770 330" role="img" aria-label="StrongTypes NuGet package layout">
   <style>
     .card-title { font: 600 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
@@ -12,8 +12,6 @@
     .sub-bullet { fill: none; stroke: #9CA3AF; stroke-width: 1.2; }
     .sm-bullet  { fill: #9CA3AF; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .core-bg       { fill: #EEF2FF; }
     .core-border   { stroke: #6366F1; }
     .card-bg       { fill: #FFFFFF; }
@@ -21,8 +19,6 @@
     .arrow-line    { stroke: #6B7280; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .core-bg       { fill: #1a1d40; }
       .core-border   { stroke: #818CF8; }
       .card-bg       { fill: #161b22; }
@@ -49,8 +45,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="800" height="360"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="799" height="359" rx="10"/>
 
   <!-- Core card (top-left) -->
   <rect class="core-bg core-border" x="15" y="15" width="395" height="190" rx="8" stroke-width="1.5"/>

--- a/docs/diagrams/package-layout-dark.svg
+++ b/docs/diagrams/package-layout-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="15 15 770 330" role="img" aria-label="StrongTypes NuGet package layout">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" role="img" aria-label="StrongTypes NuGet package layout">
   <style>
     .card-title { font: 600 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }

--- a/docs/diagrams/package-layout-dark.svg
+++ b/docs/diagrams/package-layout-dark.svg
@@ -1,0 +1,120 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" role="img" aria-label="StrongTypes NuGet package layout">
+  <style>
+    .card-title { font: 600 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .body       { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .body-mono  { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
+    .sub-body   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .sub-mono   { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .card-body  { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .card-mono  { font: 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #374151; }
+    .bullet     { fill: #6366F1; }
+    .sub-bullet { fill: none; stroke: #9CA3AF; stroke-width: 1.2; }
+    .sm-bullet  { fill: #9CA3AF; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .core-bg       { fill: #EEF2FF; }
+    .core-border   { stroke: #6366F1; }
+    .card-bg       { fill: #FFFFFF; }
+    .card-border   { stroke: #E5E7EB; }
+    .arrow-line    { stroke: #6B7280; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .core-bg       { fill: #1a1d40; }
+      .core-border   { stroke: #818CF8; }
+      .card-bg       { fill: #161b22; }
+      .card-border   { stroke: #30363d; }
+      .arrow-line    { stroke: #8b949e; }
+
+      .card-title { fill: #e6edf3; }
+      .core-title { fill: #e6edf3; }
+      .body       { fill: #c9d1d9; }
+      .body-mono  { fill: #c9d1d9; }
+      .sub-body   { fill: #8b949e; }
+      .sub-mono   { fill: #8b949e; }
+      .card-body  { fill: #c9d1d9; }
+      .card-mono  { fill: #c9d1d9; }
+      .bullet     { fill: #A5B4FC; }
+      .sub-bullet { stroke: #6e7681; }
+      .sm-bullet  { fill: #8b949e; }
+    }
+  </style>
+
+  <defs>
+    <marker id="pl-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#6B7280"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="800" height="360"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="799" height="359" rx="10"/>
+
+  <!-- Core card (top-left) -->
+  <rect class="core-bg core-border" x="15" y="15" width="395" height="190" rx="8" stroke-width="1.5"/>
+  <text class="core-title" x="33" y="42">Kalicz.StrongTypes</text>
+
+  <!-- Bullet 1: Maybe + JSON Converter -->
+  <circle class="bullet" cx="41" cy="70" r="2.5"/>
+  <text class="body-mono" x="51" y="74">Maybe&lt;T&gt;<tspan class="body"> + JSON converter</tspan></text>
+
+  <!-- Bullet 2: Result -->
+  <circle class="bullet" cx="41" cy="93" r="2.5"/>
+  <text class="body-mono" x="51" y="97">Result&lt;T&gt; / Result&lt;T, TError&gt;</text>
+
+  <!-- Bullet 3: Validated types -->
+  <circle class="bullet" cx="41" cy="116" r="2.5"/>
+  <text class="body" x="51" y="120">Validated types<tspan class="sub-body"> (with JSON converters)</tspan></text>
+
+  <!-- Sub-bullets -->
+  <circle class="sub-bullet" cx="70" cy="139" r="2.3"/>
+  <text class="sub-mono" x="81" y="143">NonEmptyString</text>
+
+  <circle class="sub-bullet" cx="70" cy="160" r="2.3"/>
+  <text class="sub-mono" x="81" y="164">NonEmptyEnumerable&lt;T&gt;</text>
+
+  <circle class="sub-bullet" cx="70" cy="181" r="2.3"/>
+  <text class="sub-body" x="81" y="185">Numeric wrappers <tspan font-family="ui-monospace, Menlo, Consolas, monospace">(Positive&lt;T&gt;, …)</tspan></text>
+
+  <!-- OpenApi.Microsoft card (top-right) -->
+  <rect class="card-bg card-border" x="460" y="15" width="320" height="92" rx="8" stroke-width="1.5"/>
+  <text class="card-title" x="474" y="37">Kalicz.StrongTypes.OpenApi.Microsoft</text>
+  <circle class="sm-bullet" cx="480" cy="62" r="2"/>
+  <text class="card-body" x="488" y="66">Schema transformers</text>
+  <circle class="sm-bullet" cx="480" cy="87" r="2"/>
+  <text class="card-body" x="488" y="91">for <tspan font-family="ui-monospace, Menlo, Consolas, monospace">AddOpenApi()</tspan></text>
+
+  <!-- OpenApi.Swashbuckle card (mid-right) -->
+  <rect class="card-bg card-border" x="460" y="113" width="320" height="92" rx="8" stroke-width="1.5"/>
+  <text class="card-title" x="474" y="135">Kalicz.StrongTypes.OpenApi.Swashbuckle</text>
+  <circle class="sm-bullet" cx="480" cy="160" r="2"/>
+  <text class="card-body" x="488" y="164">Schema filters</text>
+  <circle class="sm-bullet" cx="480" cy="185" r="2"/>
+  <text class="card-body" x="488" y="189">for <tspan font-family="ui-monospace, Menlo, Consolas, monospace">AddSwaggerGen()</tspan></text>
+
+  <!-- EfCore card (bottom-left, under Core) -->
+  <rect class="card-bg card-border" x="15" y="235" width="215" height="110" rx="8" stroke-width="1.5"/>
+  <text class="card-title" x="29" y="259">Kalicz.StrongTypes.EfCore</text>
+  <circle class="sm-bullet" cx="35" cy="284" r="2"/>
+  <text class="card-body" x="43" y="288">EF Core value converters</text>
+  <circle class="sm-bullet" cx="35" cy="306" r="2"/>
+  <text class="card-body" x="43" y="310">DbContext extension</text>
+
+  <!-- FsCheck card (bottom-right, under Core) -->
+  <rect class="card-bg card-border" x="245" y="235" width="215" height="110" rx="8" stroke-width="1.5"/>
+  <text class="card-title" x="259" y="259">Kalicz.StrongTypes.FsCheck</text>
+  <circle class="sm-bullet" cx="265" cy="282" r="2"/>
+  <text class="card-body" x="273" y="286">Property-based (generative) testing</text>
+  <circle class="sm-bullet" cx="265" cy="304" r="2"/>
+  <text class="card-body" x="273" y="308">FsCheck Arbitrary&lt;T&gt;</text>
+  <circle class="sm-bullet" cx="265" cy="326" r="2"/>
+  <text class="card-body" x="273" y="330">generators</text>
+
+  <!-- Arrows from satellite cards to core card -->
+  <line class="arrow-line" x1="460" y1="61"  x2="412" y2="61"  stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="460" y1="159" x2="412" y2="159" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="122" y1="235" x2="122" y2="210" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="352" y1="235" x2="352" y2="210" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+</svg>

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -11,6 +11,36 @@
     .bullet     { fill: #6366F1; }
     .sub-bullet { fill: none; stroke: #9CA3AF; stroke-width: 1.2; }
     .sm-bullet  { fill: #9CA3AF; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .core-bg       { fill: #EEF2FF; }
+    .core-border   { stroke: #6366F1; }
+    .card-bg       { fill: #FFFFFF; }
+    .card-border   { stroke: #E5E7EB; }
+    .arrow-line    { stroke: #6B7280; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .core-bg       { fill: #1a1d40; }
+      .core-border   { stroke: #818CF8; }
+      .card-bg       { fill: #161b22; }
+      .card-border   { stroke: #30363d; }
+      .arrow-line    { stroke: #8b949e; }
+
+      .card-title { fill: #e6edf3; }
+      .core-title { fill: #e6edf3; }
+      .body       { fill: #c9d1d9; }
+      .body-mono  { fill: #c9d1d9; }
+      .sub-body   { fill: #8b949e; }
+      .sub-mono   { fill: #8b949e; }
+      .card-body  { fill: #c9d1d9; }
+      .card-mono  { fill: #c9d1d9; }
+      .bullet     { fill: #A5B4FC; }
+      .sub-bullet { stroke: #6e7681; }
+      .sm-bullet  { fill: #8b949e; }
+    }
   </style>
 
   <defs>
@@ -19,16 +49,16 @@
     </marker>
   </defs>
 
-  <rect width="800" height="360" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="799" height="359" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect class="canvas-bg" width="800" height="360"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="799" height="359" rx="10"/>
 
   <!-- Core card (top-left) -->
-  <rect x="15" y="15" width="395" height="190" rx="8" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+  <rect class="core-bg core-border" x="15" y="15" width="395" height="190" rx="8" stroke-width="1.5"/>
   <text class="core-title" x="33" y="42">Kalicz.StrongTypes</text>
 
   <!-- Bullet 1: Maybe + JSON Converter -->
   <circle class="bullet" cx="41" cy="70" r="2.5"/>
-  <text class="body-mono" x="51" y="74">Maybe&lt;T&gt;<tspan class="body" fill="#374151"> + JSON converter</tspan></text>
+  <text class="body-mono" x="51" y="74">Maybe&lt;T&gt;<tspan class="body"> + JSON converter</tspan></text>
 
   <!-- Bullet 2: Result -->
   <circle class="bullet" cx="41" cy="93" r="2.5"/>
@@ -36,7 +66,7 @@
 
   <!-- Bullet 3: Validated types -->
   <circle class="bullet" cx="41" cy="116" r="2.5"/>
-  <text class="body" x="51" y="120">Validated types<tspan fill="#6B7280"> (with JSON converters)</tspan></text>
+  <text class="body" x="51" y="120">Validated types<tspan class="sub-body"> (with JSON converters)</tspan></text>
 
   <!-- Sub-bullets -->
   <circle class="sub-bullet" cx="70" cy="139" r="2.3"/>
@@ -49,7 +79,7 @@
   <text class="sub-body" x="81" y="185">Numeric wrappers <tspan font-family="ui-monospace, Menlo, Consolas, monospace">(Positive&lt;T&gt;, …)</tspan></text>
 
   <!-- OpenApi.Microsoft card (top-right) -->
-  <rect x="460" y="15" width="320" height="92" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="card-bg card-border" x="460" y="15" width="320" height="92" rx="8" stroke-width="1.5"/>
   <text class="card-title" x="474" y="37">Kalicz.StrongTypes.OpenApi.Microsoft</text>
   <circle class="sm-bullet" cx="480" cy="62" r="2"/>
   <text class="card-body" x="488" y="66">Schema transformers</text>
@@ -57,7 +87,7 @@
   <text class="card-body" x="488" y="91">for <tspan font-family="ui-monospace, Menlo, Consolas, monospace">AddOpenApi()</tspan></text>
 
   <!-- OpenApi.Swashbuckle card (mid-right) -->
-  <rect x="460" y="113" width="320" height="92" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="card-bg card-border" x="460" y="113" width="320" height="92" rx="8" stroke-width="1.5"/>
   <text class="card-title" x="474" y="135">Kalicz.StrongTypes.OpenApi.Swashbuckle</text>
   <circle class="sm-bullet" cx="480" cy="160" r="2"/>
   <text class="card-body" x="488" y="164">Schema filters</text>
@@ -65,7 +95,7 @@
   <text class="card-body" x="488" y="189">for <tspan font-family="ui-monospace, Menlo, Consolas, monospace">AddSwaggerGen()</tspan></text>
 
   <!-- EfCore card (bottom-left, under Core) -->
-  <rect x="15" y="235" width="215" height="110" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="card-bg card-border" x="15" y="235" width="215" height="110" rx="8" stroke-width="1.5"/>
   <text class="card-title" x="29" y="259">Kalicz.StrongTypes.EfCore</text>
   <circle class="sm-bullet" cx="35" cy="284" r="2"/>
   <text class="card-body" x="43" y="288">EF Core value converters</text>
@@ -73,7 +103,7 @@
   <text class="card-body" x="43" y="310">DbContext extension</text>
 
   <!-- FsCheck card (bottom-right, under Core) -->
-  <rect x="245" y="235" width="215" height="110" rx="8" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="card-bg card-border" x="245" y="235" width="215" height="110" rx="8" stroke-width="1.5"/>
   <text class="card-title" x="259" y="259">Kalicz.StrongTypes.FsCheck</text>
   <circle class="sm-bullet" cx="265" cy="282" r="2"/>
   <text class="card-body" x="273" y="286">Property-based (generative) testing</text>
@@ -83,8 +113,8 @@
   <text class="card-body" x="273" y="330">generators</text>
 
   <!-- Arrows from satellite cards to core card -->
-  <line x1="460" y1="61"  x2="412" y2="61"  stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
-  <line x1="460" y1="159" x2="412" y2="159" stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
-  <line x1="122" y1="235" x2="122" y2="210" stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
-  <line x1="352" y1="235" x2="352" y2="210" stroke="#6B7280" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="460" y1="61"  x2="412" y2="61"  stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="460" y1="159" x2="412" y2="159" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="122" y1="235" x2="122" y2="210" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
+  <line class="arrow-line" x1="352" y1="235" x2="352" y2="210" stroke-width="1.5" marker-end="url(#pl-arrow)"/>
 </svg>

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -20,7 +20,7 @@
     .card-border   { stroke: #E5E7EB; }
     .arrow-line    { stroke: #6B7280; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
       .core-bg       { fill: #1a1d40; }

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 15 770 330" role="img" aria-label="StrongTypes NuGet package layout">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" role="img" aria-label="StrongTypes NuGet package layout">
   <style>
     .card-title { font: 600 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }

--- a/docs/diagrams/package-layout.svg
+++ b/docs/diagrams/package-layout.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" role="img" aria-label="StrongTypes NuGet package layout">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 15 770 330" role="img" aria-label="StrongTypes NuGet package layout">
   <style>
     .card-title { font: 600 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .core-title { font: 700 15px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
@@ -12,8 +12,6 @@
     .sub-bullet { fill: none; stroke: #9CA3AF; stroke-width: 1.2; }
     .sm-bullet  { fill: #9CA3AF; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .core-bg       { fill: #EEF2FF; }
     .core-border   { stroke: #6366F1; }
     .card-bg       { fill: #FFFFFF; }
@@ -21,8 +19,6 @@
     .arrow-line    { stroke: #6B7280; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .core-bg       { fill: #1a1d40; }
       .core-border   { stroke: #818CF8; }
       .card-bg       { fill: #161b22; }
@@ -49,8 +45,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="800" height="360"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="799" height="359" rx="10"/>
 
   <!-- Core card (top-left) -->
   <rect class="core-bg core-border" x="15" y="15" width="395" height="190" rx="8" stroke-width="1.5"/>

--- a/docs/diagrams/patch-three-state-dark.svg
+++ b/docs/diagrams/patch-three-state-dark.svg
@@ -1,0 +1,122 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+  <style>
+    .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
+    .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .col-head   { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono       { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .mono-lg    { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .intent     { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+
+    .gray-bg       { fill: #F9FAFB; }
+    .gray-border   { stroke: #E5E7EB; }
+    .gray-strong-border { stroke: #9CA3AF; }
+    .gray-dot      { fill: #9CA3AF; }
+    .gray-text     { fill: #374151; }
+
+    .amber-bg      { fill: #FFFBEB; }
+    .amber-border  { stroke: #F59E0B; }
+    .amber-dot     { fill: #F59E0B; }
+    .amber-text    { fill: #B45309; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-dot     { fill: #10B981; }
+    .green-text    { fill: #047857; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+
+      .gray-bg       { fill: #161b22; }
+      .gray-border   { stroke: #30363d; }
+      .gray-strong-border { stroke: #6e7681; }
+      .gray-dot      { fill: #8b949e; }
+      .gray-text     { fill: #c9d1d9; }
+
+      .amber-bg      { fill: #2a1f0a; }
+      .amber-text    { fill: #FCD34D; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-text    { fill: #34D399; }
+
+      .title-text { fill: #e6edf3; }
+      .subtitle   { fill: #8b949e; }
+      .col-head   { fill: #8b949e; }
+      .mono       { fill: #e6edf3; }
+      .mono-lg    { fill: #e6edf3; }
+    }
+  </style>
+
+  <defs>
+    <marker id="p3-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="900" height="440"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="439" rx="12"/>
+
+  <!-- Title -->
+  <text class="title-text" x="40" y="38">PATCH three-state model</text>
+  <text class="subtitle"   x="40" y="58">Wrapping <tspan font-family="ui-monospace, Menlo, monospace">Maybe&lt;T&gt;</tspan> in <tspan font-family="ui-monospace, Menlo, monospace">T?</tspan> distinguishes <tspan font-style="italic">untouched</tspan> from <tspan font-style="italic">explicitly cleared</tspan>.</text>
+
+  <!-- Column headers -->
+  <text class="col-head" x="40"  y="105">Incoming JSON</text>
+  <text class="col-head" x="330" y="105">Property value</text>
+  <text class="col-head" x="640" y="105">Intent</text>
+
+  <!-- Row 1: Untouched (gray) -->
+  <rect class="gray-bg gray-border" x="40"  y="125" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono" x="60" y="152">field omitted</text>
+  <text class="mono" x="60" y="172">— or —</text>
+  <text class="mono" x="60" y="188">"field": null</text>
+
+  <line x1="300" y1="160" x2="330" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="gray-bg gray-border" x="330" y="125" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="168" text-anchor="middle">(Maybe&lt;T&gt;?)null</text>
+
+  <line x1="590" y1="160" x2="620" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="gray-bg gray-strong-border" x="620" y="125" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="gray-dot" cx="640" cy="160" r="6"/>
+  <text class="intent gray-text" x="656" y="166">leave untouched</text>
+
+  <!-- Row 2: Clear to null (amber) -->
+  <rect class="amber-bg amber-border" x="40"  y="210" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono" x="60" y="237">"field": {}</text>
+  <text class="mono" x="60" y="257">— or —</text>
+  <text class="mono" x="60" y="273">"field": { "Value": null }</text>
+
+  <line x1="300" y1="245" x2="330" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="amber-bg amber-border" x="330" y="210" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="253" text-anchor="middle">Maybe&lt;T&gt;.None</text>
+
+  <line x1="590" y1="245" x2="620" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="amber-bg amber-border" x="620" y="210" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="amber-dot" cx="640" cy="245" r="6"/>
+  <text class="intent amber-text" x="656" y="251">clear to null</text>
+
+  <!-- Row 3: Set to value (green) -->
+  <rect class="green-bg green-border" x="40"  y="295" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono" x="60" y="338" text-anchor="start">"field": { "Value": x }</text>
+
+  <line x1="300" y1="330" x2="330" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="green-bg green-border" x="330" y="295" width="260" height="70" rx="10" stroke-width="1.5"/>
+  <text class="mono-lg" x="460" y="338" text-anchor="middle">Maybe&lt;T&gt;.Some(x)</text>
+
+  <line x1="590" y1="330" x2="620" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
+
+  <rect class="green-bg green-border" x="620" y="295" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="green-dot" cx="640" cy="330" r="6"/>
+  <text class="intent green-text" x="656" y="336">set to x</text>
+
+  <!-- Footer note -->
+  <text class="subtitle" x="40" y="410">A plain <tspan font-family="ui-monospace, Menlo, monospace">T?</tspan> collapses rows 1 and 2 into a single <tspan font-family="ui-monospace, Menlo, monospace">null</tspan> — the outer <tspan font-family="ui-monospace, Menlo, monospace">?</tspan> around <tspan font-family="ui-monospace, Menlo, monospace">Maybe&lt;T&gt;</tspan> is what buys the third state.</text>
+</svg>

--- a/docs/diagrams/patch-three-state-dark.svg
+++ b/docs/diagrams/patch-three-state-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 364" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }

--- a/docs/diagrams/patch-three-state-dark.svg
+++ b/docs/diagrams/patch-three-state-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 364" role="img" aria-label="HTTP PATCH three-state model with Maybe">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
@@ -7,8 +7,6 @@
     .mono-lg    { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .intent     { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
 
     .gray-bg       { fill: #F9FAFB; }
     .gray-border   { stroke: #E5E7EB; }
@@ -27,8 +25,6 @@
     .green-text    { fill: #047857; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
 
       .gray-bg       { fill: #161b22; }
       .gray-border   { stroke: #30363d; }
@@ -56,8 +52,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="440"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="439" rx="12"/>
 
   <!-- Title -->
   <text class="title-text" x="40" y="38">PATCH three-state model</text>

--- a/docs/diagrams/patch-three-state.svg
+++ b/docs/diagrams/patch-three-state.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 364" role="img" aria-label="HTTP PATCH three-state model with Maybe">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
@@ -7,8 +7,6 @@
     .mono-lg    { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .intent     { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
 
     .gray-bg       { fill: #F9FAFB; }
     .gray-border   { stroke: #E5E7EB; }
@@ -27,8 +25,6 @@
     .green-text    { fill: #047857; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
 
       .gray-bg       { fill: #161b22; }
       .gray-border   { stroke: #30363d; }
@@ -56,8 +52,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="440"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="439" rx="12"/>
 
   <!-- Title -->
   <text class="title-text" x="40" y="38">PATCH three-state model</text>

--- a/docs/diagrams/patch-three-state.svg
+++ b/docs/diagrams/patch-three-state.svg
@@ -6,6 +6,48 @@
     .mono       { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .mono-lg    { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .intent     { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+
+    .gray-bg       { fill: #F9FAFB; }
+    .gray-border   { stroke: #E5E7EB; }
+    .gray-strong-border { stroke: #9CA3AF; }
+    .gray-dot      { fill: #9CA3AF; }
+    .gray-text     { fill: #374151; }
+
+    .amber-bg      { fill: #FFFBEB; }
+    .amber-border  { stroke: #F59E0B; }
+    .amber-dot     { fill: #F59E0B; }
+    .amber-text    { fill: #B45309; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-border  { stroke: #10B981; }
+    .green-dot     { fill: #10B981; }
+    .green-text    { fill: #047857; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+
+      .gray-bg       { fill: #161b22; }
+      .gray-border   { stroke: #30363d; }
+      .gray-strong-border { stroke: #6e7681; }
+      .gray-dot      { fill: #8b949e; }
+      .gray-text     { fill: #c9d1d9; }
+
+      .amber-bg      { fill: #2a1f0a; }
+      .amber-text    { fill: #FCD34D; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-text    { fill: #34D399; }
+
+      .title-text { fill: #e6edf3; }
+      .subtitle   { fill: #8b949e; }
+      .col-head   { fill: #8b949e; }
+      .mono       { fill: #e6edf3; }
+      .mono-lg    { fill: #e6edf3; }
+    }
   </style>
 
   <defs>
@@ -14,8 +56,8 @@
     </marker>
   </defs>
 
-  <rect width="900" height="440" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="899" height="439" fill="none" stroke="#E5E7EB" rx="12"/>
+  <rect class="canvas-bg" width="900" height="440"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="439" rx="12"/>
 
   <!-- Title -->
   <text class="title-text" x="40" y="38">PATCH three-state model</text>
@@ -27,53 +69,53 @@
   <text class="col-head" x="640" y="105">Intent</text>
 
   <!-- Row 1: Untouched (gray) -->
-  <rect x="40"  y="125" width="260" height="70" rx="10" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="gray-bg gray-border" x="40"  y="125" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono" x="60" y="152">field omitted</text>
   <text class="mono" x="60" y="172">— or —</text>
   <text class="mono" x="60" y="188">"field": null</text>
 
   <line x1="300" y1="160" x2="330" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="330" y="125" width="260" height="70" rx="10" fill="#F9FAFB" stroke="#E5E7EB" stroke-width="1.5"/>
+  <rect class="gray-bg gray-border" x="330" y="125" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono-lg" x="460" y="168" text-anchor="middle">(Maybe&lt;T&gt;?)null</text>
 
   <line x1="590" y1="160" x2="620" y2="160" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="620" y="125" width="240" height="70" rx="10" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
-  <circle cx="640" cy="160" r="6" fill="#9CA3AF"/>
-  <text class="intent" x="656" y="166" fill="#374151">leave untouched</text>
+  <rect class="gray-bg gray-strong-border" x="620" y="125" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="gray-dot" cx="640" cy="160" r="6"/>
+  <text class="intent gray-text" x="656" y="166">leave untouched</text>
 
   <!-- Row 2: Clear to null (amber) -->
-  <rect x="40"  y="210" width="260" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <rect class="amber-bg amber-border" x="40"  y="210" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono" x="60" y="237">"field": {}</text>
   <text class="mono" x="60" y="257">— or —</text>
   <text class="mono" x="60" y="273">"field": { "Value": null }</text>
 
   <line x1="300" y1="245" x2="330" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="330" y="210" width="260" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
+  <rect class="amber-bg amber-border" x="330" y="210" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono-lg" x="460" y="253" text-anchor="middle">Maybe&lt;T&gt;.None</text>
 
   <line x1="590" y1="245" x2="620" y2="245" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="620" y="210" width="240" height="70" rx="10" fill="#FFFBEB" stroke="#F59E0B" stroke-width="1.5"/>
-  <circle cx="640" cy="245" r="6" fill="#F59E0B"/>
-  <text class="intent" x="656" y="251" fill="#B45309">clear to null</text>
+  <rect class="amber-bg amber-border" x="620" y="210" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="amber-dot" cx="640" cy="245" r="6"/>
+  <text class="intent amber-text" x="656" y="251">clear to null</text>
 
   <!-- Row 3: Set to value (green) -->
-  <rect x="40"  y="295" width="260" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <rect class="green-bg green-border" x="40"  y="295" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono" x="60" y="338" text-anchor="start">"field": { "Value": x }</text>
 
   <line x1="300" y1="330" x2="330" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="330" y="295" width="260" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
+  <rect class="green-bg green-border" x="330" y="295" width="260" height="70" rx="10" stroke-width="1.5"/>
   <text class="mono-lg" x="460" y="338" text-anchor="middle">Maybe&lt;T&gt;.Some(x)</text>
 
   <line x1="590" y1="330" x2="620" y2="330" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#p3-arrow)"/>
 
-  <rect x="620" y="295" width="240" height="70" rx="10" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-  <circle cx="640" cy="330" r="6" fill="#10B981"/>
-  <text class="intent" x="656" y="336" fill="#047857">set to x</text>
+  <rect class="green-bg green-border" x="620" y="295" width="240" height="70" rx="10" stroke-width="1.5"/>
+  <circle class="green-dot" cx="640" cy="330" r="6"/>
+  <text class="intent green-text" x="656" y="336">set to x</text>
 
   <!-- Footer note -->
   <text class="subtitle" x="40" y="410">A plain <tspan font-family="ui-monospace, Menlo, monospace">T?</tspan> collapses rows 1 and 2 into a single <tspan font-family="ui-monospace, Menlo, monospace">null</tspan> — the outer <tspan font-family="ui-monospace, Menlo, monospace">?</tspan> around <tspan font-family="ui-monospace, Menlo, monospace">Maybe&lt;T&gt;</tspan> is what buys the third state.</text>

--- a/docs/diagrams/patch-three-state.svg
+++ b/docs/diagrams/patch-three-state.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 38 820 364" role="img" aria-label="HTTP PATCH three-state model with Maybe">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" role="img" aria-label="HTTP PATCH three-state model with Maybe">
   <style>
     .title-text { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #111827; }
     .subtitle   { font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }

--- a/docs/diagrams/patch-three-state.svg
+++ b/docs/diagrams/patch-three-state.svg
@@ -26,7 +26,7 @@
     .green-dot     { fill: #10B981; }
     .green-text    { fill: #047857; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
 

--- a/docs/diagrams/result-composition-dark.svg
+++ b/docs/diagrams/result-composition-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 520" role="img" aria-label="Result composition: Map, MapError, FlatMap">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .section-rule  { stroke: #E5E7EB; }
 
     .green-bg      { fill: #ECFDF5; }
@@ -29,8 +27,6 @@
     .pill-text     { fill: #4338CA; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }
 
       .green-bg      { fill: #0a2618; }
@@ -65,8 +61,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="600"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="599" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>

--- a/docs/diagrams/result-composition-dark.svg
+++ b/docs/diagrams/result-composition-dark.svg
@@ -1,0 +1,168 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+  <style>
+    .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .op-hint   { font: 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+    .track-tag { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; letter-spacing: 0.06em; text-transform: uppercase; }
+    .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
+    .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .section-rule  { stroke: #E5E7EB; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-bg-soft { fill: #F0FDF4; }
+    .green-border  { stroke: #10B981; }
+    .green-text    { fill: #065F46; }
+    .green-tag     { fill: #047857; }
+
+    .red-bg        { fill: #FEF2F2; }
+    .red-bg-soft   { fill: #FEF7F7; }
+    .red-border    { stroke: #EF4444; }
+    .red-text      { fill: #991B1B; }
+    .red-tag       { fill: #B91C1C; }
+
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #6366F1; }
+    .pill-text     { fill: #4338CA; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .section-rule  { stroke: #30363d; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-bg-soft { fill: #0a1f15; }
+      .green-text    { fill: #6EE7B7; }
+      .green-tag     { fill: #34D399; }
+
+      .red-bg        { fill: #2a0a0a; }
+      .red-bg-soft   { fill: #1f0808; }
+      .red-border    { stroke: #F87171; }
+      .red-text      { fill: #FCA5A5; }
+      .red-tag       { fill: #FCA5A5; }
+
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #818CF8; }
+      .pill-text     { fill: #C7D2FE; }
+
+      .op-name       { fill: #e6edf3; }
+      .op-sig        { fill: #8b949e; }
+      .op-hint       { fill: #8b949e; }
+      .op-label      { fill: #e6edf3; }
+      .note          { fill: #8b949e; }
+    }
+  </style>
+
+  <defs>
+    <marker id="rc-g" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="rc-r" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#EF4444"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="900" height="600"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="599" rx="10"/>
+
+  <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
+  <g>
+    <text class="op-name" x="30" y="40">Map</text>
+    <text class="op-sig"  x="85" y="40">f : T → U</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">transforms Success; Error passes through unchanged</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Success track -->
+    <text class="track-tag green-tag" x="30" y="90">Success</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="95" text-anchor="middle">Success(x)</text>
+    <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label" x="320" y="82" text-anchor="middle">Map(f)</text>
+    <rect class="green-bg green-border" x="410" y="74" width="170" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="495" y="95" text-anchor="middle">Success(f(x))</text>
+    <text class="note" x="600" y="95">f returned a T; Result wraps it automatically</text>
+
+    <!-- Error track -->
+    <text class="track-tag red-tag" x="30" y="140">Error</text>
+    <rect class="red-bg red-border" x="90"  y="124" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="145" text-anchor="middle">Error(e)</text>
+    <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label red-tag" x="320" y="132" text-anchor="middle">Map(f)</text>
+    <rect class="red-bg-soft red-border" x="410" y="124" width="170" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono red-text" x="495" y="145" text-anchor="middle">Error(e)</text>
+    <text class="note" x="600" y="145">f never called — pass-through</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 2: MapError ═══════════════════ -->
+  <g transform="translate(0, 180)">
+    <text class="op-name" x="30" y="40">MapError</text>
+    <text class="op-sig"  x="135" y="40">g : TError → TError2</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">transforms Error; Success passes through unchanged</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Success track (pass-through) -->
+    <text class="track-tag green-tag" x="30" y="90">Success</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="95" text-anchor="middle">Success(x)</text>
+    <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label green-tag" x="320" y="82" text-anchor="middle">MapError(g)</text>
+    <rect class="green-bg-soft green-border" x="410" y="74" width="170" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono green-text" x="495" y="95" text-anchor="middle">Success(x)</text>
+    <text class="note" x="600" y="95">g never called — pass-through</text>
+
+    <!-- Error track (transformed) -->
+    <text class="track-tag red-tag" x="30" y="140">Error</text>
+    <rect class="red-bg red-border" x="90"  y="124" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="145" text-anchor="middle">Error(e)</text>
+    <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label red-tag" x="320" y="132" text-anchor="middle">MapError(g)</text>
+    <rect class="red-bg red-border" x="410" y="124" width="170" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="495" y="145" text-anchor="middle">Error(g(e))</text>
+    <text class="note" x="600" y="145">g returned a TError2; Result wraps it</text>
+  </g>
+
+  <!-- ═══════════════════ SECTION 3: FlatMap ═══════════════════ -->
+  <g transform="translate(0, 360)">
+    <text class="op-name" x="30" y="40">FlatMap</text>
+    <text class="op-sig"  x="125" y="40">f : T → Result&lt;U, TError&gt;</text>
+    <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Result&lt;U, TError&gt; — unwrapped directly to avoid nested Result&lt;Result&lt;U, TError&gt;, TError&gt;</text>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
+
+    <!-- Success track: branches -->
+    <text class="track-tag green-tag" x="30" y="107">Success</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="112" text-anchor="middle">Success(x)</text>
+
+    <line x1="230" y1="107" x2="310" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <text class="op-label" x="270" y="99" text-anchor="middle">FlatMap(f)</text>
+
+    <!-- Intermediate: f(x) : Result<U, TError> -->
+    <rect class="pill-bg pill-border" x="310" y="91" width="200" height="32" rx="8" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono pill-text" x="410" y="112" text-anchor="middle">f(x) : Result&lt;U, TError&gt;</text>
+
+    <!-- Branches from intermediate -->
+    <path d="M 510 100 C 545 95, 555 82, 590 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
+    <path d="M 510 115 C 545 120, 555 133, 590 135" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+
+    <rect class="green-bg green-border" x="590" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="660" y="85" text-anchor="middle">Success(y)</text>
+    <text class="note" x="740" y="85">f returned Success</text>
+
+    <rect class="red-bg red-border" x="590" y="120" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="660" y="141" text-anchor="middle">Error(e′)</text>
+    <text class="note" x="740" y="141">f returned Error</text>
+
+    <!-- Error track -->
+    <text class="track-tag red-tag" x="30" y="185">Error</text>
+    <rect class="red-bg red-border" x="90"  y="169" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="190" text-anchor="middle">Error(e)</text>
+    <line x1="230" y1="185" x2="590" y2="185" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
+    <text class="op-label red-tag" x="410" y="177" text-anchor="middle">FlatMap(f)</text>
+    <rect class="red-bg-soft red-border" x="590" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono red-text" x="660" y="190" text-anchor="middle">Error(e)</text>
+    <text class="note" x="740" y="190">f never called — short-circuits</text>
+  </g>
+</svg>

--- a/docs/diagrams/result-composition-dark.svg
+++ b/docs/diagrams/result-composition-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 520" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }

--- a/docs/diagrams/result-composition.svg
+++ b/docs/diagrams/result-composition.svg
@@ -28,7 +28,7 @@
     .pill-border   { stroke: #6366F1; }
     .pill-text     { fill: #4338CA; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }

--- a/docs/diagrams/result-composition.svg
+++ b/docs/diagrams/result-composition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 520" role="img" aria-label="Result composition: Map, MapError, FlatMap">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
@@ -8,8 +8,6 @@
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .section-rule  { stroke: #E5E7EB; }
 
     .green-bg      { fill: #ECFDF5; }
@@ -29,8 +27,6 @@
     .pill-text     { fill: #4338CA; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .section-rule  { stroke: #30363d; }
 
       .green-bg      { fill: #0a2618; }
@@ -65,8 +61,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="600"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="599" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>

--- a/docs/diagrams/result-composition.svg
+++ b/docs/diagrams/result-composition.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 40 840 520" role="img" aria-label="Result composition: Map, MapError, FlatMap">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-label="Result composition: Map, MapError, FlatMap">
   <style>
     .op-name   { font: 700 16px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .op-sig    { font: 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }

--- a/docs/diagrams/result-composition.svg
+++ b/docs/diagrams/result-composition.svg
@@ -7,6 +7,53 @@
     .mono      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .op-label  { font: 600 12px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #111827; }
     .note      { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .section-rule  { stroke: #E5E7EB; }
+
+    .green-bg      { fill: #ECFDF5; }
+    .green-bg-soft { fill: #F0FDF4; }
+    .green-border  { stroke: #10B981; }
+    .green-text    { fill: #065F46; }
+    .green-tag     { fill: #047857; }
+
+    .red-bg        { fill: #FEF2F2; }
+    .red-bg-soft   { fill: #FEF7F7; }
+    .red-border    { stroke: #EF4444; }
+    .red-text      { fill: #991B1B; }
+    .red-tag       { fill: #B91C1C; }
+
+    .pill-bg       { fill: #FFFFFF; }
+    .pill-border   { stroke: #6366F1; }
+    .pill-text     { fill: #4338CA; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .section-rule  { stroke: #30363d; }
+
+      .green-bg      { fill: #0a2618; }
+      .green-bg-soft { fill: #0a1f15; }
+      .green-text    { fill: #6EE7B7; }
+      .green-tag     { fill: #34D399; }
+
+      .red-bg        { fill: #2a0a0a; }
+      .red-bg-soft   { fill: #1f0808; }
+      .red-border    { stroke: #F87171; }
+      .red-text      { fill: #FCA5A5; }
+      .red-tag       { fill: #FCA5A5; }
+
+      .pill-bg       { fill: #161b22; }
+      .pill-border   { stroke: #818CF8; }
+      .pill-text     { fill: #C7D2FE; }
+
+      .op-name       { fill: #e6edf3; }
+      .op-sig        { fill: #8b949e; }
+      .op-hint       { fill: #8b949e; }
+      .op-label      { fill: #e6edf3; }
+      .note          { fill: #8b949e; }
+    }
   </style>
 
   <defs>
@@ -18,34 +65,34 @@
     </marker>
   </defs>
 
-  <rect width="900" height="600" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="899" height="599" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect class="canvas-bg" width="900" height="600"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="599" rx="10"/>
 
   <!-- ═══════════════════ SECTION 1: Map ═══════════════════ -->
   <g>
     <text class="op-name" x="30" y="40">Map</text>
     <text class="op-sig"  x="85" y="40">f : T → U</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">transforms Success; Error passes through unchanged</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Success track -->
-    <text class="track-tag" x="30" y="90" fill="#047857">Success</text>
-    <rect x="90"  y="74" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="160" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <text class="track-tag green-tag" x="30" y="90">Success</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="95" text-anchor="middle">Success(x)</text>
     <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
     <text class="op-label" x="320" y="82" text-anchor="middle">Map(f)</text>
-    <rect x="410" y="74" width="170" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="495" y="95" text-anchor="middle" fill="#065F46">Success(f(x))</text>
+    <rect class="green-bg green-border" x="410" y="74" width="170" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="495" y="95" text-anchor="middle">Success(f(x))</text>
     <text class="note" x="600" y="95">f returned a T; Result wraps it automatically</text>
 
     <!-- Error track -->
-    <text class="track-tag" x="30" y="140" fill="#B91C1C">Error</text>
-    <rect x="90"  y="124" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono" x="160" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="track-tag red-tag" x="30" y="140">Error</text>
+    <rect class="red-bg red-border" x="90"  y="124" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="145" text-anchor="middle">Error(e)</text>
     <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
-    <text class="op-label" x="320" y="132" text-anchor="middle" fill="#B91C1C">Map(f)</text>
-    <rect x="410" y="124" width="170" height="32" rx="16" fill="#FEF7F7" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="495" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="op-label red-tag" x="320" y="132" text-anchor="middle">Map(f)</text>
+    <rect class="red-bg-soft red-border" x="410" y="124" width="170" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono red-text" x="495" y="145" text-anchor="middle">Error(e)</text>
     <text class="note" x="600" y="145">f never called — pass-through</text>
   </g>
 
@@ -54,26 +101,26 @@
     <text class="op-name" x="30" y="40">MapError</text>
     <text class="op-sig"  x="135" y="40">g : TError → TError2</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">transforms Error; Success passes through unchanged</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Success track (pass-through) -->
-    <text class="track-tag" x="30" y="90" fill="#047857">Success</text>
-    <rect x="90"  y="74" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="160" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <text class="track-tag green-tag" x="30" y="90">Success</text>
+    <rect class="green-bg green-border" x="90"  y="74" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="95" text-anchor="middle">Success(x)</text>
     <line x1="230" y1="90" x2="410" y2="90" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
-    <text class="op-label" x="320" y="82" text-anchor="middle" fill="#047857">MapError(g)</text>
-    <rect x="410" y="74" width="170" height="32" rx="16" fill="#F0FDF4" stroke="#10B981" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="495" y="95" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <text class="op-label green-tag" x="320" y="82" text-anchor="middle">MapError(g)</text>
+    <rect class="green-bg-soft green-border" x="410" y="74" width="170" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono green-text" x="495" y="95" text-anchor="middle">Success(x)</text>
     <text class="note" x="600" y="95">g never called — pass-through</text>
 
     <!-- Error track (transformed) -->
-    <text class="track-tag" x="30" y="140" fill="#B91C1C">Error</text>
-    <rect x="90"  y="124" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono" x="160" y="145" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="track-tag red-tag" x="30" y="140">Error</text>
+    <rect class="red-bg red-border" x="90"  y="124" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="145" text-anchor="middle">Error(e)</text>
     <line x1="230" y1="140" x2="410" y2="140" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
-    <text class="op-label" x="320" y="132" text-anchor="middle" fill="#B91C1C">MapError(g)</text>
-    <rect x="410" y="124" width="170" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono" x="495" y="145" text-anchor="middle" fill="#991B1B">Error(g(e))</text>
+    <text class="op-label red-tag" x="320" y="132" text-anchor="middle">MapError(g)</text>
+    <rect class="red-bg red-border" x="410" y="124" width="170" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="495" y="145" text-anchor="middle">Error(g(e))</text>
     <text class="note" x="600" y="145">g returned a TError2; Result wraps it</text>
   </g>
 
@@ -82,40 +129,40 @@
     <text class="op-name" x="30" y="40">FlatMap</text>
     <text class="op-sig"  x="125" y="40">f : T → Result&lt;U, TError&gt;</text>
     <text class="op-hint" x="870" y="40" text-anchor="end">f already returns Result&lt;U, TError&gt; — unwrapped directly to avoid nested Result&lt;Result&lt;U, TError&gt;, TError&gt;</text>
-    <line x1="30" y1="52" x2="870" y2="52" stroke="#E5E7EB" stroke-dasharray="3 3"/>
+    <line class="section-rule" x1="30" y1="52" x2="870" y2="52" stroke-dasharray="3 3"/>
 
     <!-- Success track: branches -->
-    <text class="track-tag" x="30" y="107" fill="#047857">Success</text>
-    <rect x="90"  y="91" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="160" y="112" text-anchor="middle" fill="#065F46">Success(x)</text>
+    <text class="track-tag green-tag" x="30" y="107">Success</text>
+    <rect class="green-bg green-border" x="90"  y="91" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="160" y="112" text-anchor="middle">Success(x)</text>
 
     <line x1="230" y1="107" x2="310" y2="107" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
     <text class="op-label" x="270" y="99" text-anchor="middle">FlatMap(f)</text>
 
     <!-- Intermediate: f(x) : Result<U, TError> -->
-    <rect x="310" y="91" width="200" height="32" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5" stroke-dasharray="5 3"/>
-    <text class="mono" x="410" y="112" text-anchor="middle" fill="#4338CA">f(x) : Result&lt;U, TError&gt;</text>
+    <rect class="pill-bg pill-border" x="310" y="91" width="200" height="32" rx="8" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text class="mono pill-text" x="410" y="112" text-anchor="middle">f(x) : Result&lt;U, TError&gt;</text>
 
     <!-- Branches from intermediate -->
     <path d="M 510 100 C 545 95, 555 82, 590 80" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#rc-g)"/>
     <path d="M 510 115 C 545 120, 555 133, 590 135" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
 
-    <rect x="590" y="64" width="140" height="32" rx="16" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono" x="660" y="85" text-anchor="middle" fill="#065F46">Success(y)</text>
+    <rect class="green-bg green-border" x="590" y="64" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono green-text" x="660" y="85" text-anchor="middle">Success(y)</text>
     <text class="note" x="740" y="85">f returned Success</text>
 
-    <rect x="590" y="120" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono" x="660" y="141" text-anchor="middle" fill="#991B1B">Error(e′)</text>
+    <rect class="red-bg red-border" x="590" y="120" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="660" y="141" text-anchor="middle">Error(e′)</text>
     <text class="note" x="740" y="141">f returned Error</text>
 
     <!-- Error track -->
-    <text class="track-tag" x="30" y="185" fill="#B91C1C">Error</text>
-    <rect x="90"  y="169" width="140" height="32" rx="16" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono" x="160" y="190" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="track-tag red-tag" x="30" y="185">Error</text>
+    <rect class="red-bg red-border" x="90"  y="169" width="140" height="32" rx="16" stroke-width="1.5"/>
+    <text class="mono red-text" x="160" y="190" text-anchor="middle">Error(e)</text>
     <line x1="230" y1="185" x2="590" y2="185" stroke="#EF4444" stroke-width="1.5" marker-end="url(#rc-r)"/>
-    <text class="op-label" x="410" y="177" text-anchor="middle" fill="#B91C1C">FlatMap(f)</text>
-    <rect x="590" y="169" width="140" height="32" rx="16" fill="#FEF7F7" stroke="#EF4444" stroke-width="1.5" stroke-dasharray="4 3"/>
-    <text class="mono" x="660" y="190" text-anchor="middle" fill="#991B1B">Error(e)</text>
+    <text class="op-label red-tag" x="410" y="177" text-anchor="middle">FlatMap(f)</text>
+    <rect class="red-bg-soft red-border" x="590" y="169" width="140" height="32" rx="16" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <text class="mono red-text" x="660" y="190" text-anchor="middle">Error(e)</text>
     <text class="note" x="740" y="190">f never called — short-circuits</text>
   </g>
 </svg>

--- a/docs/diagrams/trycreate-create-flow-dark.svg
+++ b/docs/diagrams/trycreate-create-flow-dark.svg
@@ -1,0 +1,201 @@
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
+  <style>
+    .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .mono             { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .mono-outcome     { font: 700 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
+    .branch-label     { font: 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #374151; }
+    .methods-head     { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.06em; text-transform: uppercase; }
+    .method-name      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
+    .bullet           { fill: #D1D5DB; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .divider-line  { stroke: #E5E7EB; }
+
+    .left-header-bg     { fill: #F3F4F6; }
+    .left-header-border { stroke: #D1D5DB; }
+    .left-header-text   { fill: #374151; }
+
+    .right-header-bg     { fill: #FEF2F2; }
+    .right-header-border { stroke: #FCA5A5; }
+    .right-header-text   { fill: #991B1B; }
+
+    .input-pill-bg     { fill: #F9FAFB; }
+    .input-pill-border { stroke: #9CA3AF; }
+    .input-pill-text   { fill: #111827; }
+
+    .decision-bg     { fill: #FFFFFF; }
+    .decision-border { stroke: #6366F1; }
+    .decision-text   { fill: #4338CA; }
+
+    .yes-text { fill: #047857; }
+    .no-text-muted { fill: #6B7280; }
+    .no-text-red   { fill: #B91C1C; }
+
+    .green-bg     { fill: #ECFDF5; }
+    .green-border { stroke: #10B981; }
+    .green-text   { fill: #065F46; }
+
+    .gray-bg     { fill: #F3F4F6; }
+    .gray-border { stroke: #9CA3AF; }
+    .gray-text   { fill: #374151; }
+
+    .red-bg     { fill: #FEF2F2; }
+    .red-border { stroke: #EF4444; }
+    .red-text   { fill: #991B1B; }
+
+    .method-name-muted { fill: #9CA3AF; }
+
+    :where(.dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .divider-line  { stroke: #30363d; }
+
+      .left-header-bg     { fill: #161b22; }
+      .left-header-border { stroke: #6e7681; }
+      .left-header-text   { fill: #c9d1d9; }
+
+      .right-header-bg     { fill: #2a0a0a; }
+      .right-header-border { stroke: #F87171; }
+      .right-header-text   { fill: #FCA5A5; }
+
+      .input-pill-bg     { fill: #161b22; }
+      .input-pill-border { stroke: #6e7681; }
+      .input-pill-text   { fill: #e6edf3; }
+
+      .decision-bg     { fill: #161b22; }
+      .decision-border { stroke: #818CF8; }
+      .decision-text   { fill: #C7D2FE; }
+
+      .branch-label  { fill: #c9d1d9; }
+      .yes-text      { fill: #34D399; }
+      .no-text-muted { fill: #8b949e; }
+      .no-text-red   { fill: #FCA5A5; }
+
+      .green-bg     { fill: #0a2618; }
+      .green-text   { fill: #6EE7B7; }
+
+      .gray-bg     { fill: #161b22; }
+      .gray-border { stroke: #6e7681; }
+      .gray-text   { fill: #c9d1d9; }
+
+      .red-bg     { fill: #2a0a0a; }
+      .red-border { stroke: #F87171; }
+      .red-text   { fill: #FCA5A5; }
+
+      .methods-head { fill: #8b949e; }
+      .method-name  { fill: #8b949e; }
+      .method-name-muted { fill: #6e7681; }
+      .bullet       { fill: #6e7681; }
+    }
+  </style>
+
+  <defs>
+    <marker id="tc-arrow-gray" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#9CA3AF"/>
+    </marker>
+    <marker id="tc-arrow-green" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#10B981"/>
+    </marker>
+    <marker id="tc-arrow-red" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#EF4444"/>
+    </marker>
+    <marker id="tc-arrow-indigo" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0,0 L 9,3 L 0,6 z" fill="#6366F1"/>
+    </marker>
+  </defs>
+
+  <rect class="canvas-bg" width="900" height="410"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="409" rx="10"/>
+
+  <!-- ============ LEFT COLUMN: TryCreate / As… ============ -->
+  <g transform="translate(20, 0)">
+    <!-- Column header bar -->
+    <rect class="left-header-bg left-header-border" x="0" y="20" width="420" height="32" rx="6" stroke-width="1.5"/>
+    <text class="col-header left-header-text" x="210" y="41" text-anchor="middle">TryCreate / As…</text>
+
+    <!-- Input pill -->
+    <rect class="input-pill-bg input-pill-border" x="150" y="72" width="120" height="34" rx="17" stroke-width="1.5"/>
+    <text class="node-label input-pill-text" x="210" y="94" text-anchor="middle">input</text>
+
+    <!-- Arrow down to validate -->
+    <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
+
+    <!-- Validate box (decision) -->
+    <rect class="decision-bg decision-border" x="150" y="130" width="120" height="38" rx="8" stroke-width="1.5"/>
+    <text class="node-label decision-text" x="210" y="154" text-anchor="middle">valid?</text>
+
+    <!-- Branch arrows -->
+    <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
+    <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#tc-arrow-gray)"/>
+
+    <!-- Branch labels -->
+    <text class="branch-label yes-text" x="148" y="185" text-anchor="middle">yes</text>
+    <text class="branch-label no-text-muted" x="272" y="185" text-anchor="middle">no</text>
+
+    <!-- Success outcome -->
+    <rect class="green-bg green-border" x="70" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome green-text" x="130" y="236" text-anchor="middle">T</text>
+
+    <!-- Failure outcome: null -->
+    <rect class="gray-bg gray-border" x="230" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome gray-text" x="290" y="236" text-anchor="middle">null</text>
+
+    <!-- Divider -->
+    <line class="divider-line" x1="10" y1="285" x2="410" y2="285" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- Methods list -->
+    <text class="methods-head" x="20" y="310">Methods in this family</text>
+    <g transform="translate(20, 330)">
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">TryCreate / TryParse<tspan class="method-name-muted">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">AsNonEmpty / AsPositive / AsNegative / AsEnum&lt;T&gt; / …</text>
+      <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">AsInt / AsGuid / AsTimeSpan / …</text>
+    </g>
+  </g>
+
+  <!-- ============ RIGHT COLUMN: Create / To… ============ -->
+  <g transform="translate(460, 0)">
+    <!-- Column header bar -->
+    <rect class="right-header-bg right-header-border" x="0" y="20" width="420" height="32" rx="6" stroke-width="1.5"/>
+    <text class="col-header right-header-text" x="210" y="41" text-anchor="middle">Create / To…</text>
+
+    <!-- Input pill -->
+    <rect class="input-pill-bg input-pill-border" x="150" y="72" width="120" height="34" rx="17" stroke-width="1.5"/>
+    <text class="node-label input-pill-text" x="210" y="94" text-anchor="middle">input</text>
+
+    <!-- Arrow down to validate -->
+    <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
+
+    <!-- Validate box (decision) -->
+    <rect class="decision-bg decision-border" x="150" y="130" width="120" height="38" rx="8" stroke-width="1.5"/>
+    <text class="node-label decision-text" x="210" y="154" text-anchor="middle">valid?</text>
+
+    <!-- Branch arrows -->
+    <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
+    <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#tc-arrow-red)"/>
+
+    <!-- Branch labels -->
+    <text class="branch-label yes-text" x="148" y="185" text-anchor="middle">yes</text>
+    <text class="branch-label no-text-red" x="272" y="185" text-anchor="middle">no</text>
+
+    <!-- Success outcome -->
+    <rect class="green-bg green-border" x="70" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome green-text" x="130" y="236" text-anchor="middle">T</text>
+
+    <!-- Failure outcome: throws -->
+    <rect class="red-bg red-border" x="230" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome red-text" x="290" y="236" text-anchor="middle">throws</text>
+
+    <!-- Divider -->
+    <line class="divider-line" x1="10" y1="285" x2="410" y2="285" stroke-width="1" stroke-dasharray="4 3"/>
+
+    <!-- Methods list -->
+    <text class="methods-head" x="20" y="310">Methods in this family</text>
+    <g transform="translate(20, 330)">
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">Create / Parse<tspan class="method-name-muted">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">ToNonEmpty / ToPositive / ToNegative / ToEnum&lt;T&gt; / …</text>
+      <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">ToInt / ToGuid / ToTimeSpan / …</text>
+    </g>
+  </g>
+</svg>

--- a/docs/diagrams/trycreate-create-flow-dark.svg
+++ b/docs/diagrams/trycreate-create-flow-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="20 20 860 370" role="img" aria-label="TryCreate vs Create factory flows">
   <style>
     .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
@@ -9,8 +9,6 @@
     .method-name      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
     .bullet           { fill: #D1D5DB; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .divider-line  { stroke: #E5E7EB; }
 
     .left-header-bg     { fill: #F3F4F6; }
@@ -48,8 +46,6 @@
     .method-name-muted { fill: #9CA3AF; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .divider-line  { stroke: #30363d; }
 
       .left-header-bg     { fill: #161b22; }
@@ -106,8 +102,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="410"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="409" rx="10"/>
 
   <!-- ============ LEFT COLUMN: TryCreate / As… ============ -->
   <g transform="translate(20, 0)">

--- a/docs/diagrams/trycreate-create-flow-dark.svg
+++ b/docs/diagrams/trycreate-create-flow-dark.svg
@@ -1,4 +1,4 @@
-<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="20 20 860 370" role="img" aria-label="TryCreate vs Create factory flows">
+<svg class="dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
   <style>
     .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/docs/diagrams/trycreate-create-flow.svg
+++ b/docs/diagrams/trycreate-create-flow.svg
@@ -8,6 +8,87 @@
     .methods-head     { font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; fill: #6B7280; letter-spacing: 0.06em; text-transform: uppercase; }
     .method-name      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
     .bullet           { fill: #D1D5DB; }
+
+    .canvas-bg     { fill: #FFFFFF; }
+    .canvas-border { fill: none; stroke: #E5E7EB; }
+    .divider-line  { stroke: #E5E7EB; }
+
+    .left-header-bg     { fill: #F3F4F6; }
+    .left-header-border { stroke: #D1D5DB; }
+    .left-header-text   { fill: #374151; }
+
+    .right-header-bg     { fill: #FEF2F2; }
+    .right-header-border { stroke: #FCA5A5; }
+    .right-header-text   { fill: #991B1B; }
+
+    .input-pill-bg     { fill: #F9FAFB; }
+    .input-pill-border { stroke: #9CA3AF; }
+    .input-pill-text   { fill: #111827; }
+
+    .decision-bg     { fill: #FFFFFF; }
+    .decision-border { stroke: #6366F1; }
+    .decision-text   { fill: #4338CA; }
+
+    .yes-text { fill: #047857; }
+    .no-text-muted { fill: #6B7280; }
+    .no-text-red   { fill: #B91C1C; }
+
+    .green-bg     { fill: #ECFDF5; }
+    .green-border { stroke: #10B981; }
+    .green-text   { fill: #065F46; }
+
+    .gray-bg     { fill: #F3F4F6; }
+    .gray-border { stroke: #9CA3AF; }
+    .gray-text   { fill: #374151; }
+
+    .red-bg     { fill: #FEF2F2; }
+    .red-border { stroke: #EF4444; }
+    .red-text   { fill: #991B1B; }
+
+    .method-name-muted { fill: #9CA3AF; }
+
+    @media (prefers-color-scheme: dark) {
+      .canvas-bg     { fill: #0d1117; }
+      .canvas-border { stroke: #30363d; }
+      .divider-line  { stroke: #30363d; }
+
+      .left-header-bg     { fill: #161b22; }
+      .left-header-border { stroke: #6e7681; }
+      .left-header-text   { fill: #c9d1d9; }
+
+      .right-header-bg     { fill: #2a0a0a; }
+      .right-header-border { stroke: #F87171; }
+      .right-header-text   { fill: #FCA5A5; }
+
+      .input-pill-bg     { fill: #161b22; }
+      .input-pill-border { stroke: #6e7681; }
+      .input-pill-text   { fill: #e6edf3; }
+
+      .decision-bg     { fill: #161b22; }
+      .decision-border { stroke: #818CF8; }
+      .decision-text   { fill: #C7D2FE; }
+
+      .branch-label  { fill: #c9d1d9; }
+      .yes-text      { fill: #34D399; }
+      .no-text-muted { fill: #8b949e; }
+      .no-text-red   { fill: #FCA5A5; }
+
+      .green-bg     { fill: #0a2618; }
+      .green-text   { fill: #6EE7B7; }
+
+      .gray-bg     { fill: #161b22; }
+      .gray-border { stroke: #6e7681; }
+      .gray-text   { fill: #c9d1d9; }
+
+      .red-bg     { fill: #2a0a0a; }
+      .red-border { stroke: #F87171; }
+      .red-text   { fill: #FCA5A5; }
+
+      .methods-head { fill: #8b949e; }
+      .method-name  { fill: #8b949e; }
+      .method-name-muted { fill: #6e7681; }
+      .bullet       { fill: #6e7681; }
+    }
   </style>
 
   <defs>
@@ -25,49 +106,49 @@
     </marker>
   </defs>
 
-  <rect width="900" height="410" fill="#FFFFFF"/>
-  <rect x="0.5" y="0.5" width="899" height="409" fill="none" stroke="#E5E7EB" rx="10"/>
+  <rect class="canvas-bg" width="900" height="410"/>
+  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="409" rx="10"/>
 
   <!-- ============ LEFT COLUMN: TryCreate / As… ============ -->
   <g transform="translate(20, 0)">
     <!-- Column header bar -->
-    <rect x="0" y="20" width="420" height="32" rx="6" fill="#F3F4F6" stroke="#D1D5DB" stroke-width="1.5"/>
-    <text class="col-header" x="210" y="41" text-anchor="middle" fill="#374151">TryCreate / As…</text>
+    <rect class="left-header-bg left-header-border" x="0" y="20" width="420" height="32" rx="6" stroke-width="1.5"/>
+    <text class="col-header left-header-text" x="210" y="41" text-anchor="middle">TryCreate / As…</text>
 
     <!-- Input pill -->
-    <rect x="150" y="72" width="120" height="34" rx="17" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
-    <text class="node-label" x="210" y="94" text-anchor="middle" fill="#111827">input</text>
+    <rect class="input-pill-bg input-pill-border" x="150" y="72" width="120" height="34" rx="17" stroke-width="1.5"/>
+    <text class="node-label input-pill-text" x="210" y="94" text-anchor="middle">input</text>
 
     <!-- Arrow down to validate -->
     <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
 
     <!-- Validate box (decision) -->
-    <rect x="150" y="130" width="120" height="38" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5"/>
-    <text class="node-label" x="210" y="154" text-anchor="middle" fill="#4338CA">valid?</text>
+    <rect class="decision-bg decision-border" x="150" y="130" width="120" height="38" rx="8" stroke-width="1.5"/>
+    <text class="node-label decision-text" x="210" y="154" text-anchor="middle">valid?</text>
 
     <!-- Branch arrows -->
     <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
     <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#tc-arrow-gray)"/>
 
     <!-- Branch labels -->
-    <text class="branch-label" x="148" y="185" text-anchor="middle" fill="#047857">yes</text>
-    <text class="branch-label" x="272" y="185" text-anchor="middle" fill="#6B7280">no</text>
+    <text class="branch-label yes-text" x="148" y="185" text-anchor="middle">yes</text>
+    <text class="branch-label no-text-muted" x="272" y="185" text-anchor="middle">no</text>
 
     <!-- Success outcome -->
-    <rect x="70" y="210" width="120" height="40" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono-outcome" x="130" y="236" text-anchor="middle" fill="#065F46">T</text>
+    <rect class="green-bg green-border" x="70" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome green-text" x="130" y="236" text-anchor="middle">T</text>
 
     <!-- Failure outcome: null -->
-    <rect x="230" y="210" width="120" height="40" rx="8" fill="#F3F4F6" stroke="#9CA3AF" stroke-width="1.5"/>
-    <text class="mono-outcome" x="290" y="236" text-anchor="middle" fill="#374151">null</text>
+    <rect class="gray-bg gray-border" x="230" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome gray-text" x="290" y="236" text-anchor="middle">null</text>
 
     <!-- Divider -->
-    <line x1="10" y1="285" x2="410" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4 3"/>
+    <line class="divider-line" x1="10" y1="285" x2="410" y2="285" stroke-width="1" stroke-dasharray="4 3"/>
 
     <!-- Methods list -->
     <text class="methods-head" x="20" y="310">Methods in this family</text>
     <g transform="translate(20, 330)">
-      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">TryCreate / TryParse<tspan fill="#9CA3AF">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">TryCreate / TryParse<tspan class="method-name-muted">  (on any validated type or enum)</tspan></text>
       <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">AsNonEmpty / AsPositive / AsNegative / AsEnum&lt;T&gt; / …</text>
       <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">AsInt / AsGuid / AsTimeSpan / …</text>
     </g>
@@ -76,43 +157,43 @@
   <!-- ============ RIGHT COLUMN: Create / To… ============ -->
   <g transform="translate(460, 0)">
     <!-- Column header bar -->
-    <rect x="0" y="20" width="420" height="32" rx="6" fill="#FEF2F2" stroke="#FCA5A5" stroke-width="1.5"/>
-    <text class="col-header" x="210" y="41" text-anchor="middle" fill="#991B1B">Create / To…</text>
+    <rect class="right-header-bg right-header-border" x="0" y="20" width="420" height="32" rx="6" stroke-width="1.5"/>
+    <text class="col-header right-header-text" x="210" y="41" text-anchor="middle">Create / To…</text>
 
     <!-- Input pill -->
-    <rect x="150" y="72" width="120" height="34" rx="17" fill="#F9FAFB" stroke="#9CA3AF" stroke-width="1.5"/>
-    <text class="node-label" x="210" y="94" text-anchor="middle" fill="#111827">input</text>
+    <rect class="input-pill-bg input-pill-border" x="150" y="72" width="120" height="34" rx="17" stroke-width="1.5"/>
+    <text class="node-label input-pill-text" x="210" y="94" text-anchor="middle">input</text>
 
     <!-- Arrow down to validate -->
     <line x1="210" y1="108" x2="210" y2="128" stroke="#6366F1" stroke-width="1.5" marker-end="url(#tc-arrow-indigo)"/>
 
     <!-- Validate box (decision) -->
-    <rect x="150" y="130" width="120" height="38" rx="8" fill="#FFFFFF" stroke="#6366F1" stroke-width="1.5"/>
-    <text class="node-label" x="210" y="154" text-anchor="middle" fill="#4338CA">valid?</text>
+    <rect class="decision-bg decision-border" x="150" y="130" width="120" height="38" rx="8" stroke-width="1.5"/>
+    <text class="node-label decision-text" x="210" y="154" text-anchor="middle">valid?</text>
 
     <!-- Branch arrows -->
     <path d="M 190 168 C 170 185, 150 195, 130 208" fill="none" stroke="#10B981" stroke-width="1.5" marker-end="url(#tc-arrow-green)"/>
     <path d="M 230 168 C 250 185, 270 195, 290 208" fill="none" stroke="#EF4444" stroke-width="1.5" marker-end="url(#tc-arrow-red)"/>
 
     <!-- Branch labels -->
-    <text class="branch-label" x="148" y="185" text-anchor="middle" fill="#047857">yes</text>
-    <text class="branch-label" x="272" y="185" text-anchor="middle" fill="#B91C1C">no</text>
+    <text class="branch-label yes-text" x="148" y="185" text-anchor="middle">yes</text>
+    <text class="branch-label no-text-red" x="272" y="185" text-anchor="middle">no</text>
 
     <!-- Success outcome -->
-    <rect x="70" y="210" width="120" height="40" rx="8" fill="#ECFDF5" stroke="#10B981" stroke-width="1.5"/>
-    <text class="mono-outcome" x="130" y="236" text-anchor="middle" fill="#065F46">T</text>
+    <rect class="green-bg green-border" x="70" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome green-text" x="130" y="236" text-anchor="middle">T</text>
 
     <!-- Failure outcome: throws -->
-    <rect x="230" y="210" width="120" height="40" rx="8" fill="#FEF2F2" stroke="#EF4444" stroke-width="1.5"/>
-    <text class="mono-outcome" x="290" y="236" text-anchor="middle" fill="#991B1B">throws</text>
+    <rect class="red-bg red-border" x="230" y="210" width="120" height="40" rx="8" stroke-width="1.5"/>
+    <text class="mono-outcome red-text" x="290" y="236" text-anchor="middle">throws</text>
 
     <!-- Divider -->
-    <line x1="10" y1="285" x2="410" y2="285" stroke="#E5E7EB" stroke-width="1" stroke-dasharray="4 3"/>
+    <line class="divider-line" x1="10" y1="285" x2="410" y2="285" stroke-width="1" stroke-dasharray="4 3"/>
 
     <!-- Methods list -->
     <text class="methods-head" x="20" y="310">Methods in this family</text>
     <g transform="translate(20, 330)">
-      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">Create / Parse<tspan fill="#9CA3AF">  (on any validated type or enum)</tspan></text>
+      <circle class="bullet" cx="6" cy="6" r="2.5"/><text class="method-name" x="18" y="10">Create / Parse<tspan class="method-name-muted">  (on any validated type or enum)</tspan></text>
       <circle class="bullet" cx="6" cy="32" r="2.5"/><text class="method-name" x="18" y="36">ToNonEmpty / ToPositive / ToNegative / ToEnum&lt;T&gt; / …</text>
       <circle class="bullet" cx="6" cy="58" r="2.5"/><text class="method-name" x="18" y="62">ToInt / ToGuid / ToTimeSpan / …</text>
     </g>

--- a/docs/diagrams/trycreate-create-flow.svg
+++ b/docs/diagrams/trycreate-create-flow.svg
@@ -47,7 +47,7 @@
 
     .method-name-muted { fill: #9CA3AF; }
 
-    @media (prefers-color-scheme: dark) {
+    :where(.dark) {
       .canvas-bg     { fill: #0d1117; }
       .canvas-border { stroke: #30363d; }
       .divider-line  { stroke: #30363d; }

--- a/docs/diagrams/trycreate-create-flow.svg
+++ b/docs/diagrams/trycreate-create-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 20 860 370" role="img" aria-label="TryCreate vs Create factory flows">
   <style>
     .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
@@ -9,8 +9,6 @@
     .method-name      { font: 13px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; fill: #6B7280; }
     .bullet           { fill: #D1D5DB; }
 
-    .canvas-bg     { fill: #FFFFFF; }
-    .canvas-border { fill: none; stroke: #E5E7EB; }
     .divider-line  { stroke: #E5E7EB; }
 
     .left-header-bg     { fill: #F3F4F6; }
@@ -48,8 +46,6 @@
     .method-name-muted { fill: #9CA3AF; }
 
     :where(.dark) {
-      .canvas-bg     { fill: #0d1117; }
-      .canvas-border { stroke: #30363d; }
       .divider-line  { stroke: #30363d; }
 
       .left-header-bg     { fill: #161b22; }
@@ -106,8 +102,6 @@
     </marker>
   </defs>
 
-  <rect class="canvas-bg" width="900" height="410"/>
-  <rect class="canvas-border" x="0.5" y="0.5" width="899" height="409" rx="10"/>
 
   <!-- ============ LEFT COLUMN: TryCreate / As… ============ -->
   <g transform="translate(20, 0)">

--- a/docs/diagrams/trycreate-create-flow.svg
+++ b/docs/diagrams/trycreate-create-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 20 860 370" role="img" aria-label="TryCreate vs Create factory flows">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 410" role="img" aria-label="TryCreate vs Create factory flows">
   <style>
     .col-header       { font: 600 14px ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace; }
     .node-label       { font: 600 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,15 @@ You can store the types directly in your EF Core entities with the use of the Ef
 > StrongTypes? See [Use with Claude or Codex](#use-with-claude-or-codex)
 > below.
 
-![Impact of StrongTypes on validation boundaries](docs/diagrams/impact.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/impact-dark.svg">
+  <img alt="Impact of StrongTypes on validation boundaries" src="docs/diagrams/impact.svg">
+</picture>
 
-![Package layout](docs/diagrams/package-layout.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/package-layout-dark.svg">
+  <img alt="Package layout" src="docs/diagrams/package-layout.svg">
+</picture>
 
 ## Contents
 
@@ -60,7 +66,10 @@ curl -L https://github.com/KaliCZ/StrongTypes/releases/latest/download/strongtyp
 
 The `TryCreate` / `Create` split (and the `As…` / `To…` extensions that mirror it) is used across every validated type in the library — pick the factory that matches how you want to handle bad input at the call site:
 
-![TryCreate vs Create flow](docs/diagrams/trycreate-create-flow.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/trycreate-create-flow-dark.svg">
+  <img alt="TryCreate vs Create flow" src="docs/diagrams/trycreate-create-flow.svg">
+</picture>
 
 ### `NonEmptyString`
 
@@ -214,7 +223,10 @@ NonEmptyEnumerable<Dog>      dogs    = [new Dog()];
 INonEmptyEnumerable<Animal>  animals = dogs;  // allowed thanks to `out T`
 ```
 
-![Covariant out T upcast](docs/diagrams/covariance.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/covariance-dark.svg">
+  <img alt="Covariant out T upcast" src="docs/diagrams/covariance.svg">
+</picture>
 
 All extensions (`Select`, `Concat`, `Max`, `Last`, …) have overloads on both the concrete type and the interface, so either receiver type works in a chain.
 
@@ -360,7 +372,10 @@ The generic constraint is `where T : notnull` — `Maybe<int?>` and `Maybe<strin
 
 HTTP `PATCH` has a long-standing modelling problem for nullable fields: a request needs to distinguish three intents — *don't touch this field*, *clear this field to null*, and *set it to a new value*. A plain `T?` collapses the first two cases. `Maybe<T>?` keeps them apart, because `Maybe<T>` itself is a value, so wrapping it in `T?` adds a real third state:
 
-![PATCH three-state model](docs/diagrams/patch-three-state.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/patch-three-state-dark.svg">
+  <img alt="PATCH three-state model" src="docs/diagrams/patch-three-state.svg">
+</picture>
 
 The request DTO and PATCH handler then read straight off pattern matching, with no out-of-band sentinel values:
 
@@ -428,7 +443,10 @@ var label = maybe.Match(
 
 `Maybe<T>` composes monadically through `Map`, `FlatMap`, and `Where`. Each operation is a no-op on `None`, so chains short-circuit cleanly without explicit null checks:
 
-![Maybe composition pipeline](docs/diagrams/maybe-composition.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/maybe-composition-dark.svg">
+  <img alt="Maybe composition pipeline" src="docs/diagrams/maybe-composition.svg">
+</picture>
 
 ```csharp
 // Map — transform the inner value when present.
@@ -543,7 +561,10 @@ public Result<Order, OrderError> CreateOrder(OrderData data)
 
 `Map`, `MapError`, `Match`, and `FlatMap` let you chain without explicit branching. Success and error values flow down independent tracks — `Map` only touches the success side, `MapError` only touches the error side, and `FlatMap` short-circuits on error:
 
-![Result composition pipeline](docs/diagrams/result-composition.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/result-composition-dark.svg">
+  <img alt="Result composition pipeline" src="docs/diagrams/result-composition.svg">
+</picture>
 
 
 ```csharp

--- a/src/StrongTypes/StrongTypes.csproj
+++ b/src/StrongTypes/StrongTypes.csproj
@@ -79,6 +79,8 @@
       <Code Type="Fragment" Language="cs"><![CDATA[
         var content = System.IO.File.ReadAllText(SourcePath);
         content = content.Replace("](docs/diagrams/", "](" + RawBaseUrl + "docs/diagrams/");
+        content = content.Replace("src=\"docs/diagrams/", "src=\"" + RawBaseUrl + "docs/diagrams/");
+        content = content.Replace("srcset=\"docs/diagrams/", "srcset=\"" + RawBaseUrl + "docs/diagrams/");
         content = content.Replace("](Skill/", "](" + RawBaseUrl + "Skill/");
         content = content.Replace("](src/", "](" + BlobBaseUrl + "src/");
         content = content.Replace("https://github.com/KaliCZ/StrongTypes/releases/latest/download/", ReleaseAssetBaseUrl);


### PR DESCRIPTION
Closes #80.

## Summary

Make the diagrams under `docs/diagrams/` dark-mode capable in two scenarios:

1. **Embedded in a host page that has its own theme toggle** (e.g. demopage at kalandra.tech) — the SVG flips when an ancestor element gets a `.dark` class.
2. **Loaded standalone via `<img>`** (GitHub README, blog posts, anywhere else) — readers in dark-mode GitHub get the dark variant via a `<picture>` element. No JS, no host wiring.

## How it works

### Single SVG, two palettes (`:where(.dark)`)

Each `*.svg` carries semantic classes (`.canvas-bg`, `.amber-bg`, `.green-text`, …) and a single dark override block at the bottom of `<style>`:

```css
.canvas-bg { fill: #FFFFFF; }
:where(.dark) {
  .canvas-bg { fill: #0d1117; }
  /* … */
}
```

CSS nesting means those rules fire only when an ancestor of the SVG element has `.dark`. When a host page like demopage inlines the SVG **or** the SVG itself carries `class="dark"` on its root, the dark palette wins.

This deliberately drops the `@media (prefers-color-scheme: dark)` approach, because OS-level dark on a page with its own toggle was actively wrong: a dark-OS user who explicitly toggled the page light would still see hardcoded-dark diagrams.

### `*-dark.svg` twins for `<picture>`

Each `*.svg` has a paired `*-dark.svg` that is byte-identical except for `class="dark"` on the root `<svg>` element. Since the root carries `.dark`, the `:where(.dark)` rules match its descendants and the file renders dark on its own.

The README now references each diagram via:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="docs/diagrams/impact-dark.svg">
  <img alt="…" src="docs/diagrams/impact.svg">
</picture>
```

GitHub ties `prefers-color-scheme` to the user's GitHub theme setting (light, dark, or follow OS), so every reader sees their preferred variant on github.com.

If a `*.svg` is later edited, regenerate the dark twin with:

```sh
sed '1s|^<svg |<svg class="dark" |' docs/diagrams/foo.svg > docs/diagrams/foo-dark.svg
```

## Files

- 7 diagrams under `docs/diagrams/` rewritten to use semantic classes + `:where(.dark)`
- 7 `*-dark.svg` twins added (one per diagram)
- `readme.md` switched to `<picture>` for all 6 image references

## Test plan

- [ ] On github.com with **light** GitHub theme: README diagrams render with light palette.
- [ ] On github.com with **dark** GitHub theme: README diagrams render with dark palette.
- [ ] Open any `*.svg` directly on raw.githubusercontent.com — light palette regardless of OS (no `.dark` ancestor exists).
- [ ] Open any `*-dark.svg` directly — dark palette regardless of OS.
- [ ] Inlined into a host page with `<html class="dark">` (see paired DemoPage PR): dark palette.

## Pairs with

[KaliCZ/DemoPage#115](https://github.com/KaliCZ/DemoPage/pull/115) — wires the strong-types page to swap each diagram `<img>`'s src on the page theme toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)