### PR TITLE
Paint format:email on Email wrapper non-body slots; document [EmailAddress] limitation (refs #95)

### DIFF
--- a/Skill/references/openapi.md
+++ b/Skill/references/openapi.md
@@ -9,11 +9,15 @@ hooks built for one do nothing for the other.
 > **Recommendation:** prefer Swashbuckle when you have a free choice.
 > `Microsoft.AspNetCore.OpenApi` has rough edges the framework exposes
 > no public hook to fix — `[EmailAddress]` doesn't propagate as
-> `format: email`, strong-type keys on dictionaries aren't always
-> honored, and the framework's deduplication pass silently strips
-> bounds the transformer placed earlier (the Microsoft adapter has to
-> repaint components after the fact). Swashbuckle's filter pipeline
-> hits all of these cleanly.
+> `format: email` on any string slot (body / query / route / header /
+> form), strong-type keys on dictionaries aren't always honored, and
+> the framework's deduplication pass silently strips bounds the
+> transformer placed earlier (the Microsoft adapter has to repaint
+> components after the fact). Swashbuckle's filter pipeline hits all
+> of these cleanly. If you need an always-`format: email` shape on
+> Microsoft, use the `Email` strong type rather than
+> `[EmailAddress] string` / `[EmailAddress] NonEmptyString` — see
+> the section below.
 
 | Spec generator                          | Package                                    | Configured on             |
 | --------------------------------------- | ------------------------------------------ | ------------------------- |
@@ -84,6 +88,19 @@ is a strong-type wrapper. Each adapter re-applies them.
   open an issue on
   [KaliCZ/StrongTypes](https://github.com/KaliCZ/StrongTypes/issues)
   so it can be added.
+
+### `[EmailAddress]` on Microsoft is a special case
+
+Microsoft.AspNetCore.OpenApi never emits `format: email` from
+`[EmailAddress]` — not on a plain `string`, not on a `NonEmptyString`,
+not on any slot (body, query, route, header, form). The adapter
+mirrors the framework here: we don't paint `format: email` from the
+attribute on wrapper types either, because doing so would mean wrapping
+a `string` in `NonEmptyString` silently enables a keyword the attribute
+didn't enable on the primitive. If you want `format: email` on
+Microsoft, use the `Email` strong type — it's painted as
+`{ "type": "string", "format": "email", "minLength": 1, "maxLength": 254 }`
+on every slot regardless of pipeline.
 
 ## OpenAPI version
 

--- a/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
+++ b/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
@@ -81,9 +81,6 @@ public static class WrapperAnnotationApplier
                 case Base64StringAttribute:
                     SchemaPaint.SetFormatIfAbsent(schema, "byte");
                     break;
-                case EmailAddressAttribute:
-                    SchemaPaint.SetFormatIfAbsent(schema, "email");
-                    break;
             }
         }
     }

--- a/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
+++ b/src/StrongTypes.OpenApi.Core/WrapperAnnotationApplier.cs
@@ -81,6 +81,9 @@ public static class WrapperAnnotationApplier
                 case Base64StringAttribute:
                     SchemaPaint.SetFormatIfAbsent(schema, "byte");
                     break;
+                case EmailAddressAttribute:
+                    SchemaPaint.SetFormatIfAbsent(schema, "email");
+                    break;
             }
         }
     }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -117,15 +117,13 @@ internal static class BindingSchemaAsserts
 
     // ── Email ────────────────────────────────────────────────────────────
 
-    internal static void AssertEmailSchema(JsonElement schema, bool isEmailStringFormatBroken)
-        => AssertJsonEquals(schema, isEmailStringFormatBroken
-            ? """{"type":"string","minLength":1,"maxLength":254}"""
-            : """{"type":"string","minLength":1,"maxLength":254,"format":"email"}""");
+    internal static void AssertEmailSchema(JsonElement schema)
+        => AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":254,"format":"email"}""");
 
     /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
     /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isEmailStringFormatBroken)
