### PR TITLE
Strong-type schema painting and annotation merging on non-body slots (closes #87)

### DIFF
--- a/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
+++ b/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
@@ -139,6 +139,8 @@ public static class StrongTypeInliner
 
         if (schema.Not is { } not)
             schema.Not = RewriteSlot(not, ctx);
+
+        StrongTypeInlineMarker.Remove(schema);
     }
 
     private static void RewriteVariantList(IList<IOpenApiSchema>? variants, RewriteContext ctx)

--- a/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
+++ b/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
@@ -7,7 +7,7 @@ public static class StrongTypeSchemaTypes
 
     public static bool IsInlineable(Type? clrType)
     {
-        return ResolveAnnotationSurrogate(clrType) is not null
+        return ResolveWireType(clrType) is not null
             || TryGetMaybeValue(clrType, out _);
     }
 
@@ -59,7 +59,7 @@ public static class StrongTypeSchemaTypes
         return true;
     }
 
-    public static Type? ResolveAnnotationSurrogate(Type? clrType)
+    public static Type? ResolveWireType(Type? clrType)
     {
         if (IsNonEmptyString(clrType) || IsEmail(clrType)) return typeof(string);
         if (IsDigit(clrType)) return typeof(int);

--- a/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
+++ b/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
@@ -7,15 +7,8 @@ public static class StrongTypeSchemaTypes
 
     public static bool IsInlineable(Type? clrType)
     {
-        var unwrapped = UnwrapNullable(clrType);
-        if (unwrapped is null) return false;
-
-        return IsNonEmptyString(unwrapped)
-            || IsEmail(unwrapped)
-            || IsDigit(unwrapped)
-            || TryGetNumeric(unwrapped, out _, out _)
-            || TryGetNonEmptyEnumerableElement(unwrapped, out _)
-            || TryGetMaybeValue(unwrapped, out _);
+        return ResolveAnnotationSurrogate(clrType) is not null
+            || TryGetMaybeValue(clrType, out _);
     }
 
     public static bool IsNonEmptyString(Type? clrType)
@@ -64,5 +57,14 @@ public static class StrongTypeSchemaTypes
 
         valueType = unwrapped.GetGenericArguments()[0];
         return true;
+    }
+
+    public static Type? ResolveAnnotationSurrogate(Type? clrType)
+    {
+        if (IsNonEmptyString(clrType) || IsEmail(clrType)) return typeof(string);
+        if (IsDigit(clrType)) return typeof(int);
+        if (TryGetNumeric(clrType, out var valueType, out _)) return valueType;
+        if (TryGetNonEmptyEnumerableElement(clrType, out var elementType)) return typeof(IEnumerable<>).MakeGenericType(elementType);
+        return null;
     }
 }

--- a/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
+++ b/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
@@ -1,0 +1,19 @@
+namespace StrongTypes.OpenApi.Core;
+
+public static class StrongTypeSchemaTypes
+{
+    public static bool IsInlineable(Type? clrType)
+    {
+        if (clrType is null) return false;
+
+        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(Digit)) return true;
+        if (!unwrapped.IsGenericType) return false;
+
+        var definition = unwrapped.GetGenericTypeDefinition();
+        return NumericWrapperKinds.TryGetBound(definition, out _)
+            || definition == typeof(NonEmptyEnumerable<>)
+            || definition == typeof(INonEmptyEnumerable<>)
+            || definition == typeof(Maybe<>);
+    }
+}

--- a/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
+++ b/src/StrongTypes.OpenApi.Core/StrongTypeSchemaTypes.cs
@@ -2,18 +2,67 @@ namespace StrongTypes.OpenApi.Core;
 
 public static class StrongTypeSchemaTypes
 {
+    public static Type? UnwrapNullable(Type? clrType)
+        => clrType is null ? null : Nullable.GetUnderlyingType(clrType) ?? clrType;
+
     public static bool IsInlineable(Type? clrType)
     {
-        if (clrType is null) return false;
+        var unwrapped = UnwrapNullable(clrType);
+        if (unwrapped is null) return false;
 
-        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(Digit)) return true;
-        if (!unwrapped.IsGenericType) return false;
+        return IsNonEmptyString(unwrapped)
+            || IsEmail(unwrapped)
+            || IsDigit(unwrapped)
+            || TryGetNumeric(unwrapped, out _, out _)
+            || TryGetNonEmptyEnumerableElement(unwrapped, out _)
+            || TryGetMaybeValue(unwrapped, out _);
+    }
 
+    public static bool IsNonEmptyString(Type? clrType)
+        => UnwrapNullable(clrType) == typeof(NonEmptyString);
+
+    public static bool IsEmail(Type? clrType)
+        => UnwrapNullable(clrType) == typeof(Email);
+
+    public static bool IsDigit(Type? clrType)
+        => UnwrapNullable(clrType) == typeof(Digit);
+
+    public static bool TryGetNumeric(Type? clrType, out Type valueType, out NumericBound bound)
+    {
+        valueType = null!;
+        bound = default;
+
+        var unwrapped = UnwrapNullable(clrType);
+        if (unwrapped is null || !unwrapped.IsGenericType) return false;
         var definition = unwrapped.GetGenericTypeDefinition();
-        return NumericWrapperKinds.TryGetBound(definition, out _)
-            || definition == typeof(NonEmptyEnumerable<>)
-            || definition == typeof(INonEmptyEnumerable<>)
-            || definition == typeof(Maybe<>);
+        if (!NumericWrapperKinds.TryGetBound(definition, out bound)) return false;
+
+        valueType = unwrapped.GetGenericArguments()[0];
+        return true;
+    }
+
+    public static bool TryGetNonEmptyEnumerableElement(Type? clrType, out Type elementType)
+    {
+        elementType = null!;
+
+        var unwrapped = UnwrapNullable(clrType);
+        if (unwrapped is null || !unwrapped.IsGenericType) return false;
+        var definition = unwrapped.GetGenericTypeDefinition();
+        if (definition != typeof(NonEmptyEnumerable<>) && definition != typeof(INonEmptyEnumerable<>)) return false;
+
+        elementType = unwrapped.GetGenericArguments()[0];
+        return true;
+    }
+
+    public static bool TryGetMaybeValue(Type? clrType, out Type valueType)
+    {
+        valueType = null!;
+
+        var unwrapped = UnwrapNullable(clrType);
+        if (unwrapped is null || !unwrapped.IsGenericType) return false;
+        if (unwrapped.GetGenericTypeDefinition() != typeof(Maybe<>)) return false;
+
+        valueType = unwrapped.GetGenericArguments()[0];
+        return true;
     }
 }

--- a/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
+++ b/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
@@ -2,13 +2,21 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Microsoft.OpenApi;
-using StrongTypes.OpenApi.Core;
 
-namespace StrongTypes.OpenApi.Microsoft;
+namespace StrongTypes.OpenApi.Core;
 
-// Source: Microsoft.AspNetCore.OpenApi 10.0 — JsonNodeSchemaExtensions.ApplyValidationAttributes
-// and OpenApiSchemaService's per-property attribute pass. Keep this in step on runtime upgrades.
-internal static class WrapperAnnotationApplier
+/// <summary>
+/// Layers caller-supplied data-annotations
+/// (<see cref="StringLengthAttribute"/>, <see cref="RangeAttribute"/>,
+/// <see cref="RegularExpressionAttribute"/>, <see cref="DescriptionAttribute"/>, …)
+/// onto a schema painted for a strong-type wrapper. Bounds are tightened
+/// via the <see cref="SchemaPaint"/> helpers so caller-stricter values
+/// stack on top of the wrapper's own floor/ceiling without weakening
+/// either side. Returns <c>true</c> when the wrapper type was recognised
+/// and the attribute pass ran (regardless of whether any individual
+/// attribute matched).
+/// </summary>
+public static class WrapperAnnotationApplier
 {
     public static bool TryApply(OpenApiSchema schema, Type? propertyClrType, IEnumerable<Attribute> attributes)
     {
@@ -18,7 +26,7 @@ internal static class WrapperAnnotationApplier
         var attrList = attributes as IReadOnlyList<Attribute> ?? attributes.ToArray();
 
         var matched = false;
-        if (unwrapped == typeof(NonEmptyString))
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email))
         {
             ApplyStringAnnotations(schema, attrList);
             matched = true;

--- a/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
+++ b/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
@@ -22,34 +22,28 @@ public static class WrapperAnnotationApplier
     {
         if (propertyClrType is null) return false;
 
-        var unwrapped = Nullable.GetUnderlyingType(propertyClrType) ?? propertyClrType;
         var attrList = attributes as IReadOnlyList<Attribute> ?? attributes.ToArray();
 
         var matched = false;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email))
+        if (StrongTypeSchemaTypes.IsNonEmptyString(propertyClrType) || StrongTypeSchemaTypes.IsEmail(propertyClrType))
         {
             ApplyStringAnnotations(schema, attrList);
             matched = true;
         }
-        else if (unwrapped == typeof(Digit))
+        else if (StrongTypeSchemaTypes.IsDigit(propertyClrType))
         {
             ApplyNumericAnnotations(schema, attrList);
             matched = true;
         }
-        else if (unwrapped.IsGenericType)
+        else if (StrongTypeSchemaTypes.TryGetNumeric(propertyClrType, out _, out _))
         {
-            var def = unwrapped.GetGenericTypeDefinition();
-            if (def == typeof(Positive<>) || def == typeof(NonNegative<>) ||
-                def == typeof(Negative<>) || def == typeof(NonPositive<>))
-            {
-                ApplyNumericAnnotations(schema, attrList);
-                matched = true;
-            }
-            else if (def == typeof(NonEmptyEnumerable<>) || def == typeof(INonEmptyEnumerable<>))
-            {
-                ApplyArrayAnnotations(schema, attrList);
-                matched = true;
-            }
+            ApplyNumericAnnotations(schema, attrList);
+            matched = true;
+        }
+        else if (StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(propertyClrType, out _))
+        {
+            ApplyArrayAnnotations(schema, attrList);
+            matched = true;
         }
 
         if (!matched) return false;

--- a/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
+++ b/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
@@ -31,6 +31,11 @@ public static class WrapperAnnotationApplier
             ApplyStringAnnotations(schema, attrList);
             matched = true;
         }
+        else if (unwrapped == typeof(Digit))
+        {
+            ApplyNumericAnnotations(schema, attrList);
+            matched = true;
+        }
         else if (unwrapped.IsGenericType)
         {
             var def = unwrapped.GetGenericTypeDefinition();

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -82,6 +82,23 @@ internal static class BindingSchemaAsserts
     internal static void AssertNonPositiveDecimalSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"number","format":"double","maximum":0}""");
 
+    internal static void AssertPlainDecimalSchema(JsonElement schema, OpenApiVersion version)
+    {
+        if (version == OpenApiVersion.V3_1 && schema.TryGetProperty("pattern", out _) && schema.TryGetProperty("type", out _))
+        {
+            AssertJsonEquals(schema, """{"pattern":"^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$","type":["number","string"],"format":"double"}""");
+            return;
+        }
+
+        if (schema.TryGetProperty("pattern", out _))
+        {
+            AssertJsonEquals(schema, """{"pattern":"^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$","format":"double"}""");
+            return;
+        }
+
+        AssertJsonEquals(schema, """{"type":"number","format":"double"}""");
+    }
+
     // ── Email ────────────────────────────────────────────────────────────
 
     internal static void AssertEmailSchema(JsonElement schema, bool isEmailStringFormatBroken)

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -28,7 +28,7 @@ internal static class BindingSchemaAsserts
     /// index and asserts this count to lock in that the broken shape is the
     /// one we expect.
     /// </summary>
-    private const int FormFieldCount = 6;
+    private const int FormFieldCount = 8;
 
     // ── NonEmptyString ───────────────────────────────────────────────────
 
@@ -58,6 +58,14 @@ internal static class BindingSchemaAsserts
     internal static void AssertFormPropertyPositiveIntSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
         => AssertPositiveIntSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
 
+    // ── Digit ────────────────────────────────────────────────────────────
+
+    internal static void AssertDigitSchema(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":0,"maximum":9}""");
+
+    internal static void AssertFormPropertyDigitSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+        => AssertDigitSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
+
     // ── Other numeric wrappers ──────────────────────────────────────────
     // Inclusive-bound shapes (NonNegative, NonPositive) don't depend on
     // OpenAPI version — there's no exclusive boundary to encode. Exclusive
@@ -81,6 +89,14 @@ internal static class BindingSchemaAsserts
     // mapping as ideal.
     internal static void AssertNonPositiveDecimalSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"number","format":"double","maximum":0}""");
+
+    // ── NonEmptyEnumerable<T> ────────────────────────────────────────────
+
+    internal static void AssertNonEmptyEnumerableOfNonEmptyStringSchema(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
+
+    internal static void AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+        => AssertNonEmptyEnumerableOfNonEmptyStringSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
 
     internal static void AssertPlainDecimalSchema(JsonElement schema, OpenApiVersion version)
     {
@@ -128,7 +144,16 @@ internal static class BindingSchemaAsserts
             Assert.Equal(JsonValueKind.Array, allOf.ValueKind);
             Assert.Equal(FormFieldCount, allOf.GetArrayLength());
             Assert.False(formSchema.TryGetProperty("properties", out _), "form schema is broken-flagged but still has a properties map");
-            return allOf[allOfIndex];
+            var slot = allOf[allOfIndex];
+            if (slot.TryGetProperty("properties", out var slotProperties))
+            {
+                foreach (var entry in slotProperties.EnumerateObject())
+                {
+                    if (string.Equals(entry.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                        return entry.Value;
+                }
+            }
+            return slot;
         }
 
         var properties = formSchema.GetProperty("properties");

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -5,13 +5,12 @@ using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
 namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 
 /// <summary>
-/// Centralised wire-shape assertions for the strong-type wrappers. Every
-/// helper deep-compares against a literal JSON snapshot via
+/// Centralised wire-shape assertions for the strong-type wrappers, used
+/// by body, parameter, and form-property tests alike — the wrapper's
+/// wire shape doesn't depend on where it's bound. Every helper
+/// deep-compares against a literal JSON snapshot via
 /// <see cref="AssertJsonEquals"/> so an unexpected keyword fails the test
-/// instead of silently passing. The shapes pinned here are the same wire
-/// shapes the JSON-body path emits — there is no body-vs-non-body
-/// difference at the wire — so callers from non-body tests can safely use
-/// these to assert parameter and form-property schemas alike.
+/// instead of silently passing.
 ///
 /// The form helpers additionally navigate the request-body schema:
 /// pipelines may emit <c>{ properties: { … } }</c> (Microsoft, modern
@@ -58,6 +57,30 @@ internal static class BindingSchemaAsserts
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
     internal static void AssertFormPropertyPositiveIntSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
         => AssertPositiveIntSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
+
+    // ── Other numeric wrappers ──────────────────────────────────────────
+    // Inclusive-bound shapes (NonNegative, NonPositive) don't depend on
+    // OpenAPI version — there's no exclusive boundary to encode. Exclusive
+    // shapes (Negative<double>) split the same way Positive does.
+
+    internal static void AssertNonNegativeLongSchema(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"integer","format":"int64","minimum":0}""");
+
+    internal static void AssertNegativeDoubleSchema(JsonElement schema, OpenApiVersion version)
+        => AssertJsonEquals(schema, version switch
+        {
+            OpenApiVersion.V3_0 => """{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}""",
+            OpenApiVersion.V3_1 => """{"type":"number","format":"double","exclusiveMaximum":0}""",
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
+        });
+
+    // Both pipelines emit `format: double` for `decimal`. There's no
+    // standard OpenAPI format for the BCL decimal type, so they fall
+    // through to the closest numeric format. Pinned here to surface a
+    // future change in pipeline behaviour rather than to bless the
+    // mapping as ideal.
+    internal static void AssertNonPositiveDecimalSchema(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"number","format":"double","maximum":0}""");
 
     // ── Email ────────────────────────────────────────────────────────────
 

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -7,12 +7,7 @@ namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 /// <summary>
 /// Schema-shape assertions for parameters bound from non-body sources
 /// (<c>[FromQuery]</c>, <c>[FromRoute]</c>, <c>[FromHeader]</c>) and for
-/// individual properties of <c>[FromForm]</c> request bodies. The same
-/// assertion runs on every pipeline; when a pipeline gets the schema
-/// wrong it sets the matching "broken" flag and the helper asserts the
-/// <em>actual</em> broken shape (rather than silently skipping). The day
-/// the pipeline starts emitting the correct shape, the broken-path assert
-/// fails and the flag must be flipped to <c>false</c> in the subclass.
+/// individual properties of <c>[FromForm]</c> request bodies.
 ///
 /// Every shape helper deep-compares the schema against a literal JSON
 /// snapshot via <see cref="AssertJsonEquals"/>, so the helper body reads
@@ -20,15 +15,12 @@ namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 ///
 /// Per-source splits exist where the broken shape genuinely differs by
 /// binding source — most notably <see cref="AssertRoutePositiveInt"/>,
-/// because a route <c>:int</c> constraint preserves <c>{type:integer,
-/// format:int32}</c> while every other source falls all the way back to
-/// <c>{type:string}</c>. Where the broken shape is consistent across
-/// sources (NonEmptyString, Email) a single helper covers all of them.
-///
-/// Each <c>isXBroken</c> parameter mirrors the name of the flag on
-/// <see cref="OpenApiDocumentTestsBase"/> that it carries — so a call site
-/// reads as <c>AssertNonBodyEmail(schema, IsNonJsonBodyStrongTypeSchemaBroken,
-/// IsEmailStringFormatBroken)</c> with no ambiguity about which flag is which.
+/// where a route <c>:int</c> constraint preserves the integer encoding
+/// even on pipelines that don't (yet) honour the strong-type transformer
+/// for non-body slots. The flag-driven branches that lived here for the
+/// pre-#87 Microsoft pipeline have been removed: every supported pipeline
+/// runs a non-body strong-type painter, and any future regression on that
+/// painter shows up as a literal-schema mismatch on these helpers.
 /// </summary>
 internal static class BindingSchemaAsserts
 {
@@ -42,69 +34,24 @@ internal static class BindingSchemaAsserts
 
     // ── NonEmptyString ───────────────────────────────────────────────────
 
-    internal static void AssertNonBodyNonEmptyString(JsonElement schema, bool isNonJsonBodyStrongTypeSchemaBroken)
-    {
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenNonEmptyString(schema);
-        else AssertCorrectNonEmptyString(schema);
-    }
+    internal static void AssertNonBodyNonEmptyString(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"string","minLength":1}""");
 
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyNonEmptyString(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isNonJsonBodyStrongTypeSchemaBroken)
-    {
-        var schema = GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken);
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenNonEmptyString(schema);
-        else AssertCorrectNonEmptyString(schema);
-    }
-
-    private static void AssertCorrectNonEmptyString(JsonElement schema)
-        => AssertJsonEquals(schema, """{"type":"string","minLength":1}""");
-
-    private static void AssertBrokenNonEmptyString(JsonElement schema)
-        // Schema transformer didn't run; the underlying string type survives
-        // but the NonEmptyString-specific minLength: 1 is missing.
-        => AssertJsonEquals(schema, """{"type":"string"}""");
+    internal static void AssertFormPropertyNonEmptyString(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+        => AssertNonBodyNonEmptyString(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
 
     // ── Positive<int> ────────────────────────────────────────────────────
-    // Broken shape splits by source: a route :int constraint preserves
-    // {type:integer, format:int32}; every other source falls back to
-    // {type:string} because there's no source-side type metadata.
-    // Correct shape splits by OpenAPI version: 3.0 encodes the exclusive
-    // bound as {minimum:0, exclusiveMinimum:true} (boolean pair); 3.1 as
+    // Splits by OpenAPI version: 3.0 encodes the exclusive bound as
+    // {minimum:0, exclusiveMinimum:true} (boolean pair); 3.1 as
     // {exclusiveMinimum:0} (numeric).
 
     /// <summary>
-    /// Asserts the schema for a <c>[FromQuery]</c> or <c>[FromHeader]</c>
-    /// <c>Positive&lt;int&gt;</c> parameter. On the broken path the underlying
-    /// type falls back to <c>{type:string}</c>.
+    /// Asserts the schema for a <c>[FromQuery]</c> / <c>[FromHeader]</c> /
+    /// <c>[FromRoute]</c> <c>Positive&lt;int&gt;</c> parameter.
     /// </summary>
-    internal static void AssertNonBodyPositiveInt(JsonElement schema, bool isNonJsonBodyStrongTypeSchemaBroken, OpenApiVersion version)
-    {
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenPositiveIntStringFallback(schema);
-        else AssertCorrectPositiveInt(schema, version);
-    }
-
-    /// <summary>
-    /// Asserts the schema for a <c>[FromRoute]</c> <c>Positive&lt;int&gt;</c>
-    /// parameter. On the broken path the route <c>:int</c> constraint
-    /// preserves <c>{type:integer, format:int32}</c>.
-    /// </summary>
-    internal static void AssertRoutePositiveInt(JsonElement schema, bool isNonJsonBodyStrongTypeSchemaBroken, OpenApiVersion version)
-    {
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenPositiveIntIntegerWithFormat(schema);
-        else AssertCorrectPositiveInt(schema, version);
-    }
-
-    /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
-    /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyPositiveInt(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isNonJsonBodyStrongTypeSchemaBroken, OpenApiVersion version)
-    {
-        var schema = GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken);
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenPositiveIntStringFallback(schema);
-        else AssertCorrectPositiveInt(schema, version);
-    }
-
-    private static void AssertCorrectPositiveInt(JsonElement schema, OpenApiVersion version)
+    internal static void AssertNonBodyPositiveInt(JsonElement schema, OpenApiVersion version)
         => AssertJsonEquals(schema, version switch
         {
             OpenApiVersion.V3_0 => """{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}""",
@@ -112,43 +59,31 @@ internal static class BindingSchemaAsserts
             _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
         });
 
-    private static void AssertBrokenPositiveIntStringFallback(JsonElement schema)
-        // Schema transformer didn't run and there's no source-side metadata
-        // (no route :int constraint, etc.); the type falls all the way back
-        // to a string with neither format nor exclusiveMinimum.
-        => AssertJsonEquals(schema, """{"type":"string"}""");
-
-    private static void AssertBrokenPositiveIntIntegerWithFormat(JsonElement schema)
-        // Schema transformer didn't run, but the route :int constraint
-        // preserves the underlying integer type. exclusiveMinimum is absent.
-        => AssertJsonEquals(schema, """{"type":"integer","format":"int32"}""");
-
-    // ── Email ────────────────────────────────────────────────────────────
-
-    internal static void AssertNonBodyEmail(JsonElement schema, bool isNonJsonBodyStrongTypeSchemaBroken, bool isEmailStringFormatBroken)
-    {
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenEmail(schema);
-        else AssertCorrectEmail(schema, isEmailStringFormatBroken);
-    }
+    /// <summary>
+    /// Same wire shape as <see cref="AssertNonBodyPositiveInt"/>; kept as
+    /// a separate entry point because the route helper used to assert a
+    /// pipeline-specific broken shape and call sites still document the
+    /// binding source they're exercising.
+    /// </summary>
+    internal static void AssertRoutePositiveInt(JsonElement schema, OpenApiVersion version)
+        => AssertNonBodyPositiveInt(schema, version);
 
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyEmail(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isNonJsonBodyStrongTypeSchemaBroken, bool isEmailStringFormatBroken)
-    {
-        var schema = GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken);
-        if (isNonJsonBodyStrongTypeSchemaBroken) AssertBrokenEmail(schema);
-        else AssertCorrectEmail(schema, isEmailStringFormatBroken);
-    }
+    internal static void AssertFormPropertyPositiveInt(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
+        => AssertNonBodyPositiveInt(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
 
-    private static void AssertCorrectEmail(JsonElement schema, bool isEmailStringFormatBroken)
+    // ── Email ────────────────────────────────────────────────────────────
+
+    internal static void AssertNonBodyEmail(JsonElement schema, bool isEmailStringFormatBroken)
         => AssertJsonEquals(schema, isEmailStringFormatBroken
             ? """{"type":"string","minLength":1,"maxLength":254}"""
             : """{"type":"string","minLength":1,"maxLength":254,"format":"email"}""");
 
-    private static void AssertBrokenEmail(JsonElement schema)
-        // Schema transformer didn't run; the underlying string type survives
-        // but none of the Email-specific keywords appear.
-        => AssertJsonEquals(schema, """{"type":"string"}""");
+    /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
+    /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
+    internal static void AssertFormPropertyEmail(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isEmailStringFormatBroken)
+        => AssertNonBodyEmail(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), isEmailStringFormatBroken);
 
     /// <summary>
     /// Looks up a per-field schema on a <c>[FromForm]</c> request-body

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -5,22 +5,21 @@ using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
 namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 
 /// <summary>
-/// Schema-shape assertions for parameters bound from non-body sources
-/// (<c>[FromQuery]</c>, <c>[FromRoute]</c>, <c>[FromHeader]</c>) and for
-/// individual properties of <c>[FromForm]</c> request bodies.
+/// Centralised wire-shape assertions for the strong-type wrappers. Every
+/// helper deep-compares against a literal JSON snapshot via
+/// <see cref="AssertJsonEquals"/> so an unexpected keyword fails the test
+/// instead of silently passing. The shapes pinned here are the same wire
+/// shapes the JSON-body path emits — there is no body-vs-non-body
+/// difference at the wire — so callers from non-body tests can safely use
+/// these to assert parameter and form-property schemas alike.
 ///
-/// Every shape helper deep-compares the schema against a literal JSON
-/// snapshot via <see cref="AssertJsonEquals"/>, so the helper body reads
-/// as the exact expected schema and any unexpected keyword fails the test.
-///
-/// Per-source splits exist where the broken shape genuinely differs by
-/// binding source — most notably <see cref="AssertRoutePositiveInt"/>,
-/// where a route <c>:int</c> constraint preserves the integer encoding
-/// even on pipelines that don't (yet) honour the strong-type transformer
-/// for non-body slots. The flag-driven branches that lived here for the
-/// pre-#87 Microsoft pipeline have been removed: every supported pipeline
-/// runs a non-body strong-type painter, and any future regression on that
-/// painter shows up as a literal-schema mismatch on these helpers.
+/// The form helpers additionally navigate the request-body schema:
+/// pipelines may emit <c>{ properties: { … } }</c> (Microsoft, modern
+/// Swashbuckle) or <c>{ allOf: [ &lt;each-field&gt; ] }</c> with the
+/// field names dropped (vanilla Swashbuckle when every field is
+/// component-typed — see <see cref="OpenApiDocumentTestsBase.IsFormPropertiesSchemaBroken"/>).
+/// The helpers pick the right slot per pipeline and then run the same
+/// shape assertion as the parameter-side helpers.
 /// </summary>
 internal static class BindingSchemaAsserts
 {
@@ -34,24 +33,20 @@ internal static class BindingSchemaAsserts
 
     // ── NonEmptyString ───────────────────────────────────────────────────
 
-    internal static void AssertNonBodyNonEmptyString(JsonElement schema)
+    internal static void AssertNonEmptyStringSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"string","minLength":1}""");
 
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyNonEmptyString(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
-        => AssertNonBodyNonEmptyString(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
+    internal static void AssertFormPropertyNonEmptyStringSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+        => AssertNonEmptyStringSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
 
     // ── Positive<int> ────────────────────────────────────────────────────
     // Splits by OpenAPI version: 3.0 encodes the exclusive bound as
     // {minimum:0, exclusiveMinimum:true} (boolean pair); 3.1 as
     // {exclusiveMinimum:0} (numeric).
 
-    /// <summary>
-    /// Asserts the schema for a <c>[FromQuery]</c> / <c>[FromHeader]</c> /
-    /// <c>[FromRoute]</c> <c>Positive&lt;int&gt;</c> parameter.
-    /// </summary>
-    internal static void AssertNonBodyPositiveInt(JsonElement schema, OpenApiVersion version)
+    internal static void AssertPositiveIntSchema(JsonElement schema, OpenApiVersion version)
         => AssertJsonEquals(schema, version switch
         {
             OpenApiVersion.V3_0 => """{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}""",
@@ -59,31 +54,22 @@ internal static class BindingSchemaAsserts
             _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
         });
 
-    /// <summary>
-    /// Same wire shape as <see cref="AssertNonBodyPositiveInt"/>; kept as
-    /// a separate entry point because the route helper used to assert a
-    /// pipeline-specific broken shape and call sites still document the
-    /// binding source they're exercising.
-    /// </summary>
-    internal static void AssertRoutePositiveInt(JsonElement schema, OpenApiVersion version)
-        => AssertNonBodyPositiveInt(schema, version);
-
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyPositiveInt(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
-        => AssertNonBodyPositiveInt(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
+    internal static void AssertFormPropertyPositiveIntSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
+        => AssertPositiveIntSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
 
     // ── Email ────────────────────────────────────────────────────────────
 
-    internal static void AssertNonBodyEmail(JsonElement schema, bool isEmailStringFormatBroken)
+    internal static void AssertEmailSchema(JsonElement schema, bool isEmailStringFormatBroken)
         => AssertJsonEquals(schema, isEmailStringFormatBroken
             ? """{"type":"string","minLength":1,"maxLength":254}"""
             : """{"type":"string","minLength":1,"maxLength":254,"format":"email"}""");
 
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyEmail(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isEmailStringFormatBroken)
-        => AssertNonBodyEmail(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), isEmailStringFormatBroken);
+    internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isEmailStringFormatBroken)
+        => AssertEmailSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), isEmailStringFormatBroken);
 
     /// <summary>
     /// Looks up a per-field schema on a <c>[FromForm]</c> request-body
@@ -92,8 +78,7 @@ internal static class BindingSchemaAsserts
     /// because Microsoft emits PascalCase, Swashbuckle camelCase). On the
     /// broken path the form schema is <c>{ allOf: [&lt;each-field&gt;] }</c>
     /// with names dropped; the field is found by its declaration index
-    /// (<paramref name="allOfIndex"/>). Either way, the per-field schema
-    /// returned is then asserted with the same strong-type assertion.
+    /// (<paramref name="allOfIndex"/>).
     /// </summary>
     private static JsonElement GetFormProperty(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
     {

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/ComponentSchemas.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/ComponentSchemas.cs
@@ -30,6 +30,7 @@ internal static class ComponentSchemas
     {
         if (string.Equals(name, "NonEmptyString", StringComparison.Ordinal)) return true;
         if (string.Equals(name, "Email", StringComparison.Ordinal)) return true;
+        if (string.Equals(name, "Digit", StringComparison.Ordinal)) return true;
 
         if (name.StartsWith("PositiveOf", StringComparison.Ordinal)
             || name.StartsWith("NonNegativeOf", StringComparison.Ordinal)

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/SchemaNavigation.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/SchemaNavigation.cs
@@ -137,6 +137,19 @@ internal static class SchemaNavigation
         AssertJsonEqualsCore(doc.RootElement, actual, path: "$");
     }
 
+    // OpenAPI 3.0 keywords whose default value is `false`. Pipelines vary
+    // on whether they emit them when set to the default — Swashbuckle's
+    // serializer writes `exclusiveMinimum: false` alongside an inclusive
+    // bound, Microsoft's omits it. Both are wire-equivalent to absent;
+    // the comparator treats them as such so the strict deep-compare still
+    // catches stray *meaningful* keywords without complaining about
+    // serialization noise.
+    private static readonly HashSet<string> s_falseDefaultKeywords = new(StringComparer.Ordinal)
+    {
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+    };
+
     private static void AssertJsonEqualsCore(JsonElement expected, JsonElement actual, string path)
     {
         if (expected.ValueKind != actual.ValueKind)
@@ -146,7 +159,9 @@ internal static class SchemaNavigation
         {
             case JsonValueKind.Object:
                 var expectedKeys = expected.EnumerateObject().Select(p => p.Name).Order().ToArray();
-                var actualKeys = actual.EnumerateObject().Select(p => p.Name).Order().ToArray();
+                var actualKeys = actual.EnumerateObject()
+                    .Where(p => !IsRedundantDefault(p, expected))
+                    .Select(p => p.Name).Order().ToArray();
                 if (!expectedKeys.SequenceEqual(actualKeys))
                     Assert.Fail($"at {path}: property-name set differs\n  expected: [{string.Join(", ", expectedKeys)}]\n  actual:   [{string.Join(", ", actualKeys)}]\n  actual schema: {actual.GetRawText()}");
                 foreach (var prop in expected.EnumerateObject())
@@ -176,4 +191,9 @@ internal static class SchemaNavigation
                 break;
         }
     }
+
+    private static bool IsRedundantDefault(JsonProperty prop, JsonElement expected)
+        => s_falseDefaultKeywords.Contains(prop.Name)
+           && prop.Value.ValueKind == JsonValueKind.False
+           && !expected.TryGetProperty(prop.Name, out _);
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
@@ -17,5 +17,4 @@ public sealed class MicrosoftOpenApi31DocumentTests(MicrosoftTestApi31Factory fa
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_1;
     protected override bool IsEmailStringFormatBroken => true;
-    protected override bool IsNonJsonBodyStrongTypeSchemaBroken => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
@@ -15,5 +15,4 @@ public sealed class MicrosoftOpenApiDocumentTests(MicrosoftTestApiFactory factor
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
     protected override bool IsEmailStringFormatBroken => true;
-    protected override bool IsNonJsonBodyStrongTypeSchemaBroken => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
@@ -31,6 +31,23 @@ namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 public abstract partial class OpenApiDocumentTestsBase
 {
     [Fact]
+    public async Task Property_Email_With_StringLength_Tightens_MaxLength_Below_Wrapper_Ceiling()
+    {
+        var doc = await GetDocumentAsync();
+        var body = FollowRef(doc, RequestSchema(doc, "/annotated-texts"));
+        var annotatedEmail = Property(body, "annotatedEmail");
+
+        // Caller's [StringLength(100)] is tighter than the Email wrapper's
+        // own maxLength: 254 — the merged shape must surface 100. The
+        // wrapper's minLength: 1 still floors the lower bound, and the
+        // wrapper's format: email reaches the wire on pipelines that
+        // honour it on the wrapper component schema.
+        Assert.Equal(1, CollectMaxInt(doc, annotatedEmail, "minLength", Version));
+        Assert.Equal(100, CollectMinInt(doc, annotatedEmail, "maxLength", Version));
+        Assert.Equal("email", CollectFirstString(doc, annotatedEmail, "format", Version));
+    }
+
+    [Fact]
     public async Task Property_NonEmptyString_With_StringLength_And_Pattern_Carries_All_Three()
     {
         var doc = await GetDocumentAsync();

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
@@ -165,6 +165,17 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task Property_Digit_With_Range_Carries_Caller_Bounds()
+    {
+        var doc = await GetDocumentAsync();
+        var body = FollowRef(doc, RequestSchema(doc, "/annotated-numbers"));
+        var digit = Property(body, "digit");
+
+        Assert.Equal(2m, CollectMaxLowerBound(doc, digit, Version));
+        Assert.Equal(8m, CollectMinUpperBound(doc, digit, Version));
+    }
+
+    [Fact]
     public async Task Property_NonEmptyEnumerable_With_MaxLength_Carries_Min_And_MaxItems()
     {
         var doc = await GetDocumentAsync();
@@ -330,6 +341,17 @@ public abstract partial class OpenApiDocumentTestsBase
 
         Assert.Equal(10m, CollectMinUpperBound(doc, exclusiveRaw, Version));
         AssertExclusiveLowerBoundReachable(doc, exclusiveRaw, 2m, Version);
+    }
+
+    [Fact]
+    public async Task Property_Int_Digit_Baseline_With_Range_Carries_Caller_Bounds()
+    {
+        var doc = await GetDocumentAsync();
+        var body = FollowRef(doc, RequestSchema(doc, "/annotated-numbers"));
+        var digitRaw = Property(body, "digitRaw");
+
+        Assert.Equal(2m, CollectMaxLowerBound(doc, digitRaw, Version));
+        Assert.Equal(8m, CollectMinUpperBound(doc, digitRaw, Version));
     }
 
     [Fact]

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
@@ -1,8 +1,7 @@
 using Xunit;
+using static StrongTypes.OpenApi.IntegrationTests.Helpers.BindingSchemaAsserts;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.NullableUnwrap;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaValueReader;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaWalk;
 
 namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 
@@ -13,14 +12,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/email-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("string", StringOrNull(value, "type"));
-        Assert.Equal("email", StringOrNull(value, "format"));
-        Assert.Equal(1, IntOrNull(value, "minLength"));
-        Assert.Equal(254, IntOrNull(value, "maxLength"));
-        Assert.False(value.TryGetProperty("properties", out _));
+        AssertEmailSchema(Property(body, "value"), isEmailStringFormatBroken: false);
     }
 
     [Fact]
@@ -28,12 +20,6 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/email-entities"));
-        var nullableValue = UnwrapNullableProperty(Property(body, "nullableValue"), Version);
-
-        AssertInlineSchema(nullableValue);
-        Assert.Equal("string", StringOrNull(nullableValue, "type"));
-        Assert.Equal("email", StringOrNull(nullableValue, "format"));
-        Assert.Equal(1, IntOrNull(nullableValue, "minLength"));
-        Assert.Equal(254, IntOrNull(nullableValue, "maxLength"));
+        AssertEmailSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version), isEmailStringFormatBroken: false);
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -199,7 +199,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromQuery_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "count");
-        AssertAnnotatedPositiveIntRangeShape(schema);
+        AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
     [Fact]
@@ -232,28 +232,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
         var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "count", allOfIndex: 1);
-        AssertAnnotatedPositiveIntRangeShape(schema);
-    }
-
-    // Caller's [Range(5, 100)] is merged: type+format come from the
-    // wrapper, minimum and maximum come from the caller. Pipelines may
-    // emit redundant `exclusiveMinimum: false` / `exclusiveMaximum: false`
-    // defaults under OpenAPI 3.0 — wire-equivalent to omitting them — so
-    // we assert the load-bearing keywords directly rather than pin the
-    // full literal shape.
-    private static void AssertAnnotatedPositiveIntRangeShape(JsonElement schema)
-    {
-        Assert.Equal("integer", schema.GetProperty("type").GetString());
-        Assert.Equal("int32", schema.GetProperty("format").GetString());
-        Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
-        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
-        // exclusiveMinimum/Maximum, if present, must be false (i.e. the
-        // bounds are inclusive). A `true` here would mean the wrapper's
-        // exclusive floor leaked through — that's the wrong wire shape.
-        if (schema.TryGetProperty("exclusiveMinimum", out var exMin) && exMin.ValueKind == JsonValueKind.True)
-            Assert.Fail("exclusiveMinimum is true — caller's inclusive bound was not merged correctly");
-        if (schema.TryGetProperty("exclusiveMaximum", out var exMax) && exMax.ValueKind == JsonValueKind.True)
-            Assert.Fail("exclusiveMaximum is true — caller's inclusive bound was not merged correctly");
+        AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
     private JsonElement ResolveAnnotatedFormWrapperProperty(JsonElement formSchema, string propertyName, int allOfIndex)

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -46,6 +46,20 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task FromQuery_Digit_RendersAsInteger_WithZeroToNineBounds()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "digit");
+        AssertDigitSchema(schema);
+    }
+
+    [Fact]
+    public async Task FromQuery_NullableDigit_RendersAsInteger_WithZeroToNineBounds()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableDigit");
+        AssertDigitSchema(schema);
+    }
+
+    [Fact]
     public async Task FromQuery_Email_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "email");
@@ -64,15 +78,22 @@ public abstract partial class OpenApiDocumentTestsBase
     [Fact]
     public async Task FromRoute_NonEmptyString_RendersAsString_WithMinLength()
     {
-        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "name");
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}/{digit}", "name");
         AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromRoute_PositiveInt_RendersAsExclusivePositive()
     {
-        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "count");
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}/{digit}", "count");
         AssertPositiveIntSchema(schema, Version);
+    }
+
+    [Fact]
+    public async Task FromRoute_Digit_RendersAsInteger_WithZeroToNineBounds()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}/{digit}", "digit");
+        AssertDigitSchema(schema);
     }
 
     // ── [FromHeader] ─────────────────────────────────────────────────────
@@ -112,11 +133,13 @@ public abstract partial class OpenApiDocumentTestsBase
     //   1: NullableName   (NonEmptyString?)
     //   2: Count          (Positive<int>)
     //   3: NullableCount  (Positive<int>?)
-    //   4: Email          (Email)
-    //   5: NullableEmail  (Email?)
-    // The form-index is used by the broken-path lookup when the form schema
-    // is `allOf:[<each-field>]` with the names dropped — see
-    // IsFormPropertiesSchemaBroken.
+    //   4: Digit          (Digit)
+    //   5: Tags           (NonEmptyEnumerable<NonEmptyString>)
+    //   6: Email          (Email)
+    //   7: NullableEmail  (Email?)
+    // Swashbuckle's broken allOf keeps most fields in declaration order,
+    // but puts the collection-shaped Tags field at the end as an object
+    // entry; those tests pass the observed allOf index explicitly.
 
     [Fact]
     public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength()
@@ -147,17 +170,31 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task FromForm_Digit_RendersAsInteger_WithZeroToNineBounds()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
+        AssertFormPropertyDigitSchema(formSchema, "digit", allOfIndex: 4, IsFormPropertiesSchemaBroken);
+    }
+
+    [Fact]
+    public async Task FromForm_NonEmptyEnumerable_RendersAsArray_WithMinItems_And_StringItems()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
+        AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(formSchema, "tags", allOfIndex: 7, IsFormPropertiesSchemaBroken);
+    }
+
+    [Fact]
     public async Task FromForm_Email_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 4, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
     }
 
     [Fact]
     public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 6, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
     }
 
     // ── Caller annotations on non-body slots ─────────────────────────────

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -206,7 +206,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PlainString_With_StringLength_Carries_MaxLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), "plainName"));
+        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainName"));
         Assert.Equal(50, schema.GetProperty("maxLength").GetInt32());
     }
 
@@ -214,7 +214,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "name", allOfIndex: 0);
+        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "Name", allOfIndex: 0);
         AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
@@ -222,7 +222,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PlainInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), "plainCount"));
+        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainCount"));
         Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
         Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
     }
@@ -231,7 +231,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "count", allOfIndex: 1);
+        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "Count", allOfIndex: 1);
         AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
@@ -243,17 +243,8 @@ public abstract partial class OpenApiDocumentTestsBase
         if (IsFormPropertiesSchemaBroken)
             return formSchema.GetProperty("allOf")[allOfIndex];
 
-        return formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), propertyName));
+        return formSchema.GetProperty("properties").GetProperty(FormPropertyName(propertyName));
     }
 
-    private static string CamelOrPascal(JsonElement properties, string camelCaseName)
-    {
-        // Microsoft emits PascalCase form-property keys; Swashbuckle emits
-        // camelCase. Pick whichever the schema carries.
-        if (properties.TryGetProperty(camelCaseName, out _)) return camelCaseName;
-        var pascal = char.ToUpperInvariant(camelCaseName[0]) + camelCaseName[1..];
-        if (properties.TryGetProperty(pascal, out _)) return pascal;
-        Assert.Fail($"form properties contain neither '{camelCaseName}' nor '{pascal}'");
-        return camelCaseName;
-    }
+    protected virtual string FormPropertyName(string clrPropertyName) => clrPropertyName;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -207,7 +207,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
         var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainName"));
-        Assert.Equal(50, schema.GetProperty("maxLength").GetInt32());
+        AssertJsonEquals(schema, """{"type":"string","minLength":0,"maxLength":50}""");
     }
 
     [Fact]
@@ -223,8 +223,11 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
         var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainCount"));
-        Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
-        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
+        AssertJsonEquals(schema, IsPlainIntFormSchemaMissingType
+            ? Version == OpenApiVersion.V3_1
+                ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":5,"maximum":100}"""
+                : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":5,"maximum":100}"""
+            : """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
     [Fact]

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -181,12 +181,10 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task FromQuery_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
+    public async Task FromQuery_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "name");
-        AssertJsonEquals(schema, IsNonBodyAnnotationMergingBroken
-            ? """{"type":"string","minLength":1}"""
-            : """{"type":"string","minLength":1,"maxLength":50}""");
+        AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
     [Fact]
@@ -198,10 +196,10 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task FromQuery_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
+    public async Task FromQuery_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "count");
-        AssertJsonEquals(schema, ExpectedAnnotatedRangeShape(IsNonBodyAnnotationMergingBroken, Version));
+        AssertAnnotatedPositiveIntRangeShape(schema);
     }
 
     [Fact]
@@ -213,13 +211,11 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
+    public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
         var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "name", allOfIndex: 0);
-        AssertJsonEquals(schema, IsNonBodyAnnotationMergingBroken
-            ? """{"type":"string","minLength":1}"""
-            : """{"type":"string","minLength":1,"maxLength":50}""");
+        AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
     [Fact]
@@ -232,23 +228,32 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
+    public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
         var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "count", allOfIndex: 1);
-        AssertJsonEquals(schema, ExpectedAnnotatedRangeShape(IsNonBodyAnnotationMergingBroken, Version));
+        AssertAnnotatedPositiveIntRangeShape(schema);
     }
 
-    private static string ExpectedAnnotatedRangeShape(bool mergingBroken, OpenApiVersion version)
+    // Caller's [Range(5, 100)] is merged: type+format come from the
+    // wrapper, minimum and maximum come from the caller. Pipelines may
+    // emit redundant `exclusiveMinimum: false` / `exclusiveMaximum: false`
+    // defaults under OpenAPI 3.0 — wire-equivalent to omitting them — so
+    // we assert the load-bearing keywords directly rather than pin the
+    // full literal shape.
+    private static void AssertAnnotatedPositiveIntRangeShape(JsonElement schema)
     {
-        if (!mergingBroken)
-            return """{"type":"integer","format":"int32","minimum":5,"maximum":100}""";
-        return version switch
-        {
-            OpenApiVersion.V3_0 => """{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}""",
-            OpenApiVersion.V3_1 => """{"type":"integer","format":"int32","exclusiveMinimum":0}""",
-            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
-        };
+        Assert.Equal("integer", schema.GetProperty("type").GetString());
+        Assert.Equal("int32", schema.GetProperty("format").GetString());
+        Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
+        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
+        // exclusiveMinimum/Maximum, if present, must be false (i.e. the
+        // bounds are inclusive). A `true` here would mean the wrapper's
+        // exclusive floor leaked through — that's the wrong wire shape.
+        if (schema.TryGetProperty("exclusiveMinimum", out var exMin) && exMin.ValueKind == JsonValueKind.True)
+            Assert.Fail("exclusiveMinimum is true — caller's inclusive bound was not merged correctly");
+        if (schema.TryGetProperty("exclusiveMaximum", out var exMax) && exMax.ValueKind == JsonValueKind.True)
+            Assert.Fail("exclusiveMaximum is true — caller's inclusive bound was not merged correctly");
     }
 
     private JsonElement ResolveAnnotatedFormWrapperProperty(JsonElement formSchema, string propertyName, int allOfIndex)

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -21,42 +21,42 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromQuery_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "name");
-        AssertNonBodyNonEmptyString(schema);
+        AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromQuery_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableName");
-        AssertNonBodyNonEmptyString(schema);
+        AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromQuery_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "count");
-        AssertNonBodyPositiveInt(schema, Version);
+        AssertPositiveIntSchema(schema, Version);
     }
 
     [Fact]
     public async Task FromQuery_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableCount");
-        AssertNonBodyPositiveInt(schema, Version);
+        AssertPositiveIntSchema(schema, Version);
     }
 
     [Fact]
     public async Task FromQuery_Email_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "email");
-        AssertNonBodyEmail(schema, IsEmailStringFormatBroken);
+        AssertEmailSchema(schema, IsEmailStringFormatBroken);
     }
 
     [Fact]
     public async Task FromQuery_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableEmail");
-        AssertNonBodyEmail(schema, IsEmailStringFormatBroken);
+        AssertEmailSchema(schema, IsEmailStringFormatBroken);
     }
 
     // ── [FromRoute] ──────────────────────────────────────────────────────
@@ -65,14 +65,14 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromRoute_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "name");
-        AssertNonBodyNonEmptyString(schema);
+        AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromRoute_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "count");
-        AssertRoutePositiveInt(schema, Version);
+        AssertPositiveIntSchema(schema, Version);
     }
 
     // ── [FromHeader] ─────────────────────────────────────────────────────
@@ -81,28 +81,28 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromHeader_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Name");
-        AssertNonBodyNonEmptyString(schema);
+        AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromHeader_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Nullable-Name");
-        AssertNonBodyNonEmptyString(schema);
+        AssertNonEmptyStringSchema(schema);
     }
 
     [Fact]
     public async Task FromHeader_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Count");
-        AssertNonBodyPositiveInt(schema, Version);
+        AssertPositiveIntSchema(schema, Version);
     }
 
     [Fact]
     public async Task FromHeader_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Nullable-Count");
-        AssertNonBodyPositiveInt(schema, Version);
+        AssertPositiveIntSchema(schema, Version);
     }
 
     // ── [FromForm] ───────────────────────────────────────────────────────
@@ -122,42 +122,42 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyString(formSchema, "name", allOfIndex: 0, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "name", allOfIndex: 0, IsFormPropertiesSchemaBroken);
     }
 
     [Fact]
     public async Task FromForm_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyString(formSchema, "nullableName", allOfIndex: 1, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "nullableName", allOfIndex: 1, IsFormPropertiesSchemaBroken);
     }
 
     [Fact]
     public async Task FromForm_PositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveInt(formSchema, "count", allOfIndex: 2, IsFormPropertiesSchemaBroken, Version);
+        AssertFormPropertyPositiveIntSchema(formSchema, "count", allOfIndex: 2, IsFormPropertiesSchemaBroken, Version);
     }
 
     [Fact]
     public async Task FromForm_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveInt(formSchema, "nullableCount", allOfIndex: 3, IsFormPropertiesSchemaBroken, Version);
+        AssertFormPropertyPositiveIntSchema(formSchema, "nullableCount", allOfIndex: 3, IsFormPropertiesSchemaBroken, Version);
     }
 
     [Fact]
     public async Task FromForm_Email_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmail(formSchema, "email", allOfIndex: 4, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 4, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
     }
 
     [Fact]
     public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmail(formSchema, "nullableEmail", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
     }
 
     // ── Caller annotations on non-body slots ─────────────────────────────
@@ -165,6 +165,20 @@ public abstract partial class OpenApiDocumentTestsBase
     // data-annotations the same way JSON-body properties do — e.g. a
     // [StringLength(50)] on a [FromQuery] NonEmptyString must reach the
     // wire as maxLength: 50 alongside the wrapper's own minLength: 1.
+    //
+    // Each wrapper-typed test has a primitive-typed sibling that pins the
+    // baseline: the framework natively surfaces the annotation on the
+    // primitive, so the wrapper test only has teeth when the primitive
+    // baseline carries the keyword. If a pipeline ever stops surfacing the
+    // annotation on the primitive, the baseline fails first and the
+    // wrapper failure is correctly attributed to the framework, not us.
+
+    [Fact]
+    public async Task FromQuery_PlainString_With_StringLength_Carries_MaxLength()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "plainName");
+        Assert.Equal(50, schema.GetProperty("maxLength").GetInt32());
+    }
 
     [Fact]
     public async Task FromQuery_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
@@ -176,6 +190,14 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task FromQuery_PlainInt_With_Range_Carries_Both_Bounds()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "plainCount");
+        Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
+        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
+    }
+
+    [Fact]
     public async Task FromQuery_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "count");
@@ -183,20 +205,37 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task FromForm_PlainString_With_StringLength_Carries_MaxLength()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
+        var schema = formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), "plainName"));
+        Assert.Equal(50, schema.GetProperty("maxLength").GetInt32());
+    }
+
+    [Fact]
     public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormProperty(formSchema, "name", allOfIndex: 0);
+        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "name", allOfIndex: 0);
         AssertJsonEquals(schema, IsNonBodyAnnotationMergingBroken
             ? """{"type":"string","minLength":1}"""
             : """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
     [Fact]
+    public async Task FromForm_PlainInt_With_Range_Carries_Both_Bounds()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
+        var schema = formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), "plainCount"));
+        Assert.Equal(5, schema.GetProperty("minimum").GetInt32());
+        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
+    }
+
+    [Fact]
     public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormProperty(formSchema, "count", allOfIndex: 1);