-        => AssertEmailSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), isEmailStringFormatBroken);
+    internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+        => AssertEmailSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
 
     /// <summary>
     /// Looks up a per-field schema on a <c>[FromForm]</c> request-body

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
@@ -16,5 +16,5 @@ public sealed class MicrosoftOpenApi31DocumentTests(MicrosoftTestApi31Factory fa
 {
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_1;
-    protected override bool IsEmailStringFormatBroken => true;
+    protected override bool IsPlainStringEmailFormatBroken => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApi31DocumentTests.cs
@@ -16,5 +16,5 @@ public sealed class MicrosoftOpenApi31DocumentTests(MicrosoftTestApi31Factory fa
 {
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_1;
-    protected override bool IsPlainStringEmailFormatBroken => true;
+    protected override bool IsEmailAddressFormatIgnored => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
@@ -14,5 +14,5 @@ public sealed class MicrosoftOpenApiDocumentTests(MicrosoftTestApiFactory factor
 {
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
-    protected override bool IsPlainStringEmailFormatBroken => true;
+    protected override bool IsEmailAddressFormatIgnored => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/MicrosoftOpenApiDocumentTests.cs
@@ -14,5 +14,5 @@ public sealed class MicrosoftOpenApiDocumentTests(MicrosoftTestApiFactory factor
 {
     protected override string DocumentUrl => "/openapi/v1.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
-    protected override bool IsEmailStringFormatBroken => true;
+    protected override bool IsPlainStringEmailFormatBroken => true;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
@@ -74,14 +74,18 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task Property_NonEmptyString_With_EmailAddress_Carries_Wrapper_MinLength_And_Format_Email()
+    public async Task Property_NonEmptyString_With_EmailAddress_Carries_Wrapper_MinLength_And_Format_Email_When_Honored()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/annotated-texts"));
         var contactEmail = Property(body, "contactEmail");
 
+        // Wrapper's minLength: 1 always reaches the wire. The [EmailAddress]
+        // format keyword only reaches it on pipelines that honour the
+        // attribute on string properties; Microsoft.AspNetCore.OpenApi
+        // drops it across every slot (see Email for the always-format type).
         Assert.Equal(1, CollectMaxInt(doc, contactEmail, "minLength", Version));
-        Assert.Equal("email", CollectFirstString(doc, contactEmail, "format", Version));
+        Assert.Equal(IsEmailAddressFormatIgnored ? null : "email", CollectFirstString(doc, contactEmail, "format", Version));
     }
 
     [Fact]
@@ -274,7 +278,7 @@ public abstract partial class OpenApiDocumentTestsBase
         var body = FollowRef(doc, RequestSchema(doc, "/annotated-texts"));
         var contactEmailRaw = Property(body, "contactEmailRaw");
 
-        Assert.Equal(IsPlainStringEmailFormatBroken ? null : "email", CollectFirstString(doc, contactEmailRaw, "format", Version));
+        Assert.Equal(IsEmailAddressFormatIgnored ? null : "email", CollectFirstString(doc, contactEmailRaw, "format", Version));
     }
 
     [Fact]

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Annotations.cs
@@ -74,17 +74,14 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task Property_NonEmptyString_With_EmailAddress_Carries_Wrapper_MinLength_And_Format_Email_When_Honored()
+    public async Task Property_NonEmptyString_With_EmailAddress_Carries_Wrapper_MinLength_And_Format_Email()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/annotated-texts"));
         var contactEmail = Property(body, "contactEmail");
 
-        // Wrapper's minLength: 1 always reaches the wire. The [EmailAddress]
-        // format keyword only reaches it on pipelines that honour the
-        // attribute on plain primitives.
         Assert.Equal(1, CollectMaxInt(doc, contactEmail, "minLength", Version));
-        Assert.Equal(IsEmailStringFormatBroken ? null : "email", CollectFirstString(doc, contactEmail, "format", Version));
+        Assert.Equal("email", CollectFirstString(doc, contactEmail, "format", Version));
     }
 
     [Fact]
@@ -277,7 +274,7 @@ public abstract partial class OpenApiDocumentTestsBase
         var body = FollowRef(doc, RequestSchema(doc, "/annotated-texts"));
         var contactEmailRaw = Property(body, "contactEmailRaw");
 
-        Assert.Equal(IsEmailStringFormatBroken ? null : "email", CollectFirstString(doc, contactEmailRaw, "format", Version));
+        Assert.Equal(IsPlainStringEmailFormatBroken ? null : "email", CollectFirstString(doc, contactEmailRaw, "format", Version));
     }
 
     [Fact]

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
@@ -12,7 +12,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/email-entities"));
-        AssertEmailSchema(Property(body, "value"), isEmailStringFormatBroken: false);
+        AssertEmailSchema(Property(body, "value"));
     }
 
     [Fact]
@@ -20,6 +20,6 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/email-entities"));
-        AssertEmailSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version), isEmailStringFormatBroken: false);
+        AssertEmailSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -63,14 +63,14 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromQuery_Email_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "email");
-        AssertEmailSchema(schema, IsEmailStringFormatBroken);
+        AssertEmailSchema(schema);
     }
 
     [Fact]
     public async Task FromQuery_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var schema = ParameterSchema(await GetDocumentAsync(), "/binding-probe/query", "nullableEmail");
-        AssertEmailSchema(schema, IsEmailStringFormatBroken);
+        AssertEmailSchema(schema);
     }
 
     // ── [FromRoute] ──────────────────────────────────────────────────────