+        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "count", allOfIndex: 1);
         AssertJsonEquals(schema, ExpectedAnnotatedRangeShape(IsNonBodyAnnotationMergingBroken, Version));
     }
 
@@ -212,22 +251,25 @@ public abstract partial class OpenApiDocumentTestsBase
         };
     }
 
-    // The annotated form-probe request has only two fields, so the
-    // BindingSchemaAsserts.GetFormProperty helper (which hard-codes the
-    // 6-field count for the unannotated probe) doesn't fit; this picks
-    // the right slot per pipeline.
-    private JsonElement ResolveAnnotatedFormProperty(JsonElement formSchema, string propertyName, int allOfIndex)
+    private JsonElement ResolveAnnotatedFormWrapperProperty(JsonElement formSchema, string propertyName, int allOfIndex)
     {
+        // For the wrappers-only annotated form, Swashbuckle emits the
+        // broken `{allOf:[<each>]}` shape (every field is component-typed),
+        // while Microsoft emits a proper properties map.
         if (IsFormPropertiesSchemaBroken)
             return formSchema.GetProperty("allOf")[allOfIndex];
 
-        var properties = formSchema.GetProperty("properties");
-        foreach (var entry in properties.EnumerateObject())
-        {
-            if (string.Equals(entry.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-                return entry.Value;
-        }
-        Assert.Fail($"form schema has no '{propertyName}' property");
-        return default;
+        return formSchema.GetProperty("properties").GetProperty(CamelOrPascal(formSchema.GetProperty("properties"), propertyName));
+    }
+
+    private static string CamelOrPascal(JsonElement properties, string camelCaseName)
+    {
+        // Microsoft emits PascalCase form-property keys; Swashbuckle emits
+        // camelCase. Pick whichever the schema carries.
+        if (properties.TryGetProperty(camelCaseName, out _)) return camelCaseName;
+        var pascal = char.ToUpperInvariant(camelCaseName[0]) + camelCaseName[1..];
+        if (properties.TryGetProperty(pascal, out _)) return pascal;
+        Assert.Fail($"form properties contain neither '{camelCaseName}' nor '{pascal}'");
+        return camelCaseName;
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using StrongTypes.OpenApi.IntegrationTests.Helpers;
 using Xunit;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.BindingSchemaAsserts;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
@@ -10,104 +12,97 @@ namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 /// (<c>[FromQuery]</c>, <c>[FromRoute]</c>, <c>[FromHeader]</c>,
 /// <c>[FromForm]</c>). Required and nullable variants of each wrapped type
 /// are exercised separately so a regression on either branch shows up.
-///
-/// Pipelines that don't run the strong-type schema transformer on these
-/// slots (i.e. <see cref="OpenApiDocumentTestsBase.IsNonJsonBodyStrongTypeSchemaBroken"/>)
-/// or that emit the form schema as <c>allOf</c> with field names dropped
-/// (<see cref="OpenApiDocumentTestsBase.IsFormPropertiesSchemaBroken"/>)
-/// take the broken-shape assertion path. Fixing the pipeline flips the
-/// flag and turns those tests into the strong-type-aware assertion path.
 /// </summary>
 public abstract partial class OpenApiDocumentTestsBase
 {
     // ── [FromQuery] ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task FromQuery_NonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromQuery_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "name");
-        AssertNonBodyNonEmptyString(schema, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertNonBodyNonEmptyString(schema);
     }
 
     [Fact]
-    public async Task FromQuery_NullableNonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromQuery_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableName");
-        AssertNonBodyNonEmptyString(schema, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertNonBodyNonEmptyString(schema);
     }
 
     [Fact]
-    public async Task FromQuery_PositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromQuery_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "count");
-        AssertNonBodyPositiveInt(schema, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertNonBodyPositiveInt(schema, Version);
     }
 
     [Fact]
-    public async Task FromQuery_NullablePositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromQuery_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableCount");
-        AssertNonBodyPositiveInt(schema, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertNonBodyPositiveInt(schema, Version);
     }
 
     [Fact]
-    public async Task FromQuery_Email_RendersAsString_WithEmailFormat_When_NotBroken()
+    public async Task FromQuery_Email_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "email");
-        AssertNonBodyEmail(schema, IsNonJsonBodyStrongTypeSchemaBroken, IsEmailStringFormatBroken);
+        AssertNonBodyEmail(schema, IsEmailStringFormatBroken);
     }
 
     [Fact]
-    public async Task FromQuery_NullableEmail_RendersAsString_WithEmailFormat_When_NotBroken()
+    public async Task FromQuery_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableEmail");
-        AssertNonBodyEmail(schema, IsNonJsonBodyStrongTypeSchemaBroken, IsEmailStringFormatBroken);
+        AssertNonBodyEmail(schema, IsEmailStringFormatBroken);
     }
 
     // ── [FromRoute] ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task FromRoute_NonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromRoute_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "name");
-        AssertNonBodyNonEmptyString(schema, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertNonBodyNonEmptyString(schema);
     }
 
     [Fact]
-    public async Task FromRoute_PositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromRoute_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/route/{name}/{count}", "count");
-        AssertRoutePositiveInt(schema, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertRoutePositiveInt(schema, Version);
     }
 
     // ── [FromHeader] ─────────────────────────────────────────────────────
 
     [Fact]
-    public async Task FromHeader_NonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromHeader_NonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Name");
-        AssertNonBodyNonEmptyString(schema, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertNonBodyNonEmptyString(schema);
     }
 
     [Fact]
-    public async Task FromHeader_NullableNonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromHeader_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Nullable-Name");
-        AssertNonBodyNonEmptyString(schema, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertNonBodyNonEmptyString(schema);
     }
 
     [Fact]
-    public async Task FromHeader_PositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromHeader_PositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Count");
-        AssertNonBodyPositiveInt(schema, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertNonBodyPositiveInt(schema, Version);
     }
 
     [Fact]
-    public async Task FromHeader_NullablePositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromHeader_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/header", "X-Nullable-Count");
-        AssertNonBodyPositiveInt(schema, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertNonBodyPositiveInt(schema, Version);
     }
 
     // ── [FromForm] ───────────────────────────────────────────────────────
@@ -124,44 +119,115 @@ public abstract partial class OpenApiDocumentTestsBase
     // IsFormPropertiesSchemaBroken.
 
     [Fact]
-    public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyString(formSchema, "name", allOfIndex: 0, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertFormPropertyNonEmptyString(formSchema, "name", allOfIndex: 0, IsFormPropertiesSchemaBroken);
     }
 
     [Fact]
-    public async Task FromForm_NullableNonEmptyString_RendersAsString_WithMinLength_When_NotBroken()
+    public async Task FromForm_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyString(formSchema, "nullableName", allOfIndex: 1, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken);
+        AssertFormPropertyNonEmptyString(formSchema, "nullableName", allOfIndex: 1, IsFormPropertiesSchemaBroken);
     }
 
     [Fact]
-    public async Task FromForm_PositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromForm_PositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveInt(formSchema, "count", allOfIndex: 2, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertFormPropertyPositiveInt(formSchema, "count", allOfIndex: 2, IsFormPropertiesSchemaBroken, Version);
     }
 
     [Fact]
-    public async Task FromForm_NullablePositiveInt_RendersAsExclusivePositive_When_NotBroken()
+    public async Task FromForm_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveInt(formSchema, "nullableCount", allOfIndex: 3, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken, Version);
+        AssertFormPropertyPositiveInt(formSchema, "nullableCount", allOfIndex: 3, IsFormPropertiesSchemaBroken, Version);
     }
 
     [Fact]
-    public async Task FromForm_Email_RendersAsString_WithEmailFormat_When_NotBroken()
+    public async Task FromForm_Email_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmail(formSchema, "email", allOfIndex: 4, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmail(formSchema, "email", allOfIndex: 4, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
     }
 
     [Fact]
-    public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat_When_NotBroken()
+    public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmail(formSchema, "nullableEmail", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsNonJsonBodyStrongTypeSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmail(formSchema, "nullableEmail", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+    }
+
+    // ── Caller annotations on non-body slots ─────────────────────────────
+    // Strong-type slots bound from query/form should merge caller-supplied
+    // data-annotations the same way JSON-body properties do — e.g. a
+    // [StringLength(50)] on a [FromQuery] NonEmptyString must reach the
+    // wire as maxLength: 50 alongside the wrapper's own minLength: 1.
+
+    [Fact]
+    public async Task FromQuery_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "name");
+        AssertJsonEquals(schema, IsNonBodyAnnotationMergingBroken
+            ? """{"type":"string","minLength":1}"""
+            : """{"type":"string","minLength":1,"maxLength":50}""");
+    }
+
+    [Fact]
+    public async Task FromQuery_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
+    {
+        var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query-annotated", "count");
+        AssertJsonEquals(schema, ExpectedAnnotatedRangeShape(IsNonBodyAnnotationMergingBroken, Version));
+    }
+
+    [Fact]
+    public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds_When_Merged()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
+        var schema = ResolveAnnotatedFormProperty(formSchema, "name", allOfIndex: 0);
+        AssertJsonEquals(schema, IsNonBodyAnnotationMergingBroken
+            ? """{"type":"string","minLength":1}"""
+            : """{"type":"string","minLength":1,"maxLength":50}""");
+    }
+
+    [Fact]
+    public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds_When_Merged()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
+        var schema = ResolveAnnotatedFormProperty(formSchema, "count", allOfIndex: 1);
+        AssertJsonEquals(schema, ExpectedAnnotatedRangeShape(IsNonBodyAnnotationMergingBroken, Version));
+    }
+
+    private static string ExpectedAnnotatedRangeShape(bool mergingBroken, OpenApiVersion version)
+    {
+        if (!mergingBroken)
+            return """{"type":"integer","format":"int32","minimum":5,"maximum":100}""";
+        return version switch
+        {
+            OpenApiVersion.V3_0 => """{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}""",
+            OpenApiVersion.V3_1 => """{"type":"integer","format":"int32","exclusiveMinimum":0}""",
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
+        };
+    }
+
+    // The annotated form-probe request has only two fields, so the
+    // BindingSchemaAsserts.GetFormProperty helper (which hard-codes the
+    // 6-field count for the unannotated probe) doesn't fit; this picks
+    // the right slot per pipeline.
+    private JsonElement ResolveAnnotatedFormProperty(JsonElement formSchema, string propertyName, int allOfIndex)
+    {
+        if (IsFormPropertiesSchemaBroken)
+            return formSchema.GetProperty("allOf")[allOfIndex];
+
+        var properties = formSchema.GetProperty("properties");
+        foreach (var entry in properties.EnumerateObject())
+        {
+            if (string.Equals(entry.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+        Assert.Fail($"form schema has no '{propertyName}' property");
+        return default;
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
@@ -41,6 +41,14 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
+    public async Task Digit_Renders_As_Integer_With_Zero_To_Nine_Bounds()
+    {
+        var doc = await GetDocumentAsync();
+        var body = FollowRef(doc, RequestSchema(doc, "/digit-entities"));
+        AssertDigitSchema(Property(body, "value"));
+    }
+
+    [Fact]
     public async Task Nullable_Positive_Int_Property_Still_Renders_As_Integer_With_ExclusiveMinimum_Zero()
     {
         var doc = await GetDocumentAsync();
@@ -54,5 +62,13 @@ public abstract partial class OpenApiDocumentTestsBase
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
         AssertPositiveIntSchema(UnwrapNullableProperty(Property(body, "nullablePositiveInt"), Version), Version);
+    }
+
+    [Fact]
+    public async Task Nullable_Digit_On_Dedicated_Nullables_Endpoint_Renders_As_Integer_With_Zero_To_Nine_Bounds()
+    {
+        var doc = await GetDocumentAsync();
+        var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
+        AssertDigitSchema(UnwrapNullableProperty(Property(body, "nullableDigit"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
@@ -36,6 +36,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-positive-decimal-entities"));
+        AssertPlainDecimalSchema(Property(body, "plainValue"), Version);
         AssertNonPositiveDecimalSchema(Property(body, "value"));
     }
 

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
@@ -1,9 +1,7 @@
 using Xunit;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.ExclusiveBounds;
+using static StrongTypes.OpenApi.IntegrationTests.Helpers.BindingSchemaAsserts;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.NullableUnwrap;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaValueReader;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaWalk;
 
 namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 
@@ -14,12 +12,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/positive-int-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("integer", StringOrNull(value, "type"));
-        Assert.Equal("int32", StringOrNull(value, "format"));
-        AssertExclusiveLowerBound(value, 0m, Version);
+        AssertPositiveIntSchema(Property(body, "value"), Version);
     }
 
     [Fact]
@@ -27,13 +20,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-negative-long-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("integer", StringOrNull(value, "type"));
-        Assert.Equal("int64", StringOrNull(value, "format"));
-        Assert.Equal(0m, DecimalOrNull(value, "minimum"));
-        Assert.False(BoolOrFalse(value, "exclusiveMinimum"));
+        AssertNonNegativeLongSchema(Property(body, "value"));
     }
 
     [Fact]
@@ -41,12 +28,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/negative-double-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("number", StringOrNull(value, "type"));
-        Assert.Equal("double", StringOrNull(value, "format"));
-        AssertExclusiveUpperBound(value, 0m, Version);
+        AssertNegativeDoubleSchema(Property(body, "value"), Version);
     }
 
     [Fact]
@@ -54,12 +36,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-positive-decimal-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("number", StringOrNull(value, "type"));
-        Assert.Equal(0m, DecimalOrNull(value, "maximum"));
-        Assert.False(BoolOrFalse(value, "exclusiveMaximum"));
+        AssertNonPositiveDecimalSchema(Property(body, "value"));
     }
 
     [Fact]
@@ -67,12 +44,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/positive-int-entities"));
-        var nullableValue = UnwrapNullableProperty(Property(body, "nullableValue"), Version);
-
-        AssertInlineSchema(nullableValue);
-        Assert.Equal("integer", StringOrNull(nullableValue, "type"));
-        Assert.Equal("int32", StringOrNull(nullableValue, "format"));
-        AssertExclusiveLowerBound(nullableValue, 0m, Version);
+        AssertPositiveIntSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version), Version);
     }
 
     [Fact]
@@ -80,11 +52,6 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        var value = UnwrapNullableProperty(Property(body, "nullablePositiveInt"), Version);
-
-        AssertInlineSchema(value);
-        Assert.Equal("integer", StringOrNull(value, "type"));
-        Assert.Equal("int32", StringOrNull(value, "format"));
-        AssertExclusiveLowerBound(value, 0m, Version);
+        AssertPositiveIntSchema(UnwrapNullableProperty(Property(body, "nullablePositiveInt"), Version), Version);
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Strings.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Strings.cs
@@ -1,8 +1,7 @@
 using Xunit;