@@ -187,14 +187,14 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_Email_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 5, IsFormPropertiesSchemaBroken);
     }
 
     [Fact]
     public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 6, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 6, IsFormPropertiesSchemaBroken);
     }
 
     // ── Caller annotations on non-body slots ─────────────────────────────

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -44,12 +44,16 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     // actual behaviour and catches it if the framework starts honouring
     // the annotation. Each flag is set in the per-pipeline subclass.
     /// <summary>
-    /// True when the pipeline doesn't surface <c>[EmailAddress]</c> on a
-    /// plain <c>string</c> property as <c>format: email</c>. Strong-type
-    /// slots (<see cref="Email"/>, <see cref="NonEmptyString"/>) always paint
-    /// the format on every pipeline; only the primitive baseline varies.
+    /// True when the pipeline drops the <see cref="EmailAddressAttribute"/>
+    /// from string slots — i.e. neither plain <c>string</c> nor
+    /// <see cref="NonEmptyString"/> properties decorated with
+    /// <c>[EmailAddress]</c> reach the wire as <c>format: email</c>.
+    /// Microsoft.AspNetCore.OpenApi never emits the keyword from the
+    /// attribute on any string slot (body / query / route / header / form);
+    /// Swashbuckle does. The always-an-email wrapper <see cref="Email"/> is
+    /// independent — it paints <c>format: email</c> on every pipeline.
     /// </summary>
-    protected virtual bool IsPlainStringEmailFormatBroken => false;
+    protected virtual bool IsEmailAddressFormatIgnored => false;
 
     /// <summary>
     /// True when the pipeline emits the <c>[FromForm]</c> request-body schema

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -43,7 +43,13 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     // rather than skipping — so the suite documents the framework's
     // actual behaviour and catches it if the framework starts honouring
     // the annotation. Each flag is set in the per-pipeline subclass.
-    protected virtual bool IsEmailStringFormatBroken => false;
+    /// <summary>
+    /// True when the pipeline doesn't surface <c>[EmailAddress]</c> on a
+    /// plain <c>string</c> property as <c>format: email</c>. Strong-type
+    /// slots (<see cref="Email"/>, <see cref="NonEmptyString"/>) always paint
+    /// the format on every pipeline; only the primitive baseline varies.
+    /// </summary>
+    protected virtual bool IsPlainStringEmailFormatBroken => false;
 
     /// <summary>
     /// True when the pipeline emits the <c>[FromForm]</c> request-body schema

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -128,13 +128,9 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
 
         if (StrongTypeSchemaTypes.IsEmail(clrType))
         {
-            // Format is intentionally left to whatever the pipeline already
-            // wrote (typically nothing — Microsoft.AspNetCore.OpenApi doesn't
-            // honor format:email even on plain string properties). The
-            // matching JSON-body Email schema and the IsEmailStringFormatBroken
-            // flag in the integration tests pin this same behavior.
             SchemaPaint.ClearWrapperShape(schema);
             schema.Type = JsonSchemaType.String;
+            SchemaPaint.SetFormatIfAbsent(schema, "email");
             SchemaPaint.TightenMinLength(schema, 1);
             SchemaPaint.TightenMaxLength(schema, Email.MaxLength);
             return true;


### PR DESCRIPTION
## Summary

Two narrow changes informed by an empirical test of `Microsoft.AspNetCore.OpenApi` 10.0.7 against `[EmailAddress]`:

- **Email wrapper, non-body slots** — `[FromQuery]` / `[FromRoute]` / `[FromHeader]` / `[FromForm]` now paint `format: email`, matching what the JSON-body `EmailSchemaTransformer` already does. The `Email` strong type now produces `{ type:string, format:email, minLength:1, maxLength:254 }` in every slot on every pipeline.
- **`[EmailAddress]` propagation, deliberately not added** — a fresh `dotnet new web` + `Microsoft.AspNetCore.OpenApi` confirmed the framework never emits `format: email` from `[EmailAddress]` on any slot (body / query / route / header / form), regardless of whether the property is `string` or `NonEmptyString`. Painting it ourselves on wrapper types only would mean wrapping a `string` in `NonEmptyString` silently enables a keyword the attribute didn't enable on the primitive — surprising and inconsistent. We mirror the framework and document the limitation, pointing users at the `Email` strong type when they want an always-`format:email` shape.

The renamed test flag is `IsEmailAddressFormatIgnored` (covers both plain `string` and `NonEmptyString` carrying `[EmailAddress]` on Microsoft).

Closes #95 as won't-fix on the `[EmailAddress]` propagation half; the Email-wrapper non-body half is fixed here.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test` — full suite passes (StrongTypes.Tests 1038, OpenApi.IntegrationTests 306, AspNetCore.IntegrationTests 22, Wpf.Tests 11, Api.IntegrationTests 844, Analyzers.Tests 39)
- [x] Empirical verification: a clean `dotnet new web` project with only `Microsoft.AspNetCore.OpenApi` (no StrongTypes) and `[EmailAddress]` on body/query/route/header/form — none surface `format: email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)