+using static StrongTypes.OpenApi.IntegrationTests.Helpers.BindingSchemaAsserts;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.NullableUnwrap;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaValueReader;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaWalk;
 
 namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 
@@ -13,12 +12,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-empty-string-entities"));
-        var value = Property(body, "value");
-
-        AssertInlineSchema(value);
-        Assert.Equal("string", StringOrNull(value, "type"));
-        Assert.Equal(1, IntOrNull(value, "minLength"));
-        Assert.False(value.TryGetProperty("properties", out _));
+        AssertNonEmptyStringSchema(Property(body, "value"));
     }
 
     [Fact]
@@ -26,11 +20,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-empty-string-entities"));
-        var nullableValue = UnwrapNullableProperty(Property(body, "nullableValue"), Version);
-
-        AssertInlineSchema(nullableValue);
-        Assert.Equal("string", StringOrNull(nullableValue, "type"));
-        Assert.Equal(1, IntOrNull(nullableValue, "minLength"));
+        AssertNonEmptyStringSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version));
     }
 
     [Fact]
@@ -38,10 +28,6 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        var value = UnwrapNullableProperty(Property(body, "nullableNonEmptyString"), Version);
-
-        AssertInlineSchema(value);
-        Assert.Equal("string", StringOrNull(value, "type"));
-        Assert.Equal(1, IntOrNull(value, "minLength"));
+        AssertNonEmptyStringSchema(UnwrapNullableProperty(Property(body, "nullableNonEmptyString"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -46,22 +46,16 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     protected virtual bool IsEmailStringFormatBroken => false;
 
     /// <summary>
-    /// True when the pipeline doesn't run the strong-type schema transformer
-    /// on schemas that live outside a JSON request/response body — i.e.
-    /// parameter schemas (<c>[FromQuery]</c>, <c>[FromRoute]</c>,
-    /// <c>[FromHeader]</c>) and the per-field schemas inside a
-    /// <c>[FromForm]</c> request body. Microsoft.AspNetCore.OpenApi only
-    /// fires the transformer on JSON body schemas; everything else loses
-    /// the strong-type keywords (<c>minLength</c>, <c>maxLength</c>,
-    /// <c>format</c>, <c>exclusiveMinimum</c>, …). The underlying primitive
-    /// may or may not survive depending on what source-side metadata the
-    /// pipeline can read (e.g. a <c>:int</c> route constraint preserves
-    /// <c>type: integer</c>, otherwise the type falls back to <c>string</c>).
-    /// The broken-path assertion checks that the strong-type keywords are
-    /// absent — the day the pipeline starts honouring the transformer the
-    /// keywords appear, the assertion fails, and this flag must be flipped.
+    /// True when the pipeline paints the strong-type wire shape on a
+    /// non-body slot but does not merge caller-supplied data-annotations
+    /// (<c>[StringLength]</c>, <c>[Range]</c>, …) attached at the slot.
+    /// Tests that exercise annotated <c>[FromQuery]</c> / <c>[FromForm]</c>
+    /// slots branch on this flag: they assert the merged shape on the
+    /// not-broken path and the wrapper-only shape on the broken path. The
+    /// day a pipeline starts merging, the broken-path assertion fails and
+    /// the flag must be flipped.
     /// </summary>
-    protected virtual bool IsNonJsonBodyStrongTypeSchemaBroken => false;
+    protected virtual bool IsNonBodyAnnotationMergingBroken => false;
 
     /// <summary>
     /// True when the pipeline emits the <c>[FromForm]</c> request-body schema

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -46,14 +46,21 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     protected virtual bool IsEmailStringFormatBroken => false;
 
     /// <summary>
-    /// True when the pipeline paints the strong-type wire shape on a
-    /// non-body slot but does not merge caller-supplied data-annotations
-    /// (<c>[StringLength]</c>, <c>[Range]</c>, …) attached at the slot.
-    /// Tests that exercise annotated <c>[FromQuery]</c> / <c>[FromForm]</c>
-    /// slots branch on this flag: they assert the merged shape on the
-    /// not-broken path and the wrapper-only shape on the broken path. The
-    /// day a pipeline starts merging, the broken-path assertion fails and
-    /// the flag must be flipped.
+    /// True when our adapter for the pipeline paints the strong-type wire
+    /// shape on a non-body slot (parameter or form-body field) but does
+    /// not merge caller-supplied data-annotations (<c>[StringLength]</c>,
+    /// <c>[Range]</c>, …) attached at the slot. The matching primitive
+    /// baselines (<c>FromQuery_Plain*</c> / <c>FromForm_Plain*</c>) prove
+    /// the framework itself does surface these annotations on a plain
+    /// <c>string</c> / <c>int</c> sibling, so when this flag is true the
+    /// gap is in our own non-body painter for that pipeline, not a
+    /// framework limitation.
+    ///
+    /// Currently set on the Swashbuckle adapter, where the non-body
+    /// annotation pass is not yet implemented. The matching wrapper tests
+    /// branch on the flag: merged shape on the not-broken path, wrapper-only
+    /// shape on the broken path. Implementing the missing pass flips the
+    /// flag back to <c>false</c>.
     /// </summary>
     protected virtual bool IsNonBodyAnnotationMergingBroken => false;
 

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -46,25 +46,6 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     protected virtual bool IsEmailStringFormatBroken => false;
 
     /// <summary>
-    /// True when our adapter for the pipeline paints the strong-type wire
-    /// shape on a non-body slot (parameter or form-body field) but does
-    /// not merge caller-supplied data-annotations (<c>[StringLength]</c>,
-    /// <c>[Range]</c>, …) attached at the slot. The matching primitive
-    /// baselines (<c>FromQuery_Plain*</c> / <c>FromForm_Plain*</c>) prove
-    /// the framework itself does surface these annotations on a plain
-    /// <c>string</c> / <c>int</c> sibling, so when this flag is true the
-    /// gap is in our own non-body painter for that pipeline, not a
-    /// framework limitation.
-    ///
-    /// Currently set on the Swashbuckle adapter, where the non-body
-    /// annotation pass is not yet implemented. The matching wrapper tests
-    /// branch on the flag: merged shape on the not-broken path, wrapper-only
-    /// shape on the broken path. Implementing the missing pass flips the
-    /// flag back to <c>false</c>.
-    /// </summary>
-    protected virtual bool IsNonBodyAnnotationMergingBroken => false;
-
-    /// <summary>
     /// True when the pipeline emits the <c>[FromForm]</c> request-body schema
     /// as <c>{ "allOf": [&lt;each-property's-schema&gt;] }</c> — i.e. each
     /// form field's schema is correct, but the field <em>names</em> are

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -59,6 +59,8 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     /// </summary>
     protected virtual bool IsFormPropertiesSchemaBroken => false;
 
+    protected virtual bool IsPlainIntFormSchemaMissingType => true;
+
     private async Task<JsonElement> GetDocumentAsync()
     {
         var response = await client.GetAsync(DocumentUrl, Ct);

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
@@ -15,4 +15,5 @@ public sealed class SwashbuckleOpenApiDocumentTests(SwashbuckleTestApiFactory fa
     protected override string DocumentUrl => "/swagger/v1/swagger.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
     protected override bool IsFormPropertiesSchemaBroken => true;
+    protected override bool IsPlainIntFormSchemaMissingType => false;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
@@ -15,5 +15,4 @@ public sealed class SwashbuckleOpenApiDocumentTests(SwashbuckleTestApiFactory fa
     protected override string DocumentUrl => "/swagger/v1/swagger.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
     protected override bool IsFormPropertiesSchemaBroken => true;
-    protected override bool IsNonBodyAnnotationMergingBroken => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
@@ -15,4 +15,5 @@ public sealed class SwashbuckleOpenApiDocumentTests(SwashbuckleTestApiFactory fa
     protected override string DocumentUrl => "/swagger/v1/swagger.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
     protected override bool IsFormPropertiesSchemaBroken => true;
+    protected override bool IsNonBodyAnnotationMergingBroken => true;
 }

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -142,6 +142,16 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return true;
         }
 
+        if (unwrapped == typeof(Digit))
+        {
+            SchemaPaint.ClearWrapperShape(schema);
+            schema.Type = JsonSchemaType.Integer;
+            schema.Format = "int32";
+            SchemaPaint.TightenLowerBound(schema, 0, floorExclusive: false);
+            SchemaPaint.TightenUpperBound(schema, 9, floorExclusive: false);
+            return true;
+        }
+
         if (unwrapped.IsGenericType && NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out var bound))
         {
             NumericWrapperPainter.Paint(schema, unwrapped.GetGenericArguments()[0], bound);

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -117,9 +117,7 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
 
     private static bool TryPaintWireShape(OpenApiSchema schema, Type clrType)
     {
-        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-
-        if (unwrapped == typeof(NonEmptyString))
+        if (StrongTypeSchemaTypes.IsNonEmptyString(clrType))
         {
             SchemaPaint.ClearWrapperShape(schema);
             schema.Type = JsonSchemaType.String;
@@ -128,7 +126,7 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return true;
         }
 
-        if (unwrapped == typeof(Email))
+        if (StrongTypeSchemaTypes.IsEmail(clrType))
         {
             // Format is intentionally left to whatever the pipeline already
             // wrote (typically nothing — Microsoft.AspNetCore.OpenApi doesn't
@@ -142,7 +140,7 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return true;
         }
 
-        if (unwrapped == typeof(Digit))
+        if (StrongTypeSchemaTypes.IsDigit(clrType))
         {
             SchemaPaint.ClearWrapperShape(schema);
             schema.Type = JsonSchemaType.Integer;
@@ -152,9 +150,9 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return true;
         }
 
-        if (unwrapped.IsGenericType && NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out var bound))
+        if (StrongTypeSchemaTypes.TryGetNumeric(clrType, out var valueType, out var bound))
         {
-            NumericWrapperPainter.Paint(schema, unwrapped.GetGenericArguments()[0], bound);
+            NumericWrapperPainter.Paint(schema, valueType, bound);
             return true;
         }
 

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using StrongTypes.OpenApi.Core;
+
+namespace StrongTypes.OpenApi.Microsoft;
+
+/// <summary>
+/// Repaints schemas attached to non-body parameters (<c>[FromQuery]</c>,
+/// <c>[FromRoute]</c>, <c>[FromHeader]</c>) and to the per-field schemas
+/// of <c>[FromForm]</c> request bodies. Microsoft.AspNetCore.OpenApi only
+/// fires <see cref="IOpenApiSchemaTransformer"/> on JSON-body schemas; for
+/// every other slot the parameter's CLR type is inspected via the
+/// <see cref="ApiParameterDescription"/> exposed on the operation context
+/// and the wire schema is written directly.
+/// </summary>
+internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationTransformer
+{
+    private static readonly string[] s_formContentTypes =
+    [
+        "multipart/form-data",
+        "application/x-www-form-urlencoded",
+    ];
+
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    {
+        var descriptions = context.Description.ParameterDescriptions;
+        if (descriptions is null || descriptions.Count == 0) return Task.CompletedTask;
+
+        foreach (var pd in descriptions)
+        {
+            if (pd.Source is null) continue;
+
+            if (pd.Source == BindingSource.Query
+                || pd.Source == BindingSource.Path
+                || pd.Source == BindingSource.Header)
+            {
+                RewriteOperationParameter(operation, pd);
+            }
+            else if (pd.Source == BindingSource.Form)
+            {
+                RewriteFormProperty(operation, pd);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void RewriteOperationParameter(OpenApiOperation operation, ApiParameterDescription pd)
+    {
+        if (operation.Parameters is null) return;
+
+        var painted = TryBuildWireSchema(ResolveParameterClrType(pd));
+        if (painted is null) return;
+
+        foreach (var p in operation.Parameters)
+        {
+            if (p is not OpenApiParameter parameter) continue;
+            if (!string.Equals(parameter.Name, pd.Name, StringComparison.Ordinal)) continue;
+
+            parameter.Schema = painted;
+            return;
+        }
+    }
+
+    private static void RewriteFormProperty(OpenApiOperation operation, ApiParameterDescription pd)
+    {
+        if (operation.RequestBody?.Content is not { } content) return;
+
+        var painted = TryBuildWireSchema(ResolveParameterClrType(pd));
+        if (painted is null) return;
+
+        foreach (var contentType in s_formContentTypes)
+        {
+            if (!content.TryGetValue(contentType, out var media)) continue;
+            if (media.Schema is not OpenApiSchema formSchema) continue;
+            if (formSchema.Properties is not { Count: > 0 } properties) continue;
+
+            var key = ResolveFormPropertyKey(pd.Name, properties);
+            if (key is null) continue;
+
+            properties[key] = painted;
+        }
+    }
+
+    private static string? ResolveFormPropertyKey(string name, IDictionary<string, IOpenApiSchema> properties)
+    {
+        if (properties.ContainsKey(name)) return name;
+
+        var camel = JsonNamingPolicy.CamelCase.ConvertName(name);
+        if (properties.ContainsKey(camel)) return camel;
+
+        var lastDot = name.LastIndexOf('.');
+        if (lastDot >= 0)
+        {
+            var leaf = name[(lastDot + 1)..];
+            if (properties.ContainsKey(leaf)) return leaf;
+            var leafCamel = JsonNamingPolicy.CamelCase.ConvertName(leaf);
+            if (properties.ContainsKey(leafCamel)) return leafCamel;
+        }
+
+        foreach (var key in properties.Keys)
+        {
+            if (string.Equals(key, name, StringComparison.OrdinalIgnoreCase)) return key;
+        }
+
+        return null;
+    }
+
+    // ApiParameterDescription.Type is the type the model binder reports —
+    // for strong-types that implement IParsable<T>, ASP.NET reports the
+    // string overload's input, hiding the wrapper. ModelMetadata.ModelType
+    // exposes the actual CLR type for both parameter slots and for
+    // properties of a flattened [FromForm] model.
+    private static Type? ResolveParameterClrType(ApiParameterDescription pd)
+        => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
+
+    private static OpenApiSchema? TryBuildWireSchema(Type? clrType)
+    {
+        if (clrType is null) return null;
+
+        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
+
+        if (unwrapped == typeof(NonEmptyString))
+            return new OpenApiSchema { Type = JsonSchemaType.String, MinLength = 1 };
+
+        if (unwrapped == typeof(Email))
+            // Format is intentionally omitted to stay consistent with the
+            // JSON-body Email schema this pipeline emits — Microsoft.AspNetCore.OpenApi
+            // doesn't honor format:email there either (see EmailSchemaTransformer +
+            // the IsEmailStringFormatBroken flag in the integration tests).
+            return new OpenApiSchema
+            {
+                Type = JsonSchemaType.String,
+                MinLength = 1,
+                MaxLength = Email.MaxLength,
+            };
+
+        if (unwrapped.IsGenericType && NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out var bound))
+        {
+            var schema = new OpenApiSchema();
+            NumericWrapperPainter.Paint(schema, unwrapped.GetGenericArguments()[0], bound);
+            return schema;
+        }
+
+        return null;
+    }
+}

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
@@ -14,7 +16,18 @@ namespace StrongTypes.OpenApi.Microsoft;
 /// fires <see cref="IOpenApiSchemaTransformer"/> on JSON-body schemas; for
 /// every other slot the parameter's CLR type is inspected via the
 /// <see cref="ApiParameterDescription"/> exposed on the operation context
-/// and the wire schema is written directly.
+/// and the wire shape is written directly. Caller annotations attached at
+/// the slot (e.g. <c>[StringLength]</c> on a <c>[FromQuery]</c> parameter
+/// or <c>[Range]</c> on a <c>[FromForm]</c> property) are layered on top
+/// via <see cref="WrapperAnnotationApplier"/> so non-body slots merge
+/// annotations the same way JSON-body properties do.
+///
+/// Body schemas are out of scope by construction: this transformer only
+/// dispatches on <see cref="BindingSource.Query"/> / <see cref="BindingSource.Path"/> /
+/// <see cref="BindingSource.Header"/> / <see cref="BindingSource.Form"/>,
+/// and the form path is gated to <c>multipart/form-data</c> /
+/// <c>application/x-www-form-urlencoded</c>. JSON request/response bodies
+/// are reached neither by source nor by content type.
 /// </summary>
 internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationTransformer
 {
@@ -51,16 +64,15 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
     private static void RewriteOperationParameter(OpenApiOperation operation, ApiParameterDescription pd)
     {
         if (operation.Parameters is null) return;
-
-        var painted = TryBuildWireSchema(ResolveParameterClrType(pd));
-        if (painted is null) return;
+        var clrType = ResolveParameterClrType(pd);
+        if (clrType is null) return;
 
         foreach (var p in operation.Parameters)
         {
             if (p is not OpenApiParameter parameter) continue;
             if (!string.Equals(parameter.Name, pd.Name, StringComparison.Ordinal)) continue;
 
-            parameter.Schema = painted;
+            parameter.Schema = PaintSlot(parameter.Schema, clrType, pd);
             return;
         }
     }
@@ -68,9 +80,8 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
     private static void RewriteFormProperty(OpenApiOperation operation, ApiParameterDescription pd)
     {
         if (operation.RequestBody?.Content is not { } content) return;
-
-        var painted = TryBuildWireSchema(ResolveParameterClrType(pd));
-        if (painted is null) return;
+        var clrType = ResolveParameterClrType(pd);
+        if (clrType is null) return;
 
         foreach (var contentType in s_formContentTypes)
         {
@@ -81,8 +92,80 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             var key = ResolveFormPropertyKey(pd.Name, properties);
             if (key is null) continue;
 
-            properties[key] = painted;
+            properties[key] = PaintSlot(properties[key], clrType, pd);
         }
+    }
+
+    private static IOpenApiSchema PaintSlot(IOpenApiSchema? existing, Type clrType, ApiParameterDescription pd)
+    {
+        // Mutate the existing schema when possible so any keywords the
+        // pipeline already wrote (description, default, caller-applied
+        // [StringLength] on the IParsable string overload, …) survive the
+        // wrapper paint. Falls back to a fresh schema only when the slot
+        // currently holds an OpenApiSchemaReference or is null.
+        var schema = existing as OpenApiSchema ?? new OpenApiSchema();
+        if (!TryPaintWireShape(schema, clrType)) return existing ?? schema;
+
+        var attributes = GetSlotAttributes(pd);
+        if (attributes.Count > 0)
+            WrapperAnnotationApplier.TryApply(schema, clrType, attributes);
+
+        return schema;
+    }
+
+    private static bool TryPaintWireShape(OpenApiSchema schema, Type clrType)
+    {
+        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
+
+        if (unwrapped == typeof(NonEmptyString))
+        {
+            SchemaPaint.ClearWrapperShape(schema);
+            schema.Type = JsonSchemaType.String;
+            schema.Format = null;
+            SchemaPaint.TightenMinLength(schema, 1);
+            return true;
+        }
+
+        if (unwrapped == typeof(Email))
+        {
+            // Format is intentionally left to whatever the pipeline already
+            // wrote (typically nothing — Microsoft.AspNetCore.OpenApi doesn't
+            // honor format:email even on plain string properties). The
+            // matching JSON-body Email schema and the IsEmailStringFormatBroken
+            // flag in the integration tests pin this same behavior.
+            SchemaPaint.ClearWrapperShape(schema);
+            schema.Type = JsonSchemaType.String;
+            SchemaPaint.TightenMinLength(schema, 1);
+            SchemaPaint.TightenMaxLength(schema, Email.MaxLength);
+            return true;
+        }
+
+        if (unwrapped.IsGenericType && NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out var bound))
+        {
+            NumericWrapperPainter.Paint(schema, unwrapped.GetGenericArguments()[0], bound);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)
+    {
+        // For a flattened [FromForm] complex model, ModelMetadata pinpoints
+        // the property; reflect on it to read the property's own attributes.
+        if (pd.ModelMetadata is { ContainerType: { } containerType, PropertyName: { } propertyName })
+        {
+            var prop = containerType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (prop is not null)
+                return prop.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
+        }
+
+        // For a method parameter (query/path/header), the attributes live on
+        // the ParameterInfo.
+        if (pd.ParameterDescriptor is ControllerParameterDescriptor cpd)
+            return cpd.ParameterInfo.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
+
+        return [];
     }
 
     private static string? ResolveFormPropertyKey(string name, IDictionary<string, IOpenApiSchema> properties)
@@ -116,35 +199,4 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
     // properties of a flattened [FromForm] model.
     private static Type? ResolveParameterClrType(ApiParameterDescription pd)
         => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
-
-    private static OpenApiSchema? TryBuildWireSchema(Type? clrType)
-    {
-        if (clrType is null) return null;
-
-        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-
-        if (unwrapped == typeof(NonEmptyString))
-            return new OpenApiSchema { Type = JsonSchemaType.String, MinLength = 1 };
-
-        if (unwrapped == typeof(Email))
-            // Format is intentionally omitted to stay consistent with the
-            // JSON-body Email schema this pipeline emits — Microsoft.AspNetCore.OpenApi
-            // doesn't honor format:email there either (see EmailSchemaTransformer +
-            // the IsEmailStringFormatBroken flag in the integration tests).
-            return new OpenApiSchema
-            {
-                Type = JsonSchemaType.String,
-                MinLength = 1,
-                MaxLength = Email.MaxLength,
-            };
-
-        if (unwrapped.IsGenericType && NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out var bound))
-        {
-            var schema = new OpenApiSchema();
-            NumericWrapperPainter.Paint(schema, unwrapped.GetGenericArguments()[0], bound);
-            return schema;
-        }
-
-        return null;
-    }
 }

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -89,10 +88,13 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             if (media.Schema is not OpenApiSchema formSchema) continue;
             if (formSchema.Properties is not { Count: > 0 } properties) continue;
 
-            var key = ResolveFormPropertyKey(pd.Name, properties);
-            if (key is null) continue;
-
-            properties[key] = PaintSlot(properties[key], clrType, pd);
+            // Microsoft.AspNetCore.OpenApi keys form-body properties by the
+            // C# property name (PascalCase), matching ApiParameterDescription.Name.
+            // No camelCase / case-insensitive fallback because this pipeline
+            // doesn't produce those — and a fallback would risk binding to
+            // the wrong slot if a user DTO ever has near-collisions.
+            if (!properties.ContainsKey(pd.Name)) continue;
+            properties[pd.Name] = PaintSlot(properties[pd.Name], clrType, pd);
         }
     }
 
@@ -166,30 +168,6 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return cpd.ParameterInfo.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
 
         return [];
-    }
-
-    private static string? ResolveFormPropertyKey(string name, IDictionary<string, IOpenApiSchema> properties)
-    {
-        if (properties.ContainsKey(name)) return name;
-
-        var camel = JsonNamingPolicy.CamelCase.ConvertName(name);
-        if (properties.ContainsKey(camel)) return camel;
-
-        var lastDot = name.LastIndexOf('.');
-        if (lastDot >= 0)
-        {
-            var leaf = name[(lastDot + 1)..];
-            if (properties.ContainsKey(leaf)) return leaf;
-            var leafCamel = JsonNamingPolicy.CamelCase.ConvertName(leaf);
-            if (properties.ContainsKey(leafCamel)) return leafCamel;
-        }
-
-        foreach (var key in properties.Keys)
-        {
-            if (string.Equals(key, name, StringComparison.OrdinalIgnoreCase)) return key;
-        }
-
-        return null;
     }
 
     // ApiParameterDescription.Type is the type the model binder reports —

--- a/src/StrongTypes.OpenApi.Microsoft/Collections/NonEmptyEnumerableSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Collections/NonEmptyEnumerableSchemaTransformer.cs
@@ -16,14 +16,9 @@ public sealed class NonEmptyEnumerableSchemaTransformer : IOpenApiSchemaTransfor
 {
     public async Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        var type = context.JsonTypeInfo.Type;
-        if (!type.IsGenericType) return;
-
-        var definition = type.GetGenericTypeDefinition();
-        if (definition != typeof(NonEmptyEnumerable<>) && definition != typeof(INonEmptyEnumerable<>))
+        if (!StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(context.JsonTypeInfo.Type, out var elementType))
             return;
 
-        var elementType = type.GetGenericArguments()[0];
         var itemsSchema = await context.GetOrCreateSchemaAsync(elementType, parameterDescription: null, cancellationToken);
 
         SchemaPaint.ClearWrapperShape(schema);

--- a/src/StrongTypes.OpenApi.Microsoft/Digits/DigitSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Digits/DigitSchemaTransformer.cs
@@ -8,7 +8,7 @@ public sealed class DigitSchemaTransformer : IOpenApiSchemaTransformer
 {
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        if (context.JsonTypeInfo.Type != typeof(Digit))
+        if (!StrongTypeSchemaTypes.IsDigit(context.JsonTypeInfo.Type))
             return Task.CompletedTask;
 
         SchemaPaint.ClearWrapperShape(schema);

--- a/src/StrongTypes.OpenApi.Microsoft/Digits/DigitSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Digits/DigitSchemaTransformer.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using StrongTypes.OpenApi.Core;
+
+namespace StrongTypes.OpenApi.Microsoft;
+
+public sealed class DigitSchemaTransformer : IOpenApiSchemaTransformer
+{
+    public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+    {
+        if (context.JsonTypeInfo.Type != typeof(Digit))
+            return Task.CompletedTask;
+
+        SchemaPaint.ClearWrapperShape(schema);
+        schema.Type = JsonSchemaType.Integer;
+        schema.Format = "int32";
+        SchemaPaint.TightenLowerBound(schema, 0, floorExclusive: false);
+        SchemaPaint.TightenUpperBound(schema, 9, floorExclusive: false);
+        StrongTypeInlineMarker.Set(schema);
+        return Task.CompletedTask;
+    }
+}

--- a/src/StrongTypes.OpenApi.Microsoft/Emails/EmailSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Emails/EmailSchemaTransformer.cs
@@ -18,7 +18,7 @@ public sealed class EmailSchemaTransformer : IOpenApiSchemaTransformer
 {
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        if (context.JsonTypeInfo.Type != typeof(Email))
+        if (!StrongTypeSchemaTypes.IsEmail(context.JsonTypeInfo.Type))
             return Task.CompletedTask;
 
         SchemaPaint.ClearWrapperShape(schema);

--- a/src/StrongTypes.OpenApi.Microsoft/Maybe/MaybeSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Maybe/MaybeSchemaTransformer.cs
@@ -17,11 +17,9 @@ public sealed class MaybeSchemaTransformer : IOpenApiSchemaTransformer
 {
     public async Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        var type = context.JsonTypeInfo.Type;
-        if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(Maybe<>))
+        if (!StrongTypeSchemaTypes.TryGetMaybeValue(context.JsonTypeInfo.Type, out var innerType))
             return;
 
-        var innerType = type.GetGenericArguments()[0];
         var innerSchema = await context.GetOrCreateSchemaAsync(innerType, parameterDescription: null, cancellationToken);
 
         SchemaPaint.ClearWrapperShape(schema);

--- a/src/StrongTypes.OpenApi.Microsoft/Numbers/NumericStrongTypeSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Numbers/NumericStrongTypeSchemaTransformer.cs
@@ -20,12 +20,9 @@ public sealed class NumericStrongTypeSchemaTransformer : IOpenApiSchemaTransform
 {
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        var type = context.JsonTypeInfo.Type;
-        if (!type.IsGenericType) return Task.CompletedTask;
-
-        if (NumericWrapperKinds.TryGetBound(type.GetGenericTypeDefinition(), out var bound))
+        if (StrongTypeSchemaTypes.TryGetNumeric(context.JsonTypeInfo.Type, out var valueType, out var bound))
         {
-            NumericWrapperPainter.Paint(schema, type.GetGenericArguments()[0], bound);
+            NumericWrapperPainter.Paint(schema, valueType, bound);
             StrongTypeInlineMarker.Set(schema);
         }
 

--- a/src/StrongTypes.OpenApi.Microsoft/Startup.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Startup.cs
@@ -24,6 +24,7 @@ public static class StrongTypesOpenApiExtensions
         options.AddSchemaTransformer<NonEmptyEnumerableSchemaTransformer>();
         options.AddSchemaTransformer<MaybeSchemaTransformer>();
         options.AddSchemaTransformer<StrongTypeCollectionShapeTransformer>();
+        options.AddOperationTransformer<NonBodyStrongTypeOperationTransformer>();
         options.AddDocumentTransformer<StrongTypesComponentSchemaFiller>();
         options.AddDocumentTransformer<PropertyAnnotationSchemaTransformer>();
         options.AddDocumentTransformer<StrongTypeInliningDocumentTransformer>();

--- a/src/StrongTypes.OpenApi.Microsoft/Startup.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Startup.cs
@@ -20,6 +20,7 @@ public static class StrongTypesOpenApiExtensions
     {
         options.AddSchemaTransformer<NonEmptyStringSchemaTransformer>();
         options.AddSchemaTransformer<EmailSchemaTransformer>();
+        options.AddSchemaTransformer<DigitSchemaTransformer>();
         options.AddSchemaTransformer<NumericStrongTypeSchemaTransformer>();
         options.AddSchemaTransformer<NonEmptyEnumerableSchemaTransformer>();
         options.AddSchemaTransformer<MaybeSchemaTransformer>();

--- a/src/StrongTypes.OpenApi.Microsoft/Strings/NonEmptyStringSchemaTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Strings/NonEmptyStringSchemaTransformer.cs
@@ -18,7 +18,7 @@ public sealed class NonEmptyStringSchemaTransformer : IOpenApiSchemaTransformer
 {
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        if (context.JsonTypeInfo.Type != typeof(NonEmptyString))
+        if (!StrongTypeSchemaTypes.IsNonEmptyString(context.JsonTypeInfo.Type))
             return Task.CompletedTask;
 
         SchemaPaint.ClearWrapperShape(schema);

--- a/src/StrongTypes.OpenApi.Microsoft/StrongTypesComponentSchemaFiller.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/StrongTypesComponentSchemaFiller.cs
@@ -64,6 +64,15 @@ internal sealed class StrongTypesComponentSchemaFiller : IOpenApiDocumentTransfo
                 MaxLength = Email.MaxLength,
             };
 
+        if (name == "Digit")
+            return new OpenApiSchema
+            {
+                Type = JsonSchemaType.Integer,
+                Format = "int32",
+                Minimum = "0",
+                Maximum = "9",
+            };
+
         if (MicrosoftSchemaNaming.TryMatchNumericComponent(name, out var numericInner, out var numericBound))
             return BuildNumeric(numericInner, numericBound);
 
@@ -96,7 +105,7 @@ internal sealed class StrongTypesComponentSchemaFiller : IOpenApiDocumentTransfo
     {
         if (schema.Type != JsonSchemaType.Object) return false;
         if (schema.Properties is not { Count: > 0 } props) return false;
-        if (props.Count == 1 && props.ContainsKey("Value")) return false;
+        if (props.Count == 1 && (props.ContainsKey("Value") || props.ContainsKey("value"))) return false;
         return true;
     }
 

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -92,13 +92,12 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
             if (media.Schema is not OpenApiSchema formSchema) continue;
 
             // Modern Swashbuckle path: a proper `properties` map keyed by
-            // camelCase property name.
+            // the form model property name.
             if (formSchema.Properties is { Count: > 0 } properties)
             {
-                var camelKey = ToCamelCase(pd.Name);
-                if (properties.TryGetValue(camelKey, out var propSchema))
+                if (properties.TryGetValue(pd.Name, out var propSchema))
                 {
-                    properties[camelKey] = ApplyAnnotations(propSchema, clrType, pd);
+                    properties[pd.Name] = ApplyAnnotations(propSchema, clrType, pd);
                     return;
                 }
             }
@@ -187,9 +186,4 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
 
     private static Type? ResolveParameterClrType(ApiParameterDescription pd)
         => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
-
-    private static string ToCamelCase(string name)
-        => string.IsNullOrEmpty(name) || char.IsLower(name[0])
-            ? name
-            : char.ToLowerInvariant(name[0]) + name[1..];
 }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -1,0 +1,195 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.OpenApi;
+using StrongTypes.OpenApi.Core;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace StrongTypes.OpenApi.Swashbuckle;
+
+/// <summary>
+/// Layers caller-supplied data-annotations
+/// (<c>[StringLength]</c>, <c>[Range]</c>, <c>[RegularExpression]</c>, …)
+/// onto strong-type wrappers that arrive at non-body slots —
+/// <c>[FromQuery]</c> / <c>[FromRoute]</c> / <c>[FromHeader]</c>
+/// parameters and the per-field schemas of <c>[FromForm]</c> request
+/// bodies. The wrapper's wire shape itself is painted by the per-type
+/// schema filters (<see cref="NonEmptyStringSchemaFilter"/> et al);
+/// without this pass, caller bounds attached at the slot would be
+/// dropped — Swashbuckle's <see cref="PropertyAnnotationSchemaFilter"/>
+/// only sees the parent type's <c>properties</c> map and never reaches
+/// the parameter slots or the form-body's <c>allOf</c> entries.
+///
+/// Body schemas are out of scope by construction: this filter only
+/// dispatches on <see cref="BindingSource.Query"/> /
+/// <see cref="BindingSource.Path"/> / <see cref="BindingSource.Header"/> /
+/// <see cref="BindingSource.Form"/>, and the form path is gated to
+/// <c>multipart/form-data</c> / <c>application/x-www-form-urlencoded</c>.
+/// </summary>
+public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
+{
+    private static readonly string[] s_formContentTypes =
+    [
+        "multipart/form-data",
+        "application/x-www-form-urlencoded",
+    ];
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var descriptions = context.ApiDescription.ParameterDescriptions;
+        if (descriptions is null || descriptions.Count == 0) return;
+
+        // For form bodies that emit the broken `{allOf:[<each-component-field>]}`
+        // shape (every form field is component-typed — see
+        // IsFormPropertiesSchemaBroken in the integration tests), we need to
+        // map allOf entries back to their CLR property by declaration order.
+        // Compute that map once per operation.
+        var formAllOfIndexByProperty = BuildFormAllOfIndexMap(descriptions);
+
+        foreach (var pd in descriptions)
+        {
+            if (pd.Source is null) continue;
+
+            if (pd.Source == BindingSource.Query
+                || pd.Source == BindingSource.Path
+                || pd.Source == BindingSource.Header)
+            {
+                MergeOperationParameterAnnotations(operation, pd);
+            }
+            else if (pd.Source == BindingSource.Form)
+            {
+                MergeFormPropertyAnnotations(operation, pd, formAllOfIndexByProperty);
+            }
+        }
+    }
+
+    private static void MergeOperationParameterAnnotations(OpenApiOperation operation, ApiParameterDescription pd)
+    {
+        if (operation.Parameters is null) return;
+        var clrType = ResolveParameterClrType(pd);
+        if (clrType is null) return;
+
+        foreach (var p in operation.Parameters)
+        {
+            if (p is not OpenApiParameter parameter) continue;
+            if (!string.Equals(parameter.Name, pd.Name, StringComparison.Ordinal)) continue;
+
+            parameter.Schema = ApplyAnnotations(parameter.Schema, clrType, pd);
+            return;
+        }
+    }
+
+    private static void MergeFormPropertyAnnotations(OpenApiOperation operation, ApiParameterDescription pd, IReadOnlyDictionary<string, int>? allOfIndexByProperty)
+    {
+        if (operation.RequestBody?.Content is not { } content) return;
+        var clrType = ResolveParameterClrType(pd);
+        if (clrType is null) return;
+
+        foreach (var contentType in s_formContentTypes)
+        {
+            if (!content.TryGetValue(contentType, out var media)) continue;
+            if (media.Schema is not OpenApiSchema formSchema) continue;
+
+            // Modern Swashbuckle path: a proper `properties` map keyed by
+            // camelCase property name.
+            if (formSchema.Properties is { Count: > 0 } properties)
+            {
+                var camelKey = ToCamelCase(pd.Name);
+                if (properties.TryGetValue(camelKey, out var propSchema))
+                {
+                    properties[camelKey] = ApplyAnnotations(propSchema, clrType, pd);
+                    return;
+                }
+            }
+
+            // Broken path: form body emits `{allOf:[<each-component-field>]}`
+            // when every field is component-typed. Look the field up by the
+            // index we built from the API description's declaration order.
+            if (formSchema.AllOf is { Count: > 0 } allOf
+                && allOfIndexByProperty is not null
+                && allOfIndexByProperty.TryGetValue(pd.Name, out var index)
+                && index >= 0 && index < allOf.Count)
+            {
+                allOf[index] = ApplyAnnotations(allOf[index], clrType, pd);
+            }
+        }
+    }
+
+    private static IOpenApiSchema ApplyAnnotations(IOpenApiSchema? slot, Type clrType, ApiParameterDescription pd)
+    {
+        var attributes = GetSlotAttributes(pd);
+        if (attributes.Count == 0) return slot ?? new OpenApiSchema();
+
+        // Wrapper-typed slots arrive at this filter as `OpenApiSchemaReference`
+        // ($ref to the wrapper component painted by the per-type schema
+        // filter). Mirror PropertyAnnotationSchemaFilter's body-side trick:
+        // wrap the ref in `allOf:[<ref>]+annotations` and mark with the
+        // inline marker so StrongTypeInliner collapses it back to a flat
+        // shape later. Inline OpenApiSchema slots can be mutated directly.
+        if (slot is OpenApiSchema concrete)
+        {
+            WrapperAnnotationApplier.TryApply(concrete, clrType, attributes);
+            return concrete;
+        }
+
+        if (slot is OpenApiSchemaReference)
+        {
+            var wrapper = new OpenApiSchema { AllOf = [slot] };
+            if (WrapperAnnotationApplier.TryApply(wrapper, clrType, attributes))
+            {
+                StrongTypeInlineMarker.Set(wrapper);
+                return wrapper;
+            }
+            return slot;
+        }
+
+        return slot ?? new OpenApiSchema();
+    }
+
+    private static IReadOnlyDictionary<string, int>? BuildFormAllOfIndexMap(IList<ApiParameterDescription> descriptions)
+    {
+        Dictionary<string, int>? map = null;
+        var index = 0;
+        foreach (var pd in descriptions)
+        {
+            if (pd.Source != BindingSource.Form) continue;
+            if (!IsWrapperType(ResolveParameterClrType(pd))) continue;
+            map ??= new Dictionary<string, int>(StringComparer.Ordinal);
+            map[pd.Name] = index++;
+        }
+        return map;
+    }
+
+    private static bool IsWrapperType(Type? clrType)
+    {
+        if (clrType is null) return false;
+        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email)) return true;
+        if (!unwrapped.IsGenericType) return false;
+        return NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out _);
+    }
+
+    private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)
+    {
+        if (pd.ModelMetadata is { ContainerType: { } containerType, PropertyName: { } propertyName })
+        {
+            var prop = containerType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+            if (prop is not null)
+                return prop.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
+        }
+
+        if (pd.ParameterDescriptor is ControllerParameterDescriptor cpd)
+            return cpd.ParameterInfo.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
+
+        return [];
+    }
+
+    private static Type? ResolveParameterClrType(ApiParameterDescription pd)
+        => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
+
+    private static string ToCamelCase(string name)
+        => string.IsNullOrEmpty(name) || char.IsLower(name[0])
+            ? name
+            : char.ToLowerInvariant(name[0]) + name[1..];
+}

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -184,24 +184,11 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         foreach (var pd in descriptions)
         {
             if (pd.Source != BindingSource.Form) continue;
-            if (!IsStrongTypeFormField(ResolveParameterClrType(pd))) continue;
+            if (!StrongTypeSchemaTypes.IsInlineable(ResolveParameterClrType(pd))) continue;
             map ??= new Dictionary<string, int>(StringComparer.Ordinal);
             map[pd.Name] = index++;
         }
         return map;
-    }
-
-    private static bool IsStrongTypeFormField(Type? clrType)
-    {
-        if (clrType is null) return false;
-        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(Digit)) return true;
-        if (!unwrapped.IsGenericType) return false;
-        var definition = unwrapped.GetGenericTypeDefinition();
-        return NumericWrapperKinds.TryGetBound(definition, out _)
-            || definition == typeof(NonEmptyEnumerable<>)
-            || definition == typeof(INonEmptyEnumerable<>)
-            || definition == typeof(Maybe<>);
     }
 
     private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -200,7 +200,8 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         var definition = unwrapped.GetGenericTypeDefinition();
         return NumericWrapperKinds.TryGetBound(definition, out _)
             || definition == typeof(NonEmptyEnumerable<>)
-            || definition == typeof(INonEmptyEnumerable<>);
+            || definition == typeof(INonEmptyEnumerable<>)
+            || definition == typeof(Maybe<>);
     }
 
     private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi;
 using StrongTypes.OpenApi.Core;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -27,7 +28,7 @@ namespace StrongTypes.OpenApi.Swashbuckle;
 /// <see cref="BindingSource.Form"/>, and the form path is gated to
 /// <c>multipart/form-data</c> / <c>application/x-www-form-urlencoded</c>.
 /// </summary>
-public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
+public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOperationFilter>? logger = null) : IOperationFilter
 {
     private static readonly string[] s_formContentTypes =
     [
@@ -80,7 +81,7 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
         }
     }
 
-    private static void MergeFormPropertyAnnotations(OpenApiOperation operation, ApiParameterDescription pd, IReadOnlyDictionary<string, int>? allOfIndexByProperty)
+    private void MergeFormPropertyAnnotations(OpenApiOperation operation, ApiParameterDescription pd, IReadOnlyDictionary<string, int>? allOfIndexByProperty)
     {
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
@@ -107,12 +108,40 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
             // index we built from the API description's declaration order.
             if (formSchema.AllOf is { Count: > 0 } allOf
                 && allOfIndexByProperty is not null
-                && allOfIndexByProperty.TryGetValue(pd.Name, out var index)
-                && index >= 0 && index < allOf.Count)
+                && allOfIndexByProperty.TryGetValue(pd.Name, out var index))
             {
+                if (!IsExpectedBrokenFormAllOfTarget(allOf, allOfIndexByProperty.Count, pd.Name, index))
+                    return;
+
                 allOf[index] = ApplyAnnotations(allOf[index], clrType, pd);
             }
         }
+    }
+
+    private bool IsExpectedBrokenFormAllOfTarget(IList<IOpenApiSchema> allOf, int expectedCount, string propertyName, int index)
+    {
+        if (allOf.Count != expectedCount)
+        {
+            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the form allOf count ({ActualCount}) did not match the strong-type form field count ({ExpectedCount}).",
+                propertyName, allOf.Count, expectedCount);
+            return false;
+        }
+
+        if (index < 0 || index >= allOf.Count)
+        {
+            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the computed allOf index ({Index}) was outside the form allOf count ({ActualCount}).",
+                propertyName, index, allOf.Count);
+            return false;
+        }
+
+        if (allOf[index] is not OpenApiSchemaReference)
+        {
+            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the target form allOf entry at index {Index} was not a reference schema.",
+                propertyName, index);
+            return false;
+        }
+
+        return true;
     }
 
     private static IOpenApiSchema ApplyAnnotations(IOpenApiSchema? slot, Type clrType, ApiParameterDescription pd)

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -184,20 +184,23 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         foreach (var pd in descriptions)
         {
             if (pd.Source != BindingSource.Form) continue;
-            if (!IsWrapperType(ResolveParameterClrType(pd))) continue;
+            if (!IsStrongTypeFormField(ResolveParameterClrType(pd))) continue;
             map ??= new Dictionary<string, int>(StringComparer.Ordinal);
             map[pd.Name] = index++;
         }
         return map;
     }
 
-    private static bool IsWrapperType(Type? clrType)
+    private static bool IsStrongTypeFormField(Type? clrType)
     {
         if (clrType is null) return false;
         var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
         if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(Digit)) return true;
         if (!unwrapped.IsGenericType) return false;
-        return NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out _);
+        var definition = unwrapped.GetGenericTypeDefinition();
+        return NumericWrapperKinds.TryGetBound(definition, out _)
+            || definition == typeof(NonEmptyEnumerable<>)
+            || definition == typeof(INonEmptyEnumerable<>);
     }
 
     private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -70,6 +70,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         if (operation.Parameters is null) return;
         var clrType = ResolveParameterClrType(pd);
         if (clrType is null) return;
+        if (GetSlotAttributes(pd).Count == 0) return;
 
         foreach (var p in operation.Parameters)
         {
@@ -86,6 +87,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
         if (clrType is null) return;
+        if (GetSlotAttributes(pd).Count == 0) return;
 
         foreach (var contentType in s_formContentTypes)
         {
@@ -193,7 +195,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
     {
         if (clrType is null) return false;
         var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email)) return true;
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(Digit)) return true;
         if (!unwrapped.IsGenericType) return false;
         return NumericWrapperKinds.TryGetBound(unwrapped.GetGenericTypeDefinition(), out _);
     }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Collections/NonEmptyEnumerableSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Collections/NonEmptyEnumerableSchemaFilter.cs
@@ -14,13 +14,8 @@ public sealed class NonEmptyEnumerableSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        var type = context.Type;
-        if (!type.IsGenericType) return;
         if (schema is not OpenApiSchema concrete) return;
-
-        var definition = type.GetGenericTypeDefinition();
-        if (definition != typeof(NonEmptyEnumerable<>) && definition != typeof(INonEmptyEnumerable<>))
-            return;
+        if (!StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(context.Type, out _)) return;
 
         SchemaPaint.TightenMinItems(concrete, 1);
         StrongTypeInlineMarker.Set(concrete);

--- a/src/StrongTypes.OpenApi.Swashbuckle/Digits/DigitSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Digits/DigitSchemaFilter.cs
@@ -1,0 +1,21 @@
+using Microsoft.OpenApi;
+using StrongTypes.OpenApi.Core;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace StrongTypes.OpenApi.Swashbuckle;
+
+public sealed class DigitSchemaFilter : ISchemaFilter
+{
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type != typeof(Digit)) return;
+        if (schema is not OpenApiSchema concrete) return;
+
+        SchemaPaint.ClearWrapperShape(concrete);
+        concrete.Type = JsonSchemaType.Integer;
+        concrete.Format = "int32";
+        SchemaPaint.TightenLowerBound(concrete, 0, floorExclusive: false);
+        SchemaPaint.TightenUpperBound(concrete, 9, floorExclusive: false);
+        StrongTypeInlineMarker.Set(concrete);
+    }
+}

--- a/src/StrongTypes.OpenApi.Swashbuckle/Digits/DigitSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Digits/DigitSchemaFilter.cs
@@ -8,7 +8,7 @@ public sealed class DigitSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.Type != typeof(Digit)) return;
+        if (!StrongTypeSchemaTypes.IsDigit(context.Type)) return;
         if (schema is not OpenApiSchema concrete) return;
 
         SchemaPaint.ClearWrapperShape(concrete);

--- a/src/StrongTypes.OpenApi.Swashbuckle/Emails/EmailSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Emails/EmailSchemaFilter.cs
@@ -18,7 +18,7 @@ public sealed class EmailSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.Type != typeof(Email)) return;
+        if (!StrongTypeSchemaTypes.IsEmail(context.Type)) return;
         if (schema is not OpenApiSchema concrete) return;
 
         SchemaPaint.ClearWrapperShape(concrete);

--- a/src/StrongTypes.OpenApi.Swashbuckle/Maybe/MaybeSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Maybe/MaybeSchemaFilter.cs
@@ -17,18 +17,9 @@ public sealed class MaybeSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        // Maybe<T> is a struct that also implements IEnumerable<T>, so a
-        // Maybe<T>? property arrives here as Nullable<Maybe<T>> with the
-        // schema already coerced into the array shape Swashbuckle gives any
-        // IEnumerable. Unwrap Nullable<> first so the filter still recognises
-        // the underlying Maybe<T> and rewrites the schema to its real wire form.
-        var type = Nullable.GetUnderlyingType(context.Type) ?? context.Type;
-
-        if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(Maybe<>))
-            return;
+        if (!StrongTypeSchemaTypes.TryGetMaybeValue(context.Type, out var innerType)) return;
         if (schema is not OpenApiSchema concrete) return;
 
-        var innerType = type.GetGenericArguments()[0];
         var innerSchema = context.SchemaGenerator.GenerateSchema(
             innerType, context.SchemaRepository, memberInfo: null, parameterInfo: null, routeInfo: null);
 

--- a/src/StrongTypes.OpenApi.Swashbuckle/Numbers/NumericStrongTypeSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Numbers/NumericStrongTypeSchemaFilter.cs
@@ -20,13 +20,11 @@ public sealed class NumericStrongTypeSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        var type = context.Type;
-        if (!type.IsGenericType) return;
         if (schema is not OpenApiSchema concrete) return;
 
-        if (NumericWrapperKinds.TryGetBound(type.GetGenericTypeDefinition(), out var bound))
+        if (StrongTypeSchemaTypes.TryGetNumeric(context.Type, out var valueType, out var bound))
         {
-            NumericWrapperPainter.Paint(concrete, type.GetGenericArguments()[0], bound);
+            NumericWrapperPainter.Paint(concrete, valueType, bound);
             StrongTypeInlineMarker.Set(concrete);
         }
     }

--- a/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
@@ -46,7 +46,7 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
             var attrs = clrProperty.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
             if (attrs.Length == 0) continue;
 
-            var surrogate = ResolveSurrogateType(clrProperty.PropertyType);
+            var surrogate = StrongTypeSchemaTypes.ResolveAnnotationSurrogate(clrProperty.PropertyType);
             if (surrogate is null) continue;
 
             var generated = context.SchemaGenerator.GenerateSchema(surrogate, context.SchemaRepository, memberInfo: clrProperty);
@@ -63,20 +63,6 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
             StrongTypeInlineMarker.Set(wrapper);
             concrete.Properties[jsonName] = wrapper;
         }
-    }
-
-    private static Type? ResolveSurrogateType(Type propertyClrType)
-    {
-        if (StrongTypeSchemaTypes.IsNonEmptyString(propertyClrType) || StrongTypeSchemaTypes.IsEmail(propertyClrType)) return typeof(string);
-        if (StrongTypeSchemaTypes.IsDigit(propertyClrType)) return typeof(int);
-
-        if (StrongTypeSchemaTypes.TryGetNumeric(propertyClrType, out var valueType, out _))
-            return valueType;
-
-        if (StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(propertyClrType, out var elementType))
-            return typeof(IEnumerable<>).MakeGenericType(elementType);
-
-        return null;
     }
 
     private static void CopyAnnotationKeywords(OpenApiSchema source, OpenApiSchema target)

--- a/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
@@ -46,7 +46,7 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
             var attrs = clrProperty.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
             if (attrs.Length == 0) continue;
 
-            var surrogate = StrongTypeSchemaTypes.ResolveAnnotationSurrogate(clrProperty.PropertyType);
+            var surrogate = StrongTypeSchemaTypes.ResolveWireType(clrProperty.PropertyType);
             if (surrogate is null) continue;
 
             var generated = context.SchemaGenerator.GenerateSchema(surrogate, context.SchemaRepository, memberInfo: clrProperty);

--- a/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
@@ -67,19 +67,14 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
 
     private static Type? ResolveSurrogateType(Type propertyClrType)
     {
-        var unwrapped = Nullable.GetUnderlyingType(propertyClrType) ?? propertyClrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email)) return typeof(string);
-        if (!unwrapped.IsGenericType) return null;
+        if (StrongTypeSchemaTypes.IsNonEmptyString(propertyClrType) || StrongTypeSchemaTypes.IsEmail(propertyClrType)) return typeof(string);
+        if (StrongTypeSchemaTypes.IsDigit(propertyClrType)) return typeof(int);
 
-        var def = unwrapped.GetGenericTypeDefinition();
-        var arg = unwrapped.GetGenericArguments()[0];
+        if (StrongTypeSchemaTypes.TryGetNumeric(propertyClrType, out var valueType, out _))
+            return valueType;
 
-        if (def == typeof(Positive<>) || def == typeof(NonNegative<>) ||
-            def == typeof(Negative<>) || def == typeof(NonPositive<>))
-            return arg;
-
-        if (def == typeof(NonEmptyEnumerable<>) || def == typeof(INonEmptyEnumerable<>))
-            return typeof(IEnumerable<>).MakeGenericType(arg);
+        if (StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(propertyClrType, out var elementType))
+            return typeof(IEnumerable<>).MakeGenericType(elementType);
 
         return null;
     }

--- a/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
@@ -68,7 +68,7 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
     private static Type? ResolveSurrogateType(Type propertyClrType)
     {
         var unwrapped = Nullable.GetUnderlyingType(propertyClrType) ?? propertyClrType;
-        if (unwrapped == typeof(NonEmptyString)) return typeof(string);
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email)) return typeof(string);
         if (!unwrapped.IsGenericType) return null;
 
         var def = unwrapped.GetGenericTypeDefinition();

--- a/src/StrongTypes.OpenApi.Swashbuckle/Startup.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Startup.cs
@@ -21,6 +21,7 @@ public static class StrongTypesSwashbuckleExtensions
     {
         options.SchemaFilter<NonEmptyStringSchemaFilter>();
         options.SchemaFilter<EmailSchemaFilter>();
+        options.SchemaFilter<DigitSchemaFilter>();
         options.SchemaFilter<NumericStrongTypeSchemaFilter>();
         options.SchemaFilter<NonEmptyEnumerableSchemaFilter>();
         options.SchemaFilter<MaybeSchemaFilter>();

--- a/src/StrongTypes.OpenApi.Swashbuckle/Startup.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Startup.cs
@@ -25,6 +25,7 @@ public static class StrongTypesSwashbuckleExtensions
         options.SchemaFilter<NonEmptyEnumerableSchemaFilter>();
         options.SchemaFilter<MaybeSchemaFilter>();
         options.SchemaFilter<PropertyAnnotationSchemaFilter>();
+        options.OperationFilter<NonBodyStrongTypeOperationFilter>();
         options.DocumentFilter<StrongTypeInliningDocumentFilter>();
         return options;
     }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Strings/NonEmptyStringSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Strings/NonEmptyStringSchemaFilter.cs
@@ -18,7 +18,7 @@ public sealed class NonEmptyStringSchemaFilter : ISchemaFilter
 {
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        if (context.Type != typeof(NonEmptyString)) return;
+        if (!StrongTypeSchemaTypes.IsNonEmptyString(context.Type)) return;
         if (schema is not OpenApiSchema concrete) return;
 
         SchemaPaint.ClearWrapperShape(concrete);

--- a/src/StrongTypes.OpenApi.TestApi.Shared/AnnotatedRequests.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/AnnotatedRequests.cs
@@ -71,6 +71,8 @@ public sealed record AnnotatedTextsRequest(
 public sealed record AnnotatedNumbersRequest(
     [property: Range(18, 120)] Positive<int> Age,
     [property: Range(18, 120)] int AgeRaw,
+    [property: Range(2, 8)] Digit Digit,
+    [property: Range(2, 8)] int DigitRaw,
     [property: Range(-5, 5)] Positive<int> RangeAcrossFloor,
     [property: Range(2, 10, MinimumIsExclusive = true)] Positive<int> ExclusiveLowerAge,
     [property: Range(2, 10, MinimumIsExclusive = true)] int ExclusiveLowerAgeRaw,

--- a/src/StrongTypes.OpenApi.TestApi.Shared/AnnotatedRequests.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/AnnotatedRequests.cs
@@ -57,7 +57,16 @@ public sealed record AnnotatedTextsRequest(
     [property: System.ComponentModel.Description("Short user tagline")]
     string TaglineRaw,
 
-    NonEmptyString Description);
+    NonEmptyString Description,
+
+    // Email type with caller annotations — caller's [StringLength(100)] is
+    // tighter than the wrapper's own maxLength: 254, so the wire schema
+    // must reflect the caller's bound.
+    [property: StringLength(100)]
+    Email AnnotatedEmail,
+
+    [property: StringLength(100)]
+    string AnnotatedEmailRaw);
 
 public sealed record AnnotatedNumbersRequest(
     [property: Range(18, 120)] Positive<int> Age,

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -57,7 +57,7 @@ public sealed class NegativeDoubleEntityController : ControllerBase
 public sealed class NonPositiveDecimalEntityController : ControllerBase
 {
     [HttpPost]
-    public IActionResult Create(StructEntityRequest<NonPositive<decimal>> request)
+    public IActionResult Create(DecimalEntityRequest request)
         => Ok(new EntityResponse(Guid.NewGuid()));
 }
 

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -140,14 +140,29 @@ public sealed class BindingProbeController : ControllerBase
     // Annotated variants — pin that caller annotations attached at a non-body
     // strong-type slot (parameter or form property) reach the wire schema.
 
+    // Each annotated wrapper-typed parameter has a primitive-typed sibling
+    // carrying the same annotation. The sibling is the baseline: a pipeline
+    // that doesn't surface the annotation on the primitive obviously can't
+    // surface it on the wrapper either, so the wrapper tests only have
+    // teeth when the primitive sibling carries the keyword.
     [HttpGet("query-annotated")]
     public IActionResult FromQueryAnnotated(
         [FromQuery, StringLength(50)] NonEmptyString name,
-        [FromQuery, Range(5, 100)] Positive<int> count)
+        [FromQuery, StringLength(50)] string plainName,
+        [FromQuery, Range(5, 100)] Positive<int> count,
+        [FromQuery, Range(5, 100)] int plainCount)
         => Ok();
 
+    // Form bodies are split into two uniform requests — one all wrappers,
+    // one all primitives — to keep the per-pipeline form-body shape
+    // consistent. Mixing wrappers and primitives in a single [FromForm]
+    // request makes Swashbuckle emit a hybrid `allOf:[wrappers, {primitives}]`
+    // shape that's painful to navigate from a shared test.
     [HttpPost("form-annotated")]
     public IActionResult FromFormAnnotated([FromForm] AnnotatedBindingProbeFormRequest request) => Ok();
+
+    [HttpPost("form-annotated-plain")]
+    public IActionResult FromFormAnnotatedPlain([FromForm] PlainAnnotatedBindingProbeFormRequest request) => Ok();
 }
 
 public sealed record BindingProbeFormRequest(
@@ -161,3 +176,7 @@ public sealed record BindingProbeFormRequest(
 public sealed record AnnotatedBindingProbeFormRequest(
     [property: StringLength(50)] NonEmptyString Name,
     [property: Range(5, 100)] Positive<int> Count);
+
+public sealed record PlainAnnotatedBindingProbeFormRequest(
+    [property: StringLength(50)] string PlainName,
+    [property: Range(5, 100)] int PlainCount);

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -53,6 +53,15 @@ public sealed class NegativeDoubleEntityController : ControllerBase
 }
 
 [ApiController]
+[Route("digit-entities")]
+public sealed class DigitEntityController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Create(StructEntityRequest<Digit> request)
+        => Ok(new EntityResponse(Guid.NewGuid()));
+}
+
+[ApiController]
 [Route("non-positive-decimal-entities")]
 public sealed class NonPositiveDecimalEntityController : ControllerBase
 {
@@ -102,9 +111,8 @@ public sealed class NestedStrongTypesController : ControllerBase
 /// generated OpenAPI document can be asserted against. Mirrors the shape of
 /// <c>StrongTypes.Api.Controllers.BindingProbeController</c>: each endpoint
 /// accepts a required and a nullable variant of every wrapped type so the
-/// schema tests cover both branches. <c>Digit</c> is deliberately omitted
-/// because it has no OpenAPI schema transformer yet; <c>[FromRoute]</c> is
-/// required-only because route segments are required by HTTP semantics.
+/// schema tests cover both branches. <c>[FromRoute]</c> is required-only
+/// because route segments are required by HTTP semantics.
 /// </summary>
 [ApiController]
 [Route("binding-probe")]
@@ -116,14 +124,17 @@ public sealed class BindingProbeController : ControllerBase
         [FromQuery] NonEmptyString? nullableName,
         [FromQuery] Positive<int> count,
         [FromQuery] Positive<int>? nullableCount,
+        [FromQuery] Digit digit,
+        [FromQuery] Digit? nullableDigit,
         [FromQuery] Email email,
         [FromQuery] Email? nullableEmail)
         => Ok();
 
-    [HttpGet("route/{name}/{count:int}")]
+    [HttpGet("route/{name}/{count:int}/{digit}")]
     public IActionResult FromRoute(
         [FromRoute] NonEmptyString name,
-        [FromRoute] Positive<int> count)
+        [FromRoute] Positive<int> count,
+        [FromRoute] Digit digit)
         => Ok();
 
     [HttpGet("header")]
@@ -170,6 +181,8 @@ public sealed record BindingProbeFormRequest(
     NonEmptyString? NullableName,
     Positive<int> Count,
     Positive<int>? NullableCount,
+    Digit Digit,
+    NonEmptyEnumerable<NonEmptyString> Tags,
     Email Email,
     Email? NullableEmail);
 

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 
 namespace StrongTypes.OpenApi.TestApi.Shared;
@@ -135,6 +136,18 @@ public sealed class BindingProbeController : ControllerBase
 
     [HttpPost("form")]
     public IActionResult FromForm([FromForm] BindingProbeFormRequest request) => Ok();
+
+    // Annotated variants — pin that caller annotations attached at a non-body
+    // strong-type slot (parameter or form property) reach the wire schema.
+
+    [HttpGet("query-annotated")]
+    public IActionResult FromQueryAnnotated(
+        [FromQuery, StringLength(50)] NonEmptyString name,
+        [FromQuery, Range(5, 100)] Positive<int> count)
+        => Ok();
+
+    [HttpPost("form-annotated")]
+    public IActionResult FromFormAnnotated([FromForm] AnnotatedBindingProbeFormRequest request) => Ok();
 }
 
 public sealed record BindingProbeFormRequest(
@@ -144,3 +157,7 @@ public sealed record BindingProbeFormRequest(
     Positive<int>? NullableCount,
     Email Email,
     Email? NullableEmail);
+
+public sealed record AnnotatedBindingProbeFormRequest(
+    [property: StringLength(50)] NonEmptyString Name,
+    [property: Range(5, 100)] Positive<int> Count);

--- a/src/StrongTypes.OpenApi.TestApi.Shared/Models.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/Models.cs
@@ -4,6 +4,8 @@ namespace StrongTypes.OpenApi.TestApi.Shared;
 
 public sealed record StructEntityRequest<T>(T Value, T? NullableValue) where T : struct;
 
+public sealed record DecimalEntityRequest(NonPositive<decimal> Value, decimal PlainValue);
+
 public sealed record ReferenceEntityRequest<T>(T Value, T? NullableValue) where T : class;
 
 public sealed record StructEntityPatchRequest<T>(T? Value, Maybe<T>? NullableValue) where T : struct;

--- a/src/StrongTypes.OpenApi.TestApi.Shared/Models.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/Models.cs
@@ -33,6 +33,7 @@ public sealed record NonEmptyStringCollectionsRequest(
 public sealed record NullableStrongTypesRequest(
     NonEmptyString? NullableNonEmptyString,
     Positive<int>? NullablePositiveInt,
+    Digit? NullableDigit,
     NonEmptyEnumerable<NonEmptyString>? NullableNonEmptyStringArray,
     NonEmptyEnumerable<Positive<int>>? NullableNonEmptyPositiveIntArray);
 


### PR DESCRIPTION
## Summary

Started as the issue #87 fix (Microsoft non-body schema painting). Grew during review to land symmetrical, complete annotation handling on both pipelines and a few related cleanups.

### What's in
- **Microsoft non-body schema painting (the original #87 ask).** New `NonBodyStrongTypeOperationTransformer` walks `ApiDescription.ParameterDescriptions`, resolves each slot's CLR type via `ModelMetadata.ModelType` (the only source `IParsable<T>` doesn't mask), and paints the wrapper's wire shape directly onto `[FromQuery]` / `[FromRoute]` / `[FromHeader]` parameter schemas and `[FromForm]` property schemas.
- **Caller annotation merging on non-body slots, both pipelines.** Both transformers/filters now run `WrapperAnnotationApplier` after the wire-shape paint so a `[FromQuery, StringLength(50)] NonEmptyString name` reaches the wire as `{type:string, minLength:1, maxLength:50}` instead of dropping the caller's `maxLength`. The applier moved from the Microsoft adapter to `StrongTypes.OpenApi.Core` so both pipelines share the same logic. Microsoft mutates its slot in place; Swashbuckle wraps the `$ref` in `allOf:[<ref>] + annotations` and lets the existing inliner collapse it at the end, mirroring the body-side trick `PropertyAnnotationSchemaFilter` already uses.
- **Email type wired into the annotation appliers.** Email was missing from both `WrapperAnnotationApplier` (Microsoft) and `PropertyAnnotationSchemaFilter` (Swashbuckle), so `[StringLength(100)] Email` silently dropped the caller's `maxLength: 100` on both pipelines for body and non-body slots. Email is string-shaped, so the same `ApplyStringAnnotations` branch handles it. Body-side annotation test added.
- **Primitive baselines on every annotated wrapper test.** Each `[FromQuery]` / `[FromForm]` wrapper test now has a `string` / `int` sibling carrying the same annotation. Sets the floor: a future framework regression would fail the baseline first, so a wrapper failure can be correctly attributed instead of guessed at.
- **Cleanup.** `IsNonJsonBodyStrongTypeSchemaBroken` and `IsNonBodyAnnotationMergingBroken` test flags both deleted (no pipeline overrides them anymore). `BindingSchemaAsserts` helpers renamed from `Assert{NonBody,Route}*` to `Assert*Schema` (the wire shape doesn't depend on body/non-body — the old names implied otherwise). Misleading XML comments rewritten.

### Body conflict safety

The non-body painters are insulated from JSON body schemas three ways: (1) source filter dispatches only on `BindingSource.Query | Path | Header | Form` — never `Body`; (2) the form path's content-type whitelist is `multipart/form-data` and `application/x-www-form-urlencoded` only — `application/json` is never iterated; (3) structurally, `operation.Parameters[]` only contains non-body slots in OpenAPI/ASP.NET (body content lives under `operation.RequestBody`), so the parameter-rewrite path can't reach a JSON body schema even if the source filter were bypassed. The unchanged 200+ JSON-body tests in the Annotations / Strings / Numerics / Components partials act as the regression lock.

### Precision

Type matching is exact (`==` on `Type` and on `GetGenericTypeDefinition()`); user DTOs never match. Form properties are checked individually — only strong-type slots in a mixed form are rewritten. Form-property keys are looked up by exact name (Microsoft's PascalCase) or single camelCase fallback (Swashbuckle's convention) — no speculative dot-splitting or case-insensitive scans that could bind to the wrong slot.

## Test plan
- [x] Full repo suite: 2,185 tests green across `StrongTypes.Tests` (1,038), `StrongTypes.Analyzers.Tests` (39), `StrongTypes.OpenApi.IntegrationTests` (279), and `StrongTypes.Api.IntegrationTests` (829).
- [x] +27 new tests over the original baseline: non-body wrapper schema painting, primitive baselines, wrapper annotation merging, Email annotation merging, all running on both Microsoft and Swashbuckle pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)