### PR TITLE
Reshape Swashbuckle [FromForm] allOf into a properties map

### DIFF
--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -12,33 +12,20 @@ namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 /// <see cref="AssertJsonEquals"/> so an unexpected keyword fails the test
 /// instead of silently passing.
 ///
-/// The form helpers additionally navigate the request-body schema:
-/// pipelines may emit <c>{ properties: { … } }</c> (Microsoft, modern
-/// Swashbuckle) or <c>{ allOf: [ &lt;each-field&gt; ] }</c> with the
-/// field names dropped (vanilla Swashbuckle when every field is
-/// component-typed — see <see cref="OpenApiDocumentTestsBase.IsFormPropertiesSchemaBroken"/>).
-/// The helpers pick the right slot per pipeline and then run the same
-/// shape assertion as the parameter-side helpers.
+/// The form helpers additionally navigate the request-body schema by
+/// looking up the field by name in the form's <c>properties</c> map.
+/// Casing is treated case-insensitively because Microsoft emits
+/// PascalCase and Swashbuckle camelCase.
 /// </summary>
 internal static class BindingSchemaAsserts
 {
-    /// <summary>
-    /// Number of fields in <c>BindingProbeFormRequest</c>. The Swashbuckle
-    /// broken-path navigates the form schema's <c>allOf</c> by declaration
-    /// index and asserts this count to lock in that the broken shape is the
-    /// one we expect.
-    /// </summary>
-    private const int FormFieldCount = 8;
-
     // ── NonEmptyString ───────────────────────────────────────────────────
 
     internal static void AssertNonEmptyStringSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"string","minLength":1}""");
 
-    /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
-    /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyNonEmptyStringSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
-        => AssertNonEmptyStringSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
+    internal static void AssertFormPropertyNonEmptyStringSchema(JsonElement formSchema, string propertyName)
+        => AssertNonEmptyStringSchema(GetFormProperty(formSchema, propertyName));
 
     // ── Positive<int> ────────────────────────────────────────────────────
     // Splits by OpenAPI version: 3.0 encodes the exclusive bound as
@@ -53,18 +40,16 @@ internal static class BindingSchemaAsserts
             _ => throw new ArgumentOutOfRangeException(nameof(version), version, null),
         });
 
-    /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
-    /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyPositiveIntSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, OpenApiVersion version)
-        => AssertPositiveIntSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), version);
+    internal static void AssertFormPropertyPositiveIntSchema(JsonElement formSchema, string propertyName, OpenApiVersion version)
+        => AssertPositiveIntSchema(GetFormProperty(formSchema, propertyName), version);
 
     // ── Digit ────────────────────────────────────────────────────────────
 
     internal static void AssertDigitSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":0,"maximum":9}""");
 
-    internal static void AssertFormPropertyDigitSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
-        => AssertDigitSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
+    internal static void AssertFormPropertyDigitSchema(JsonElement formSchema, string propertyName)
+        => AssertDigitSchema(GetFormProperty(formSchema, propertyName));
 
     // ── Other numeric wrappers ──────────────────────────────────────────
     // Inclusive-bound shapes (NonNegative, NonPositive) don't depend on
@@ -95,8 +80,8 @@ internal static class BindingSchemaAsserts
     internal static void AssertNonEmptyEnumerableOfNonEmptyStringSchema(JsonElement schema)
         => AssertJsonEquals(schema, """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
 
-    internal static void AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
-        => AssertNonEmptyEnumerableOfNonEmptyStringSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken));
+    internal static void AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(JsonElement formSchema, string propertyName)
+        => AssertNonEmptyEnumerableOfNonEmptyStringSchema(GetFormProperty(formSchema, propertyName));
 
     internal static void AssertPlainDecimalSchema(JsonElement schema, OpenApiVersion version)
     {
@@ -122,40 +107,16 @@ internal static class BindingSchemaAsserts
             ? """{"type":"string","minLength":1,"maxLength":254}"""
             : """{"type":"string","minLength":1,"maxLength":254,"format":"email"}""");
 
-    /// <param name="propertyName">Field name as it appears in the form schema's <c>properties</c> map on the not-broken path.</param>
-    /// <param name="allOfIndex">Position in the form schema's <c>allOf</c> array, used only when <paramref name="isFormPropertiesSchemaBroken"/> is true (the field name has been dropped, so navigation is by declaration index).</param>
-    internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken, bool isEmailStringFormatBroken)
-        => AssertEmailSchema(GetFormProperty(formSchema, propertyName, allOfIndex, isFormPropertiesSchemaBroken), isEmailStringFormatBroken);
+    internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName, bool isEmailStringFormatBroken)
+        => AssertEmailSchema(GetFormProperty(formSchema, propertyName), isEmailStringFormatBroken);
 
     /// <summary>
     /// Looks up a per-field schema on a <c>[FromForm]</c> request-body
-    /// schema. On the not-broken path the form schema is an object with a
-    /// <c>properties</c> map; the field is found by name (case-insensitive
-    /// because Microsoft emits PascalCase, Swashbuckle camelCase). On the
-    /// broken path the form schema is <c>{ allOf: [&lt;each-field&gt;] }</c>
-    /// with names dropped; the field is found by its declaration index
-    /// (<paramref name="allOfIndex"/>).
+    /// schema. The field is found by name (case-insensitive because
+    /// Microsoft emits PascalCase, Swashbuckle camelCase).
     /// </summary>
-    private static JsonElement GetFormProperty(JsonElement formSchema, string propertyName, int allOfIndex, bool isFormPropertiesSchemaBroken)
+    private static JsonElement GetFormProperty(JsonElement formSchema, string propertyName)
     {
-        if (isFormPropertiesSchemaBroken)
-        {
-            Assert.True(formSchema.TryGetProperty("allOf", out var allOf), "form schema is broken-flagged but has no allOf");
-            Assert.Equal(JsonValueKind.Array, allOf.ValueKind);
-            Assert.Equal(FormFieldCount, allOf.GetArrayLength());
-            Assert.False(formSchema.TryGetProperty("properties", out _), "form schema is broken-flagged but still has a properties map");
-            var slot = allOf[allOfIndex];
-            if (slot.TryGetProperty("properties", out var slotProperties))
-            {
-                foreach (var entry in slotProperties.EnumerateObject())
-                {
-                    if (string.Equals(entry.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-                        return entry.Value;
-                }
-            }
-            return slot;
-        }
-
         var properties = formSchema.GetProperty("properties");
         foreach (var entry in properties.EnumerateObject())
         {

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -12,10 +12,9 @@ namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
 /// <see cref="AssertJsonEquals"/> so an unexpected keyword fails the test
 /// instead of silently passing.
 ///
-/// The form helpers additionally navigate the request-body schema by
-/// looking up the field by name in the form's <c>properties</c> map.
-/// Casing is treated case-insensitively because Microsoft emits
-/// PascalCase and Swashbuckle camelCase.
+/// Both Microsoft.AspNetCore.OpenApi and Swashbuckle emit form-body
+/// property keys in PascalCase (matching the C# property name), so
+/// callers pass the name as declared in the source.
 /// </summary>
 internal static class BindingSchemaAsserts
 {
@@ -108,20 +107,6 @@ internal static class BindingSchemaAsserts
     internal static void AssertFormPropertyEmailSchema(JsonElement formSchema, string propertyName)
         => AssertEmailSchema(GetFormProperty(formSchema, propertyName));
 
-    /// <summary>
-    /// Looks up a per-field schema on a <c>[FromForm]</c> request-body
-    /// schema. The field is found by name (case-insensitive because
-    /// Microsoft emits PascalCase, Swashbuckle camelCase).
-    /// </summary>
     private static JsonElement GetFormProperty(JsonElement formSchema, string propertyName)
-    {
-        var properties = formSchema.GetProperty("properties");
-        foreach (var entry in properties.EnumerateObject())
-        {
-            if (string.Equals(entry.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-                return entry.Value;
-        }
-        Assert.Fail($"form schema has no '{propertyName}' property (case-insensitive)");
-        return default;
-    }
+        => formSchema.GetProperty("properties").GetProperty(propertyName);
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -109,4 +109,30 @@ internal static class BindingSchemaAsserts
 
     private static JsonElement GetFormProperty(JsonElement formSchema, string propertyName)
         => formSchema.GetProperty("properties").GetProperty(propertyName);
+
+    /// <summary>
+    /// Asserts that a <c>[FromForm]</c> request-body schema is a clean
+    /// <c>{ type: object, properties: { … } }</c> shape — no top-level
+    /// <c>allOf</c> / <c>anyOf</c> / <c>oneOf</c> / <c>$ref</c>, a
+    /// <c>properties</c> map present, and exactly the expected
+    /// property-name set (compared case-insensitively).
+    /// </summary>
+    internal static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
+    {
+        Assert.False(formSchema.TryGetProperty("allOf", out _), "form body should not be wrapped in a top-level allOf");
+        Assert.False(formSchema.TryGetProperty("anyOf", out _), "form body should not be wrapped in a top-level anyOf");
+        Assert.False(formSchema.TryGetProperty("oneOf", out _), "form body should not be wrapped in a top-level oneOf");
+        Assert.False(formSchema.TryGetProperty("$ref", out _), "form body should be inlined, not a $ref");
+        Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
+        Assert.Equal(JsonValueKind.Object, properties.ValueKind);
+
+        var actualNames = properties.EnumerateObject()
+            .Select(p => p.Name)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var expected = expectedPropertyNames
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(expected, actualNames, StringComparer.OrdinalIgnoreCase);
+    }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -114,8 +114,9 @@ internal static class BindingSchemaAsserts
     /// Asserts that a <c>[FromForm]</c> request-body schema is a clean
     /// <c>{ type: object, properties: { … } }</c> shape — no top-level
     /// <c>allOf</c> / <c>anyOf</c> / <c>oneOf</c> / <c>$ref</c>, a
-    /// <c>properties</c> map present, and exactly the expected
-    /// property-name set (compared case-insensitively).
+    /// <c>properties</c> map present, and exactly the expected set of
+    /// property names (order is irrelevant; comparison is
+    /// case-insensitive).
     /// </summary>
     internal static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
     {
@@ -126,13 +127,12 @@ internal static class BindingSchemaAsserts
         Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
         Assert.Equal(JsonValueKind.Object, properties.ValueKind);
 
-        var actualNames = properties.EnumerateObject()
-            .Select(p => p.Name)
-            .Order(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        var expected = expectedPropertyNames
-            .Order(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        Assert.Equal(expected, actualNames, StringComparer.OrdinalIgnoreCase);
+        var actual = properties.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var expected = expectedPropertyNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (actual.SetEquals(expected)) return;
+
+        var missing = expected.Except(actual, StringComparer.OrdinalIgnoreCase).Order().ToArray();
+        var extra = actual.Except(expected, StringComparer.OrdinalIgnoreCase).Order().ToArray();
+        Assert.Fail($"form properties differ.\n  missing: [{string.Join(", ", missing)}]\n  extra:   [{string.Join(", ", extra)}]");
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -111,6 +111,16 @@ internal static class BindingSchemaAsserts
         => formSchema.GetProperty("properties").GetProperty(propertyName);
 
     /// <summary>
+    /// Asserts that the named property in a form-body / object schema's
+    /// <c>properties</c> map deep-equals the literal JSON snapshot. Thin
+    /// composition of <see cref="GetFormProperty"/> +
+    /// <see cref="AssertJsonEquals"/> — exists because tests that pin every
+    /// property of a form body had repeated this exact two-step inline.
+    /// </summary>
+    internal static void AssertSchema(JsonElement formSchema, string propertyName, string expectedJson)
+        => AssertJsonEquals(GetFormProperty(formSchema, propertyName), expectedJson);
+
+    /// <summary>
     /// Asserts that a <c>[FromForm]</c> request-body schema is a clean
     /// <c>{ type: object, properties: { … } }</c> shape — no top-level
     /// <c>allOf</c> / <c>anyOf</c> / <c>oneOf</c> / <c>$ref</c>, a

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/BindingSchemaAsserts.cs
@@ -115,8 +115,7 @@ internal static class BindingSchemaAsserts
     /// <c>{ type: object, properties: { … } }</c> shape — no top-level
     /// <c>allOf</c> / <c>anyOf</c> / <c>oneOf</c> / <c>$ref</c>, a
     /// <c>properties</c> map present, and exactly the expected set of
-    /// property names (order is irrelevant; comparison is
-    /// case-insensitive).
+    /// property names (order is irrelevant).
     /// </summary>
     internal static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
     {
@@ -127,12 +126,7 @@ internal static class BindingSchemaAsserts
         Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
         Assert.Equal(JsonValueKind.Object, properties.ValueKind);
 
-        var actual = properties.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var expected = expectedPropertyNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        if (actual.SetEquals(expected)) return;
-
-        var missing = expected.Except(actual, StringComparer.OrdinalIgnoreCase).Order().ToArray();
-        var extra = actual.Except(expected, StringComparer.OrdinalIgnoreCase).Order().ToArray();
-        Assert.Fail($"form properties differ.\n  missing: [{string.Join(", ", missing)}]\n  extra:   [{string.Join(", ", extra)}]");
+        var actual = properties.EnumerateObject().Select(p => p.Name);
+        Assert.Equivalent(expectedPropertyNames, actual);
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Composition.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Composition.cs
@@ -1,9 +1,8 @@
+using StrongTypes.OpenApi.IntegrationTests.Helpers;
 using Xunit;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.ExclusiveBounds;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.NullableUnwrap;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaNavigation;
 using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaValueReader;
-using static StrongTypes.OpenApi.IntegrationTests.Helpers.SchemaWalk;
 
 namespace StrongTypes.OpenApi.IntegrationTests.Tests;
 
@@ -20,24 +19,16 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         // The PATCH request for a numeric entity carries `Maybe<T>? NullableValue`.
         // The converter writes {"Value": x} or {"Value": null} and reads {} as None,
-        // so the schema must describe an object with a non-required Value property.
+        // so the schema must describe an object with a non-required Value property —
+        // a deep-equal against the literal shape catches any spurious `required: ["Value"]`
+        // alongside the rest of the wrapper's wire form.
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/positive-int-entities/{id}", method: "patch"));
         var nullableValue = Resolve(doc, UnwrapNullableProperty(Property(body, "nullableValue"), Version));
 
-        Assert.Equal("object", StringOrNull(nullableValue, "type"));
-        Assert.True(nullableValue.TryGetProperty("properties", out var props));
-        Assert.True(props.TryGetProperty("Value", out var inner));
-
-        AssertInlineSchema(inner);
-        Assert.Equal("integer", StringOrNull(inner, "type"));
-
-        // Value is not listed under `required` — that's how the converter
-        // accepts `{}` as the None case.
-        var required = nullableValue.TryGetProperty("required", out var r)
-            ? r.EnumerateArray().Select(e => e.GetString()).ToArray()
-            : [];
-        Assert.DoesNotContain("Value", required);
+        AssertJsonEquals(nullableValue, Version == OpenApiVersion.V3_1
+            ? """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","exclusiveMinimum":0}}}"""
+            : """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}}}""");
     }
 
     [Fact]
@@ -47,13 +38,9 @@ public abstract partial class OpenApiDocumentTestsBase
         var body = FollowRef(doc, RequestSchema(doc, "/nested-strong-types"));
         var maybe = Resolve(doc, Property(body, "maybePositiveInt"));
 
-        Assert.Equal("object", StringOrNull(maybe, "type"));
-
-        var inner = maybe.GetProperty("properties").GetProperty("Value");
-        AssertInlineSchema(inner);
-        Assert.Equal("integer", StringOrNull(inner, "type"));
-        Assert.Equal("int32", StringOrNull(inner, "format"));
-        AssertExclusiveLowerBound(inner, 0m, Version);
+        AssertJsonEquals(maybe, Version == OpenApiVersion.V3_1
+            ? """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","exclusiveMinimum":0}}}"""
+            : """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}}}""");
     }
 
     [Fact]
@@ -63,12 +50,7 @@ public abstract partial class OpenApiDocumentTestsBase
         var body = FollowRef(doc, RequestSchema(doc, "/nested-strong-types"));
         var maybe = Resolve(doc, Property(body, "maybeNonEmptyString"));
 
-        Assert.Equal("object", StringOrNull(maybe, "type"));
-
-        var inner = maybe.GetProperty("properties").GetProperty("Value");
-        AssertInlineSchema(inner);
-        Assert.Equal("string", StringOrNull(inner, "type"));
-        Assert.Equal(1, IntOrNull(inner, "minLength"));
+        AssertJsonEquals(maybe, """{"type":"object","properties":{"Value":{"type":"string","minLength":1}}}""");
     }
 
     [Fact]
@@ -78,17 +60,7 @@ public abstract partial class OpenApiDocumentTestsBase
         var body = FollowRef(doc, RequestSchema(doc, "/nested-strong-types"));
         var maybe = Resolve(doc, Property(body, "maybeNonEmptyStringArray"));
 
-        Assert.Equal("object", StringOrNull(maybe, "type"));
-
-        var inner = maybe.GetProperty("properties").GetProperty("Value");
-        AssertInlineSchema(inner);
-        Assert.Equal("array", StringOrNull(inner, "type"));
-        Assert.Equal(1, IntOrNull(inner, "minItems"));
-
-        var items = inner.GetProperty("items");
-        AssertInlineSchema(items);
-        Assert.Equal("string", StringOrNull(items, "type"));
-        Assert.Equal(1, IntOrNull(items, "minLength"));
+        AssertJsonEquals(maybe, """{"type":"object","properties":{"Value":{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}}}""");
     }
 
     [Fact]
@@ -103,12 +75,8 @@ public abstract partial class OpenApiDocumentTestsBase
         Assert.Equal(1, IntOrNull(array, "minItems"));
 
         var maybe = Resolve(doc, array.GetProperty("items"));
-        Assert.Equal("object", StringOrNull(maybe, "type"));
-
-        var inner = maybe.GetProperty("properties").GetProperty("Value");
-        AssertInlineSchema(inner);
-        Assert.Equal("integer", StringOrNull(inner, "type"));
-        Assert.Equal("int32", StringOrNull(inner, "format"));
-        AssertExclusiveLowerBound(inner, 0m, Version);
+        AssertJsonEquals(maybe, Version == OpenApiVersion.V3_1
+            ? """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","exclusiveMinimum":0}}}"""
+            : """{"type":"object","properties":{"Value":{"type":"integer","format":"int32","minimum":0,"exclusiveMinimum":true}}}""");
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -257,8 +257,7 @@ public abstract partial class OpenApiDocumentTestsBase
         AssertJsonEquals(properties.GetProperty("Title"), """{"type":"string","minLength":0,"maxLength":50}""");
         AssertJsonEquals(properties.GetProperty("Description"), """{"type":"string","minLength":0,"maxLength":200}""");
 
-        var isActive = properties.GetProperty("IsActive");
-        Assert.Equal("boolean", isActive.GetProperty("type").GetString());
+        AssertJsonEquals(properties.GetProperty("IsActive"), """{"type":"boolean"}""");
 
         var age = properties.GetProperty("Age");
         AssertJsonEquals(age, IsPlainIntFormSchemaMissingType

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -202,24 +202,21 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PlainString_With_StringLength_Carries_MaxLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty("PlainName");
-        AssertJsonEquals(schema, """{"type":"string","minLength":0,"maxLength":50}""");
+        AssertSchema(formSchema, "PlainName", """{"type":"string","minLength":0,"maxLength":50}""");
     }
 
     [Fact]
     public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = formSchema.GetProperty("properties").GetProperty("Name");
-        AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
+        AssertSchema(formSchema, "Name", """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
     [Fact]
     public async Task FromForm_PlainInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty("PlainCount");
-        AssertJsonEquals(schema, IsPlainIntFormSchemaMissingType
+        AssertSchema(formSchema, "PlainCount", IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":5,"maximum":100}"""
                 : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":5,"maximum":100}"""
@@ -230,8 +227,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = formSchema.GetProperty("properties").GetProperty("Count");
-        AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
+        AssertSchema(formSchema, "Count", """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
     // ── Diverse form-body shapes ─────────────────────────────────────────
@@ -252,15 +248,10 @@ public abstract partial class OpenApiDocumentTestsBase
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-simple-types");
         AssertFormBodyHasObjectShape(formSchema, "Title", "Age", "IsActive", "Description");
 
-        var properties = formSchema.GetProperty("properties");
-
-        AssertJsonEquals(properties.GetProperty("Title"), """{"type":"string","minLength":0,"maxLength":50}""");
-        AssertJsonEquals(properties.GetProperty("Description"), """{"type":"string","minLength":0,"maxLength":200}""");
-
-        AssertJsonEquals(properties.GetProperty("IsActive"), """{"type":"boolean"}""");
-
-        var age = properties.GetProperty("Age");
-        AssertJsonEquals(age, IsPlainIntFormSchemaMissingType
+        AssertSchema(formSchema, "Title", """{"type":"string","minLength":0,"maxLength":50}""");
+        AssertSchema(formSchema, "Description", """{"type":"string","minLength":0,"maxLength":200}""");
+        AssertSchema(formSchema, "IsActive", """{"type":"boolean"}""");
+        AssertSchema(formSchema, "Age", IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":0,"maximum":150}"""
                 : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":0,"maximum":150}"""
@@ -273,16 +264,12 @@ public abstract partial class OpenApiDocumentTestsBase
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-all-wrappers");
         AssertFormBodyHasObjectShape(formSchema, "Code", "Website", "Description", "Quantity", "Contact", "Losses");
 
-        var properties = formSchema.GetProperty("properties");
-
-        AssertJsonEquals(properties.GetProperty("Code"), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}-\\d{4}$"}""");
-        AssertJsonEquals(properties.GetProperty("Website"), """{"type":"string","minLength":1,"format":"uri"}""");
-        AssertJsonEquals(properties.GetProperty("Description"), """{"type":"string","minLength":1,"maxLength":200}""");
-        AssertJsonEquals(properties.GetProperty("Quantity"), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
-
-        AssertEmailSchema(properties.GetProperty("Contact"));
-
-        AssertJsonEquals(properties.GetProperty("Losses"), Version == OpenApiVersion.V3_1
+        AssertSchema(formSchema, "Code", """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}-\\d{4}$"}""");
+        AssertSchema(formSchema, "Website", """{"type":"string","minLength":1,"format":"uri"}""");
+        AssertSchema(formSchema, "Description", """{"type":"string","minLength":1,"maxLength":200}""");
+        AssertSchema(formSchema, "Quantity", """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+        AssertFormPropertyEmailSchema(formSchema, "Contact");
+        AssertSchema(formSchema, "Losses", Version == OpenApiVersion.V3_1
             ? """{"type":"array","minItems":2,"items":{"type":"number","format":"double","exclusiveMaximum":0}}"""
             : """{"type":"array","minItems":2,"items":{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}}""");
     }
@@ -315,19 +302,15 @@ public abstract partial class OpenApiDocumentTestsBase
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-mixed");
         AssertFormBodyHasObjectShape(formSchema, "Title", "Code", "Quantity", "Stock", "ContactEmail", "Tags");
 
-        var properties = formSchema.GetProperty("properties");
-
-        AssertJsonEquals(properties.GetProperty("Title"), """{"type":"string","minLength":0,"maxLength":100}""");
-        AssertJsonEquals(properties.GetProperty("Code"), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}$"}""");
-
-        AssertJsonEquals(properties.GetProperty("Quantity"), IsPlainIntFormSchemaMissingType
+        AssertSchema(formSchema, "Title", """{"type":"string","minLength":0,"maxLength":100}""");
+        AssertSchema(formSchema, "Code", """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}$"}""");
+        AssertSchema(formSchema, "Quantity", IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":1,"maximum":1000}"""
                 : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":1,"maximum":1000}"""
             : """{"type":"integer","format":"int32","minimum":1,"maximum":1000}""");
-
-        AssertJsonEquals(properties.GetProperty("Stock"), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
-        AssertEmailSchema(properties.GetProperty("ContactEmail"));
-        AssertJsonEquals(properties.GetProperty("Tags"), """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
+        AssertSchema(formSchema, "Stock", """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+        AssertFormPropertyEmailSchema(formSchema, "ContactEmail");
+        AssertSchema(formSchema, "Tags", """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -128,73 +128,78 @@ public abstract partial class OpenApiDocumentTestsBase
 
     // ── [FromForm] ───────────────────────────────────────────────────────
 
-    // BindingProbeFormRequest declaration order:
-    //   0: Name           (NonEmptyString)
-    //   1: NullableName   (NonEmptyString?)
-    //   2: Count          (Positive<int>)
-    //   3: NullableCount  (Positive<int>?)
-    //   4: Digit          (Digit)
-    //   5: Tags           (NonEmptyEnumerable<NonEmptyString>)
-    //   6: Email          (Email)
-    //   7: NullableEmail  (Email?)
-    // Swashbuckle's broken allOf keeps most fields in declaration order,
-    // but puts the collection-shaped Tags field at the end as an object
-    // entry; those tests pass the observed allOf index explicitly.
-
     [Fact]
     public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyStringSchema(formSchema, "name", allOfIndex: 0, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "name");
     }
 
     [Fact]
     public async Task FromForm_NullableNonEmptyString_RendersAsString_WithMinLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyStringSchema(formSchema, "nullableName", allOfIndex: 1, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "nullableName");
     }
 
     [Fact]
     public async Task FromForm_PositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveIntSchema(formSchema, "count", allOfIndex: 2, IsFormPropertiesSchemaBroken, Version);
+        AssertFormPropertyPositiveIntSchema(formSchema, "count", Version);
     }
 
     [Fact]
     public async Task FromForm_NullablePositiveInt_RendersAsExclusivePositive()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveIntSchema(formSchema, "nullableCount", allOfIndex: 3, IsFormPropertiesSchemaBroken, Version);
+        AssertFormPropertyPositiveIntSchema(formSchema, "nullableCount", Version);
     }
 
     [Fact]
     public async Task FromForm_Digit_RendersAsInteger_WithZeroToNineBounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyDigitSchema(formSchema, "digit", allOfIndex: 4, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyDigitSchema(formSchema, "digit");
     }
 
     [Fact]
     public async Task FromForm_NonEmptyEnumerable_RendersAsArray_WithMinItems_And_StringItems()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(formSchema, "tags", allOfIndex: 7, IsFormPropertiesSchemaBroken);
+        AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(formSchema, "tags");
     }
 
     [Fact]
     public async Task FromForm_Email_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "email", allOfIndex: 5, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "email", IsEmailStringFormatBroken);
     }
 
     [Fact]
     public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", allOfIndex: 6, IsFormPropertiesSchemaBroken, IsEmailStringFormatBroken);
+        AssertFormPropertyEmailSchema(formSchema, "nullableEmail", IsEmailStringFormatBroken);
+    }
+
+    /// <summary>
+    /// The all-wrapper form body schema is a regular
+    /// <c>{ type: object, properties: { … } }</c> shape with one entry per
+    /// field. Swashbuckle's stock form-body assembler emits a nameless
+    /// <c>{ allOf: [&lt;each&gt;] }</c> instead whenever every field is
+    /// component-typed; <c>NonBodyStrongTypeOperationFilter</c> rebuilds
+    /// the properties map. This pins the aggregate shape so a regression
+    /// on either pipeline shows up as a missing property rather than as
+    /// per-field assertions silently looking up the wrong slot.
+    /// </summary>
+    [Fact]
+    public async Task FromForm_AllWrappers_FormBody_IsObjectWithPropertiesMap()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
+        AssertFormBodyHasObjectShape(formSchema,
+            "Name", "NullableName", "Count", "NullableCount", "Digit", "Tags", "Email", "NullableEmail");
     }
 
     // ── Caller annotations on non-body slots ─────────────────────────────
@@ -251,7 +256,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "Name", allOfIndex: 0);
+        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("Name"));
         AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
@@ -271,19 +276,104 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = ResolveAnnotatedFormWrapperProperty(formSchema, "Count", allOfIndex: 1);
+        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("Count"));
         AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
-    private JsonElement ResolveAnnotatedFormWrapperProperty(JsonElement formSchema, string propertyName, int allOfIndex)
-    {
-        // For the wrappers-only annotated form, Swashbuckle emits the
-        // broken `{allOf:[<each>]}` shape (every field is component-typed),
-        // while Microsoft emits a proper properties map.
-        if (IsFormPropertiesSchemaBroken)
-            return formSchema.GetProperty("allOf")[allOfIndex];
+    // ── Diverse form-body shapes ─────────────────────────────────────────
+    // The aggregate-shape test above pins the all-wrapper form body. The
+    // three tests below exercise the form-body reshape on more diverse
+    // payloads: a primitives-only form (Swashbuckle emits a clean
+    // properties map natively), an all-wrappers form where multiple
+    // NonEmptyStrings each carry a different annotation
+    // (RegularExpression, Url, StringLength) alongside Email,
+    // Positive<int>, and a NonEmptyEnumerable of a numeric wrapper, and a
+    // mixed form combining both kinds with caller annotations on each.
+    // Each test pins every property's full schema so a regression on
+    // either pipeline shows up as a per-property diff.
 
-        return formSchema.GetProperty("properties").GetProperty(FormPropertyName(propertyName));
+    [Fact]
+    public async Task FromForm_SimpleTypes_FormBody_RendersAllPropertiesWithTheirAnnotations()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-simple-types");
+        AssertFormBodyHasObjectShape(formSchema, "Title", "Age", "IsActive", "Description");
+
+        var properties = formSchema.GetProperty("properties");
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Title")), """{"type":"string","minLength":0,"maxLength":50}""");
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Description")), """{"type":"string","minLength":0,"maxLength":200}""");
+
+        var isActive = properties.GetProperty(FormPropertyName("IsActive"));
+        Assert.Equal("boolean", isActive.GetProperty("type").GetString());
+
+        var age = properties.GetProperty(FormPropertyName("Age"));
+        AssertJsonEquals(age, IsPlainIntFormSchemaMissingType
+            ? Version == OpenApiVersion.V3_1
+                ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":0,"maximum":150}"""
+                : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":0,"maximum":150}"""
+            : """{"type":"integer","format":"int32","minimum":0,"maximum":150}""");
+    }
+
+    [Fact]
+    public async Task FromForm_AllStrongTypes_FormBody_RendersEveryWrapperWithItsAnnotation()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-all-wrappers");
+        AssertFormBodyHasObjectShape(formSchema, "Code", "Website", "Description", "Quantity", "Contact", "Losses");
+
+        var properties = formSchema.GetProperty("properties");
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Code")), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}-\\d{4}$"}""");
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Website")), """{"type":"string","minLength":1,"format":"uri"}""");
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Description")), """{"type":"string","minLength":1,"maxLength":200}""");
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Quantity")), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+
+        AssertEmailSchema(properties.GetProperty(FormPropertyName("Contact")), IsEmailStringFormatBroken);
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Losses")), Version switch
+        {
+            OpenApiVersion.V3_0 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}}""",
+            OpenApiVersion.V3_1 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","exclusiveMaximum":0}}""",
+            _ => throw new ArgumentOutOfRangeException(nameof(Version), Version, null),
+        });
+    }
+
+    [Fact]
+    public async Task FromForm_Mixed_FormBody_RendersBothPrimitivesAndWrappersWithAnnotations()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-mixed");
+        AssertFormBodyHasObjectShape(formSchema, "Title", "Code", "Quantity", "Stock", "ContactEmail", "Tags");
+
+        var properties = formSchema.GetProperty("properties");
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Title")), """{"type":"string","minLength":0,"maxLength":100}""");
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Code")), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}$"}""");
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Quantity")), IsPlainIntFormSchemaMissingType
+            ? Version == OpenApiVersion.V3_1
+                ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":1,"maximum":1000}"""
+                : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":1,"maximum":1000}"""
+            : """{"type":"integer","format":"int32","minimum":1,"maximum":1000}""");
+
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Stock")), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+        AssertEmailSchema(properties.GetProperty(FormPropertyName("ContactEmail")), IsEmailStringFormatBroken);
+        AssertJsonEquals(properties.GetProperty(FormPropertyName("Tags")), """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
+    }
+
+    private static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
+    {
+        Assert.False(formSchema.TryGetProperty("allOf", out _), "form body should not be wrapped in a top-level allOf");
+        Assert.False(formSchema.TryGetProperty("$ref", out _), "form body should be inlined, not a $ref");
+        Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
+        Assert.Equal(JsonValueKind.Object, properties.ValueKind);
+
+        var actualNames = properties.EnumerateObject()
+            .Select(p => p.Name)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var expected = expectedPropertyNames
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(expected, actualNames, StringComparer.OrdinalIgnoreCase);
     }
 
     protected virtual string FormPropertyName(string clrPropertyName) => clrPropertyName;

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -282,12 +282,9 @@ public abstract partial class OpenApiDocumentTestsBase
 
         AssertEmailSchema(properties.GetProperty("Contact"));
 
-        AssertJsonEquals(properties.GetProperty("Losses"), Version switch
-        {
-            OpenApiVersion.V3_0 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}}""",
-            OpenApiVersion.V3_1 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","exclusiveMaximum":0}}""",
-            _ => throw new ArgumentOutOfRangeException(nameof(Version), Version, null),
-        });
+        AssertJsonEquals(properties.GetProperty("Losses"), Version == OpenApiVersion.V3_1
+            ? """{"type":"array","minItems":2,"items":{"type":"number","format":"double","exclusiveMaximum":0}}"""
+            : """{"type":"array","minItems":2,"items":{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}}""");
     }
 
     /// <summary>

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -334,23 +334,4 @@ public abstract partial class OpenApiDocumentTestsBase
         AssertEmailSchema(properties.GetProperty("ContactEmail"));
         AssertJsonEquals(properties.GetProperty("Tags"), """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
     }
-
-    private static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
-    {
-        Assert.False(formSchema.TryGetProperty("allOf", out _), "form body should not be wrapped in a top-level allOf");
-        Assert.False(formSchema.TryGetProperty("anyOf", out _), "form body should not be wrapped in a top-level anyOf");
-        Assert.False(formSchema.TryGetProperty("oneOf", out _), "form body should not be wrapped in a top-level oneOf");
-        Assert.False(formSchema.TryGetProperty("$ref", out _), "form body should be inlined, not a $ref");
-        Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
-        Assert.Equal(JsonValueKind.Object, properties.ValueKind);
-
-        var actualNames = properties.EnumerateObject()
-            .Select(p => p.Name)
-            .Order(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        var expected = expectedPropertyNames
-            .Order(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        Assert.Equal(expected, actualNames, StringComparer.OrdinalIgnoreCase);
-    }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.NonBodyBinding.cs
@@ -128,78 +128,32 @@ public abstract partial class OpenApiDocumentTestsBase
 
     // ── [FromForm] ───────────────────────────────────────────────────────
 
-    [Fact]
-    public async Task FromForm_NonEmptyString_RendersAsString_WithMinLength()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyStringSchema(formSchema, "name");
-    }
-
-    [Fact]
-    public async Task FromForm_NullableNonEmptyString_RendersAsString_WithMinLength()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyStringSchema(formSchema, "nullableName");
-    }
-
-    [Fact]
-    public async Task FromForm_PositiveInt_RendersAsExclusivePositive()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveIntSchema(formSchema, "count", Version);
-    }
-
-    [Fact]
-    public async Task FromForm_NullablePositiveInt_RendersAsExclusivePositive()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyPositiveIntSchema(formSchema, "nullableCount", Version);
-    }
-
-    [Fact]
-    public async Task FromForm_Digit_RendersAsInteger_WithZeroToNineBounds()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyDigitSchema(formSchema, "digit");
-    }
-
-    [Fact]
-    public async Task FromForm_NonEmptyEnumerable_RendersAsArray_WithMinItems_And_StringItems()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(formSchema, "tags");
-    }
-
-    [Fact]
-    public async Task FromForm_Email_RendersAsString_WithEmailFormat()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "email");
-    }
-
-    [Fact]
-    public async Task FromForm_NullableEmail_RendersAsString_WithEmailFormat()
-    {
-        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
-        AssertFormPropertyEmailSchema(formSchema, "nullableEmail");
-    }
-
     /// <summary>
-    /// The all-wrapper form body schema is a regular
-    /// <c>{ type: object, properties: { … } }</c> shape with one entry per
-    /// field. Swashbuckle's stock form-body assembler emits a nameless
-    /// <c>{ allOf: [&lt;each&gt;] }</c> instead whenever every field is
-    /// component-typed; <c>NonBodyStrongTypeOperationFilter</c> rebuilds
-    /// the properties map. This pins the aggregate shape so a regression
-    /// on either pipeline shows up as a missing property rather than as
-    /// per-field assertions silently looking up the wrong slot.
+    /// Pins the aggregate form-body shape and every per-field schema for
+    /// an all-wrapper form. Swashbuckle's stock form-body assembler emits
+    /// a nameless <c>{ allOf: [&lt;each&gt;] }</c> whenever every field
+    /// is component-typed; <c>NonBodyStrongTypeOperationFilter</c>
+    /// rebuilds it as <c>{ type: object, properties: { … } }</c>.
+    /// Asserting both the structural shape and each property's wire form
+    /// in the same test catches a regression in the reshape pass (a
+    /// missing property surfaces as a slot lookup failure) and a
+    /// regression in the per-type painters (a slot's contents differ).
     /// </summary>
     [Fact]
-    public async Task FromForm_AllWrappers_FormBody_IsObjectWithPropertiesMap()
+    public async Task FromForm_AllWrappers_FormBody_RendersObjectWithEveryPropertyInItsWireShape()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form");
         AssertFormBodyHasObjectShape(formSchema,
             "Name", "NullableName", "Count", "NullableCount", "Digit", "Tags", "Email", "NullableEmail");
+
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "Name");
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "NullableName");
+        AssertFormPropertyPositiveIntSchema(formSchema, "Count", Version);
+        AssertFormPropertyPositiveIntSchema(formSchema, "NullableCount", Version);
+        AssertFormPropertyDigitSchema(formSchema, "Digit");
+        AssertFormPropertyNonEmptyEnumerableOfNonEmptyStringSchema(formSchema, "Tags");
+        AssertFormPropertyEmailSchema(formSchema, "Email");
+        AssertFormPropertyEmailSchema(formSchema, "NullableEmail");
     }
 
     // ── Caller annotations on non-body slots ─────────────────────────────
@@ -248,7 +202,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PlainString_With_StringLength_Carries_MaxLength()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainName"));
+        var schema = formSchema.GetProperty("properties").GetProperty("PlainName");
         AssertJsonEquals(schema, """{"type":"string","minLength":0,"maxLength":50}""");
     }
 
@@ -256,7 +210,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_NonEmptyString_With_StringLength_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("Name"));
+        var schema = formSchema.GetProperty("properties").GetProperty("Name");
         AssertJsonEquals(schema, """{"type":"string","minLength":1,"maxLength":50}""");
     }
 
@@ -264,7 +218,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PlainInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated-plain");
-        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("PlainCount"));
+        var schema = formSchema.GetProperty("properties").GetProperty("PlainCount");
         AssertJsonEquals(schema, IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":5,"maximum":100}"""
@@ -276,7 +230,7 @@ public abstract partial class OpenApiDocumentTestsBase
     public async Task FromForm_PositiveInt_With_Range_Carries_Both_Bounds()
     {
         var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-annotated");
-        var schema = formSchema.GetProperty("properties").GetProperty(FormPropertyName("Count"));
+        var schema = formSchema.GetProperty("properties").GetProperty("Count");
         AssertJsonEquals(schema, """{"type":"integer","format":"int32","minimum":5,"maximum":100}""");
     }
 
@@ -300,13 +254,13 @@ public abstract partial class OpenApiDocumentTestsBase
 
         var properties = formSchema.GetProperty("properties");
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Title")), """{"type":"string","minLength":0,"maxLength":50}""");
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Description")), """{"type":"string","minLength":0,"maxLength":200}""");
+        AssertJsonEquals(properties.GetProperty("Title"), """{"type":"string","minLength":0,"maxLength":50}""");
+        AssertJsonEquals(properties.GetProperty("Description"), """{"type":"string","minLength":0,"maxLength":200}""");
 
-        var isActive = properties.GetProperty(FormPropertyName("IsActive"));
+        var isActive = properties.GetProperty("IsActive");
         Assert.Equal("boolean", isActive.GetProperty("type").GetString());
 
-        var age = properties.GetProperty(FormPropertyName("Age"));
+        var age = properties.GetProperty("Age");
         AssertJsonEquals(age, IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":0,"maximum":150}"""
@@ -322,19 +276,41 @@ public abstract partial class OpenApiDocumentTestsBase
 
         var properties = formSchema.GetProperty("properties");
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Code")), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}-\\d{4}$"}""");
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Website")), """{"type":"string","minLength":1,"format":"uri"}""");
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Description")), """{"type":"string","minLength":1,"maxLength":200}""");
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Quantity")), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+        AssertJsonEquals(properties.GetProperty("Code"), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}-\\d{4}$"}""");
+        AssertJsonEquals(properties.GetProperty("Website"), """{"type":"string","minLength":1,"format":"uri"}""");
+        AssertJsonEquals(properties.GetProperty("Description"), """{"type":"string","minLength":1,"maxLength":200}""");
+        AssertJsonEquals(properties.GetProperty("Quantity"), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
 
-        AssertEmailSchema(properties.GetProperty(FormPropertyName("Contact")));
+        AssertEmailSchema(properties.GetProperty("Contact"));
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Losses")), Version switch
+        AssertJsonEquals(properties.GetProperty("Losses"), Version switch
         {
             OpenApiVersion.V3_0 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","maximum":0,"exclusiveMaximum":true}}""",
             OpenApiVersion.V3_1 => """{"type":"array","minItems":2,"items":{"type":"number","format":"double","exclusiveMaximum":0}}""",
             _ => throw new ArgumentOutOfRangeException(nameof(Version), Version, null),
         });
+    }
+
+    /// <summary>
+    /// <see cref="Maybe{T}"/> bound from a non-body slot via
+    /// <c>StrongTypes.AspNetCore</c>'s model binder reads a single raw
+    /// form-data value, parses it as <typeparamref name="T"/>, and wraps
+    /// the result in <c>Some</c>/<c>None</c>. The wire is therefore the
+    /// inner <typeparamref name="T"/> — not the body-side
+    /// <c>{"Value":&lt;T&gt;}</c> wrapper object the JSON converter
+    /// emits. Both pipelines must paint the inner shape on every
+    /// <c>[FromForm]</c> <see cref="Maybe{T}"/> property; recursion
+    /// matches what we already do for <see cref="NonEmptyEnumerable{T}"/>.
+    /// </summary>
+    [Fact]
+    public async Task FromForm_Maybe_FormBody_RendersInnerWireShapeForEachProperty()
+    {
+        var formSchema = FormRequestSchema(await GetDocumentAsync(), "/binding-probe/form-maybe");
+        AssertFormBodyHasObjectShape(formSchema, "Greeting", "Quantity", "ContactEmail");
+
+        AssertFormPropertyNonEmptyStringSchema(formSchema, "Greeting");
+        AssertFormPropertyPositiveIntSchema(formSchema, "Quantity", Version);
+        AssertFormPropertyEmailSchema(formSchema, "ContactEmail");
     }
 
     [Fact]
@@ -345,23 +321,25 @@ public abstract partial class OpenApiDocumentTestsBase
 
         var properties = formSchema.GetProperty("properties");
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Title")), """{"type":"string","minLength":0,"maxLength":100}""");
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Code")), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}$"}""");
+        AssertJsonEquals(properties.GetProperty("Title"), """{"type":"string","minLength":0,"maxLength":100}""");
+        AssertJsonEquals(properties.GetProperty("Code"), """{"type":"string","minLength":1,"pattern":"^[A-Z]{3}$"}""");
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Quantity")), IsPlainIntFormSchemaMissingType
+        AssertJsonEquals(properties.GetProperty("Quantity"), IsPlainIntFormSchemaMissingType
             ? Version == OpenApiVersion.V3_1
                 ? """{"pattern":"^-?(?:0|[1-9]\\d*)$","type":["integer","string"],"format":"int32","minimum":1,"maximum":1000}"""
                 : """{"pattern":"^-?(?:0|[1-9]\\d*)$","format":"int32","minimum":1,"maximum":1000}"""
             : """{"type":"integer","format":"int32","minimum":1,"maximum":1000}""");
 
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Stock")), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
-        AssertEmailSchema(properties.GetProperty(FormPropertyName("ContactEmail")));
-        AssertJsonEquals(properties.GetProperty(FormPropertyName("Tags")), """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
+        AssertJsonEquals(properties.GetProperty("Stock"), """{"type":"integer","format":"int32","minimum":1,"maximum":100}""");
+        AssertEmailSchema(properties.GetProperty("ContactEmail"));
+        AssertJsonEquals(properties.GetProperty("Tags"), """{"type":"array","minItems":1,"items":{"type":"string","minLength":1}}""");
     }
 
     private static void AssertFormBodyHasObjectShape(JsonElement formSchema, params string[] expectedPropertyNames)
     {
         Assert.False(formSchema.TryGetProperty("allOf", out _), "form body should not be wrapped in a top-level allOf");
+        Assert.False(formSchema.TryGetProperty("anyOf", out _), "form body should not be wrapped in a top-level anyOf");
+        Assert.False(formSchema.TryGetProperty("oneOf", out _), "form body should not be wrapped in a top-level oneOf");
         Assert.False(formSchema.TryGetProperty("$ref", out _), "form body should be inlined, not a $ref");
         Assert.True(formSchema.TryGetProperty("properties", out var properties), "form body must have a properties map");
         Assert.Equal(JsonValueKind.Object, properties.ValueKind);
@@ -375,6 +353,4 @@ public abstract partial class OpenApiDocumentTestsBase
             .ToArray();
         Assert.Equal(expected, actualNames, StringComparer.OrdinalIgnoreCase);
     }
-
-    protected virtual string FormPropertyName(string clrPropertyName) => clrPropertyName;
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.cs
@@ -45,20 +45,6 @@ public abstract partial class OpenApiDocumentTestsBase(HttpClient client) : IDis
     // the annotation. Each flag is set in the per-pipeline subclass.
     protected virtual bool IsEmailStringFormatBroken => false;
 
-    /// <summary>
-    /// True when the pipeline emits the <c>[FromForm]</c> request-body schema
-    /// as <c>{ "allOf": [&lt;each-property's-schema&gt;] }</c> — i.e. each
-    /// form field's schema is correct, but the field <em>names</em> are
-    /// dropped and there's no top-level <c>properties</c> map. Vanilla
-    /// Swashbuckle does this whenever every form field is component-typed,
-    /// because its form-body assembler doesn't know how to merge $refs into
-    /// a properties map. The broken-path navigates the allOf by declaration
-    /// index and asserts the same per-property shape; the day Swashbuckle
-    /// fixes the assembler the allOf disappears, the assertion fails, and
-    /// this flag must be flipped to <c>false</c>.
-    /// </summary>
-    protected virtual bool IsFormPropertiesSchemaBroken => false;
-
     protected virtual bool IsPlainIntFormSchemaMissingType => true;
 
     private async Task<JsonElement> GetDocumentAsync()

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/SwashbuckleOpenApiDocumentTests.cs
@@ -14,6 +14,5 @@ public sealed class SwashbuckleOpenApiDocumentTests(SwashbuckleTestApiFactory fa
 {
     protected override string DocumentUrl => "/swagger/v1/swagger.json";
     protected override OpenApiVersion Version => OpenApiVersion.V3_0;
-    protected override bool IsFormPropertiesSchemaBroken => true;
     protected override bool IsPlainIntFormSchemaMissingType => false;
 }

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -100,6 +100,15 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
 
     private static IOpenApiSchema PaintSlot(IOpenApiSchema? existing, Type clrType, ApiParameterDescription pd)
     {
+        // Maybe<T> bound from a non-body slot via the StrongTypes.AspNetCore
+        // model binder reads a single raw form-data value and wraps it as
+        // Some/None — the wire is the inner T, not the body-side
+        // {"Value":<T>} wrapper object the JSON converter emits. Unwrap
+        // here so the rest of this pass paints the inner shape and merges
+        // slot annotations against it.
+        if (StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var maybeInner))
+            clrType = maybeInner;
+
         // Mutate the existing schema when possible so any keywords the
         // pipeline already wrote (description, default, caller-applied
         // [StringLength] on the IParsable string overload, …) survive the

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -156,6 +156,17 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
             return true;
         }
 
+        if (StrongTypeSchemaTypes.TryGetNonEmptyEnumerableElement(clrType, out var elementType))
+        {
+            SchemaPaint.ClearWrapperShape(schema);
+            schema.Type = JsonSchemaType.Array;
+            SchemaPaint.TightenMinItems(schema, 1);
+            var itemsSchema = new OpenApiSchema();
+            if (TryPaintWireShape(itemsSchema, elementType))
+                schema.Items = itemsSchema;
+            return true;
+        }
+
         return false;
     }
 

--- a/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
+++ b/src/StrongTypes.OpenApi.Microsoft/Binding/NonBodyStrongTypeOperationTransformer.cs
@@ -64,7 +64,6 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
     {
         if (operation.Parameters is null) return;
         var clrType = ResolveParameterClrType(pd);
-        if (clrType is null) return;
 
         foreach (var p in operation.Parameters)
         {
@@ -80,7 +79,6 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
     {
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
-        if (clrType is null) return;
 
         foreach (var contentType in s_formContentTypes)
         {
@@ -194,11 +192,10 @@ internal sealed class NonBodyStrongTypeOperationTransformer : IOpenApiOperationT
         return [];
     }
 
-    // ApiParameterDescription.Type is the type the model binder reports —
-    // for strong-types that implement IParsable<T>, ASP.NET reports the
-    // string overload's input, hiding the wrapper. ModelMetadata.ModelType
-    // exposes the actual CLR type for both parameter slots and for
-    // properties of a flattened [FromForm] model.
-    private static Type? ResolveParameterClrType(ApiParameterDescription pd)
-        => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
+    // ApiParameterDescription.Type lies for strong types implementing IParsable<T> —
+    // it reports the string overload's input, hiding the wrapper. ModelMetadata.ModelType
+    // exposes the actual CLR type for both parameter slots and for properties of a
+    // flattened [FromForm] model.
+    private static Type ResolveParameterClrType(ApiParameterDescription pd)
+        => pd.ModelMetadata.ModelType;
 }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi;
 using StrongTypes.OpenApi.Core;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -27,8 +26,15 @@ namespace StrongTypes.OpenApi.Swashbuckle;
 /// <see cref="BindingSource.Path"/> / <see cref="BindingSource.Header"/> /
 /// <see cref="BindingSource.Form"/>, and the form path is gated to
 /// <c>multipart/form-data</c> / <c>application/x-www-form-urlencoded</c>.
+///
+/// The form path also reshapes Swashbuckle's <c>{ allOf: [&lt;each-field&gt;] }</c>
+/// request body — emitted whenever every form field is component-typed —
+/// back into a proper <c>{ type: object, properties: { … } }</c> map keyed
+/// by the form-field names from the <see cref="ApiParameterDescription"/>s.
+/// Without that, consumers see a nameless allOf and can't tell which schema
+/// belongs to which field.
 /// </summary>
-public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOperationFilter>? logger = null) : IOperationFilter
+public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
 {
     private static readonly string[] s_formContentTypes =
     [
@@ -41,12 +47,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         var descriptions = context.ApiDescription.ParameterDescriptions;
         if (descriptions is null || descriptions.Count == 0) return;
 
-        // For form bodies that emit the broken `{allOf:[<each-component-field>]}`
-        // shape (every form field is component-typed — see
-        // IsFormPropertiesSchemaBroken in the integration tests), we need to
-        // map allOf entries back to their CLR property by declaration order.
-        // Compute that map once per operation.
-        var formAllOfIndexByProperty = BuildFormAllOfIndexMap(descriptions);
+        ReshapeFormAllOfIntoProperties(operation, descriptions, context.SchemaGenerator, context.SchemaRepository);
 
         foreach (var pd in descriptions)
         {
@@ -60,7 +61,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
             }
             else if (pd.Source == BindingSource.Form)
             {
-                MergeFormPropertyAnnotations(operation, pd, formAllOfIndexByProperty);
+                MergeFormPropertyAnnotations(operation, pd);
             }
         }
     }
@@ -82,7 +83,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         }
     }
 
-    private void MergeFormPropertyAnnotations(OpenApiOperation operation, ApiParameterDescription pd, IReadOnlyDictionary<string, int>? allOfIndexByProperty)
+    private static void MergeFormPropertyAnnotations(OpenApiOperation operation, ApiParameterDescription pd)
     {
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
@@ -93,57 +94,76 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         {
             if (!content.TryGetValue(contentType, out var media)) continue;
             if (media.Schema is not OpenApiSchema formSchema) continue;
+            if (formSchema.Properties is not { Count: > 0 } properties) continue;
+            if (!properties.TryGetValue(pd.Name, out var propSchema)) continue;
 
-            // Modern Swashbuckle path: a proper `properties` map keyed by
-            // the form model property name.
-            if (formSchema.Properties is { Count: > 0 } properties)
-            {
-                if (properties.TryGetValue(pd.Name, out var propSchema))
-                {
-                    properties[pd.Name] = ApplyAnnotations(propSchema, clrType, pd);
-                    return;
-                }
-            }
-
-            // Broken path: form body emits `{allOf:[<each-component-field>]}`
-            // when every field is component-typed. Look the field up by the
-            // index we built from the API description's declaration order.
-            if (formSchema.AllOf is { Count: > 0 } allOf
-                && allOfIndexByProperty is not null
-                && allOfIndexByProperty.TryGetValue(pd.Name, out var index))
-            {
-                if (!IsExpectedBrokenFormAllOfTarget(allOf, allOfIndexByProperty.Count, pd.Name, index))
-                    return;
-
-                allOf[index] = ApplyAnnotations(allOf[index], clrType, pd);
-            }
+            properties[pd.Name] = ApplyAnnotations(propSchema, clrType, pd);
+            return;
         }
     }
 
-    private bool IsExpectedBrokenFormAllOfTarget(IList<IOpenApiSchema> allOf, int expectedCount, string propertyName, int index)
+    /// <summary>
+    /// Replaces Swashbuckle's all-component <c>{ allOf: [&lt;each-field&gt;] }</c>
+    /// form-body schema (and the hybrid <c>{ allOf: [wrappers, {primitives}] }</c>
+    /// shape Swashbuckle emits for mixed forms) with a flat
+    /// <c>{ type: object, properties: { … } }</c> map keyed by each form
+    /// field's <see cref="ApiParameterDescription.Name"/>. Per-property
+    /// schemas come from the schema generator: wrappers stay as
+    /// <c>$ref</c>s to their components (or inline schemas for
+    /// collection-shaped wrappers Swashbuckle inlines anyway), and
+    /// primitives are generated with their <see cref="MemberInfo"/> so
+    /// Swashbuckle's own data-annotation pipeline applies
+    /// <c>[StringLength]</c>, <c>[Range]</c>, etc. directly to the
+    /// emitted schema.
+    /// </summary>
+    private static void ReshapeFormAllOfIntoProperties(
+        OpenApiOperation operation,
+        IList<ApiParameterDescription> descriptions,
+        ISchemaGenerator schemaGenerator,
+        SchemaRepository schemaRepository)
     {
-        if (allOf.Count != expectedCount)
-        {
-            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the form allOf count ({ActualCount}) did not match the strong-type form field count ({ExpectedCount}).",
-                propertyName, allOf.Count, expectedCount);
-            return false;
-        }
+        if (operation.RequestBody?.Content is not { } content) return;
 
-        if (index < 0 || index >= allOf.Count)
+        foreach (var contentType in s_formContentTypes)
         {
-            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the computed allOf index ({Index}) was outside the form allOf count ({ActualCount}).",
-                propertyName, index, allOf.Count);
-            return false;
-        }
+            if (!content.TryGetValue(contentType, out var media)) continue;
+            if (media.Schema is not OpenApiSchema formSchema) continue;
+            if (formSchema.AllOf is not { Count: > 0 }) continue;
+            if (formSchema.Properties is { Count: > 0 }) continue;
 
-        if (allOf[index] is not OpenApiSchemaReference)
-        {
-            logger?.LogError("StrongTypes form annotation merge skipped for property '{PropertyName}' because the target form allOf entry at index {Index} was not a reference schema.",
-                propertyName, index);
-            return false;
-        }
+            var properties = new Dictionary<string, IOpenApiSchema>(StringComparer.Ordinal);
+            foreach (var pd in descriptions)
+            {
+                if (pd.Source != BindingSource.Form) continue;
+                var clrType = ResolveParameterClrType(pd);
+                if (clrType is null) continue;
 
-        return true;
+                // For primitives, hand Swashbuckle the form record's
+                // PropertyInfo so its generator surfaces caller annotations
+                // (`[StringLength]`, `[Range]`, …) directly. For wrappers
+                // we want a clean $ref — `MergeFormPropertyAnnotations`
+                // layers slot annotations on top via WrapperAnnotationApplier,
+                // and passing MemberInfo here would risk double-emission
+                // without the inline marker the inliner needs.
+                MemberInfo? memberInfo = null;
+                if (!StrongTypeSchemaTypes.IsInlineable(clrType))
+                    memberInfo = ResolveFormPropertyMember(pd);
+
+                properties[pd.Name] = schemaGenerator.GenerateSchema(clrType, schemaRepository, memberInfo);
+            }
+
+            if (properties.Count == 0) continue;
+
+            formSchema.Properties = properties;
+            formSchema.AllOf = null;
+            formSchema.Type ??= JsonSchemaType.Object;
+        }
+    }
+
+    private static MemberInfo? ResolveFormPropertyMember(ApiParameterDescription pd)
+    {
+        if (pd.ModelMetadata is not { ContainerType: { } containerType, PropertyName: { } propertyName }) return null;
+        return containerType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
     }
 
     private static IOpenApiSchema ApplyAnnotations(IOpenApiSchema? slot, Type clrType, ApiParameterDescription pd)
@@ -175,20 +195,6 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         }
 
         return slot ?? new OpenApiSchema();
-    }
-
-    private static IReadOnlyDictionary<string, int>? BuildFormAllOfIndexMap(IList<ApiParameterDescription> descriptions)
-    {
-        Dictionary<string, int>? map = null;
-        var index = 0;
-        foreach (var pd in descriptions)
-        {
-            if (pd.Source != BindingSource.Form) continue;
-            if (!StrongTypeSchemaTypes.IsInlineable(ResolveParameterClrType(pd))) continue;
-            map ??= new Dictionary<string, int>(StringComparer.Ordinal);
-            map[pd.Name] = index++;
-        }
-        return map;
     }
 
     private static IReadOnlyList<Attribute> GetSlotAttributes(ApiParameterDescription pd)

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -146,7 +146,7 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
                 var clrType = ResolveParameterClrType(pd);
                 if (clrType is null)
                 {
-                    logger?.LogWarning(
+                    logger?.LogError(
                         "StrongTypes form-body reshape skipped property '{PropertyName}' on operation '{OperationId}' because no CLR type could be resolved from its ApiParameterDescription. The emitted form schema may be incomplete.",
                         pd.Name, operation.OperationId ?? "(unnamed)");
                     continue;
@@ -179,14 +179,14 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
 
             if (properties.Count != formParamCount)
             {
-                logger?.LogWarning(
+                logger?.LogError(
                     "StrongTypes form-body reshape on operation '{OperationId}' resolved {ResolvedCount} of {TotalCount} form parameters; the rest will be missing from the emitted properties map.",
                     operation.OperationId ?? "(unnamed)", properties.Count, formParamCount);
             }
 
             if (allOf.Count > formParamCount)
             {
-                logger?.LogWarning(
+                logger?.LogError(
                     "StrongTypes form-body reshape on operation '{OperationId}' replaced an allOf with {AllOfCount} entries using only {FormParamCount} form parameters; entries beyond the parameter set are dropped. This usually means Swashbuckle assembled the form body in a shape we don't recognise.",
                     operation.OperationId ?? "(unnamed)", allOf.Count, formParamCount);
             }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi;
 using StrongTypes.OpenApi.Core;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -34,7 +35,7 @@ namespace StrongTypes.OpenApi.Swashbuckle;
 /// Without that, consumers see a nameless allOf and can't tell which schema
 /// belongs to which field.
 /// </summary>
-public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
+public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOperationFilter>? logger = null) : IOperationFilter
 {
     private static readonly string[] s_formContentTypes =
     [
@@ -47,7 +48,8 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
         var descriptions = context.ApiDescription.ParameterDescriptions;
         if (descriptions is null || descriptions.Count == 0) return;
 
-        ReshapeFormAllOfIntoProperties(operation, descriptions, context.SchemaGenerator, context.SchemaRepository);
+        ReshapeFormAllOfIntoProperties(operation, descriptions, context.SchemaGenerator, context.SchemaRepository, logger);
+        ReshapeMaybeFormPropertiesIntoInnerWireShape(operation, descriptions, context.SchemaGenerator, context.SchemaRepository);
 
         foreach (var pd in descriptions)
         {
@@ -88,6 +90,8 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
         if (clrType is null) return;
+        if (StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var maybeInner))
+            clrType = maybeInner;
         if (GetSlotAttributes(pd).Count == 0) return;
 
         foreach (var contentType in s_formContentTypes)
@@ -120,7 +124,8 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
         OpenApiOperation operation,
         IList<ApiParameterDescription> descriptions,
         ISchemaGenerator schemaGenerator,
-        SchemaRepository schemaRepository)
+        SchemaRepository schemaRepository,
+        ILogger? logger)
     {
         if (operation.RequestBody?.Content is not { } content) return;
 
@@ -128,15 +133,33 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
         {
             if (!content.TryGetValue(contentType, out var media)) continue;
             if (media.Schema is not OpenApiSchema formSchema) continue;
-            if (formSchema.AllOf is not { Count: > 0 }) continue;
+            if (formSchema.AllOf is not { Count: > 0 } allOf) continue;
             if (formSchema.Properties is { Count: > 0 }) continue;
 
+            var formParamCount = 0;
             var properties = new Dictionary<string, IOpenApiSchema>(StringComparer.Ordinal);
             foreach (var pd in descriptions)
             {
                 if (pd.Source != BindingSource.Form) continue;
+                formParamCount++;
+
                 var clrType = ResolveParameterClrType(pd);
-                if (clrType is null) continue;
+                if (clrType is null)
+                {
+                    logger?.LogWarning(
+                        "StrongTypes form-body reshape skipped property '{PropertyName}' on operation '{OperationId}' because no CLR type could be resolved from its ApiParameterDescription. The emitted form schema may be incomplete.",
+                        pd.Name, operation.OperationId ?? "(unnamed)");
+                    continue;
+                }
+
+                // Maybe<T> bound from a non-body slot via the StrongTypes.AspNetCore
+                // model binder reads a single raw form-data value and wraps
+                // it as Some/None — the wire is the inner T, not the
+                // body-side {"Value":<T>} wrapper object. Generate the
+                // schema for the inner T so consumers see the field's
+                // actual on-the-wire shape.
+                if (StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var maybeInner))
+                    clrType = maybeInner;
 
                 // For primitives, hand Swashbuckle the form record's
                 // PropertyInfo so its generator surfaces caller annotations
@@ -154,9 +177,65 @@ public sealed class NonBodyStrongTypeOperationFilter : IOperationFilter
 
             if (properties.Count == 0) continue;
 
+            if (properties.Count != formParamCount)
+            {
+                logger?.LogWarning(
+                    "StrongTypes form-body reshape on operation '{OperationId}' resolved {ResolvedCount} of {TotalCount} form parameters; the rest will be missing from the emitted properties map.",
+                    operation.OperationId ?? "(unnamed)", properties.Count, formParamCount);
+            }
+
+            if (allOf.Count > formParamCount)
+            {
+                logger?.LogWarning(
+                    "StrongTypes form-body reshape on operation '{OperationId}' replaced an allOf with {AllOfCount} entries using only {FormParamCount} form parameters; entries beyond the parameter set are dropped. This usually means Swashbuckle assembled the form body in a shape we don't recognise.",
+                    operation.OperationId ?? "(unnamed)", allOf.Count, formParamCount);
+            }
+
             formSchema.Properties = properties;
             formSchema.AllOf = null;
             formSchema.Type ??= JsonSchemaType.Object;
+        }
+    }
+
+    /// <summary>
+    /// Replaces the per-property schemas of <see cref="Maybe{T}"/>-typed
+    /// form fields with the inner type's wire shape. The body-side Maybe
+    /// schema is the wrapper object (<c>{"type":"object","properties":{"Value":&lt;T&gt;}}</c>)
+    /// the JSON converter emits, but the <c>StrongTypes.AspNetCore</c>
+    /// model binder reads non-body slots as a single raw value of the
+    /// inner type, so the form-data wire is the inner type. Runs after
+    /// <see cref="ReshapeFormAllOfIntoProperties"/> so it covers both the
+    /// reshaped path and the case where Swashbuckle natively emitted a
+    /// properties map.
+    /// </summary>
+    private static void ReshapeMaybeFormPropertiesIntoInnerWireShape(
+        OpenApiOperation operation,
+        IList<ApiParameterDescription> descriptions,
+        ISchemaGenerator schemaGenerator,
+        SchemaRepository schemaRepository)
+    {
+        if (operation.RequestBody?.Content is not { } content) return;
+
+        foreach (var contentType in s_formContentTypes)
+        {
+            if (!content.TryGetValue(contentType, out var media)) continue;
+            if (media.Schema is not OpenApiSchema formSchema) continue;
+            if (formSchema.Properties is not { Count: > 0 } properties) continue;
+
+            foreach (var pd in descriptions)
+            {
+                if (pd.Source != BindingSource.Form) continue;
+                var clrType = ResolveParameterClrType(pd);
+                if (clrType is null) continue;
+                if (!StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var innerType)) continue;
+                if (!properties.ContainsKey(pd.Name)) continue;
+
+                MemberInfo? memberInfo = null;
+                if (!StrongTypeSchemaTypes.IsInlineable(innerType))
+                    memberInfo = ResolveFormPropertyMember(pd);
+
+                properties[pd.Name] = schemaGenerator.GenerateSchema(innerType, schemaRepository, memberInfo);
+            }
         }
     }
 

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -72,7 +72,6 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
     {
         if (operation.Parameters is null) return;
         var clrType = ResolveParameterClrType(pd);
-        if (clrType is null) return;
         if (GetSlotAttributes(pd).Count == 0) return;
 
         foreach (var p in operation.Parameters)
@@ -89,7 +88,6 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
     {
         if (operation.RequestBody?.Content is not { } content) return;
         var clrType = ResolveParameterClrType(pd);
-        if (clrType is null) return;
         if (StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var maybeInner))
             clrType = maybeInner;
         if (GetSlotAttributes(pd).Count == 0) return;
@@ -144,13 +142,6 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
                 formParamCount++;
 
                 var clrType = ResolveParameterClrType(pd);
-                if (clrType is null)
-                {
-                    logger?.LogError(
-                        "StrongTypes form-body reshape skipped property '{PropertyName}' on operation '{OperationId}' because no CLR type could be resolved from its ApiParameterDescription. The emitted form schema may be incomplete.",
-                        pd.Name, operation.OperationId ?? "(unnamed)");
-                    continue;
-                }
 
                 // Maybe<T> bound from a non-body slot via the StrongTypes.AspNetCore
                 // model binder reads a single raw form-data value and wraps
@@ -226,7 +217,6 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
             {
                 if (pd.Source != BindingSource.Form) continue;
                 var clrType = ResolveParameterClrType(pd);
-                if (clrType is null) continue;
                 if (!StrongTypeSchemaTypes.TryGetMaybeValue(clrType, out var innerType)) continue;
                 if (!properties.ContainsKey(pd.Name)) continue;
 
@@ -291,6 +281,10 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
         return [];
     }
 
-    private static Type? ResolveParameterClrType(ApiParameterDescription pd)
-        => pd.ModelMetadata?.ModelType ?? pd.ParameterDescriptor?.ParameterType ?? pd.Type;
+    // ApiParameterDescription.Type lies for strong types implementing IParsable<T> —
+    // it reports the string overload's input, hiding the wrapper. ModelMetadata.ModelType
+    // exposes the actual CLR type for both parameter slots and for properties of a
+    // flattened [FromForm] model.
+    private static Type ResolveParameterClrType(ApiParameterDescription pd)
+        => pd.ModelMetadata.ModelType;
 }

--- a/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/Binding/NonBodyStrongTypeOperationFilter.cs
@@ -285,6 +285,5 @@ public sealed class NonBodyStrongTypeOperationFilter(ILogger<NonBodyStrongTypeOp
     // it reports the string overload's input, hiding the wrapper. ModelMetadata.ModelType
     // exposes the actual CLR type for both parameter slots and for properties of a
     // flattened [FromForm] model.
-    private static Type ResolveParameterClrType(ApiParameterDescription pd)
-        => pd.ModelMetadata.ModelType;
+    private static Type ResolveParameterClrType(ApiParameterDescription pd) => pd.ModelMetadata.ModelType;
 }

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -191,6 +191,9 @@ public sealed class BindingProbeController : ControllerBase
 
     [HttpPost("form-mixed")]
     public IActionResult FromFormMixed([FromForm] MixedFormRequest request) => Ok();
+
+    [HttpPost("form-maybe")]
+    public IActionResult FromFormMaybe([FromForm] MaybeFormRequest request) => Ok();
 }
 
 public sealed record BindingProbeFormRequest(
@@ -232,3 +235,8 @@ public sealed record MixedFormRequest(
     [property: Range(1, 100)] Positive<int> Stock,
     Email ContactEmail,
     NonEmptyEnumerable<NonEmptyString> Tags);
+
+public sealed record MaybeFormRequest(
+    Maybe<NonEmptyString> Greeting,
+    Maybe<Positive<int>> Quantity,
+    Maybe<Email> ContactEmail);

--- a/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
+++ b/src/StrongTypes.OpenApi.TestApi.Shared/BasicControllers.cs
@@ -166,14 +166,31 @@ public sealed class BindingProbeController : ControllerBase
 
     // Form bodies are split into two uniform requests — one all wrappers,
     // one all primitives — to keep the per-pipeline form-body shape
-    // consistent. Mixing wrappers and primitives in a single [FromForm]
-    // request makes Swashbuckle emit a hybrid `allOf:[wrappers, {primitives}]`
-    // shape that's painful to navigate from a shared test.
+    // consistent. The `NonBodyStrongTypeOperationFilter` reshapes
+    // Swashbuckle's `{ allOf: [<each>] }` form-body schema (emitted
+    // whenever every field is component-typed) back into a proper
+    // `{ properties: { … } }` map, so consumers see field names on both
+    // pipelines.
     [HttpPost("form-annotated")]
     public IActionResult FromFormAnnotated([FromForm] AnnotatedBindingProbeFormRequest request) => Ok();
 
     [HttpPost("form-annotated-plain")]
     public IActionResult FromFormAnnotatedPlain([FromForm] PlainAnnotatedBindingProbeFormRequest request) => Ok();
+
+    // The three endpoints below cover the form-body reshape on diverse
+    // payload shapes: a primitives-only form (Swashbuckle emits a proper
+    // properties map natively), an all-wrappers form with a mix of
+    // annotations on multiple wrappers of the same type, and a mixed form
+    // exercising both kinds together with caller annotations on each.
+
+    [HttpPost("form-simple-types")]
+    public IActionResult FromFormSimpleTypes([FromForm] SimpleTypesFormRequest request) => Ok();
+
+    [HttpPost("form-all-wrappers")]
+    public IActionResult FromFormAllWrappers([FromForm] AllStrongTypesFormRequest request) => Ok();
+
+    [HttpPost("form-mixed")]
+    public IActionResult FromFormMixed([FromForm] MixedFormRequest request) => Ok();
 }
 
 public sealed record BindingProbeFormRequest(
@@ -193,3 +210,25 @@ public sealed record AnnotatedBindingProbeFormRequest(
 public sealed record PlainAnnotatedBindingProbeFormRequest(
     [property: StringLength(50)] string PlainName,
     [property: Range(5, 100)] int PlainCount);
+
+public sealed record SimpleTypesFormRequest(
+    [property: StringLength(50)] string Title,
+    [property: Range(0, 150)] int Age,
+    bool IsActive,
+    [property: StringLength(200)] string Description);
+
+public sealed record AllStrongTypesFormRequest(
+    [property: RegularExpression(@"^[A-Z]{3}-\d{4}$")] NonEmptyString Code,
+    [property: Url] NonEmptyString Website,
+    [property: StringLength(200)] NonEmptyString Description,
+    [property: Range(1, 100)] Positive<int> Quantity,
+    Email Contact,
+    [property: MinLength(2)] NonEmptyEnumerable<Negative<decimal>> Losses);
+
+public sealed record MixedFormRequest(
+    [property: StringLength(100)] string Title,
+    [property: RegularExpression(@"^[A-Z]{3}$")] NonEmptyString Code,
+    [property: Range(1, 1000)] int Quantity,
+    [property: Range(1, 100)] Positive<int> Stock,
+    Email ContactEmail,
+    NonEmptyEnumerable<NonEmptyString> Tags);


### PR DESCRIPTION
## Summary

- Vanilla Swashbuckle emits a nameless `{ allOf: [<each-field>] }` for `[FromForm]` request bodies when every form field is component-typed, and a hybrid `{ allOf: [<wrappers>, {<primitives>}] }` for mixed forms — consumers can't tell which schema belongs to which field. The Swashbuckle non-body operation filter now rebuilds a flat `{ type: object, properties: { … } }` keyed by each form field's `ApiParameterDescription.Name`, passing `MemberInfo` for primitives so `[StringLength]` / `[Range]` / `[RegularExpression]` surface directly.
- Microsoft's non-body transformer was missing the `NonEmptyEnumerable<T>` branch in `TryPaintWireShape`, so `[MinLength]` / `[MaxLength]` on collection-shaped form fields never reached the wire schema. Added recursively.
- `IsFormPropertiesSchemaBroken`, the `allOf`-by-index navigation, the per-test `allOfIndex` parameters, and the broken-path branch are all gone — the workaround code no longer exists.
- Three new form-body integration tests exercise the reshape on diverse payloads: a primitives-only form, an all-wrappers form with multiple `NonEmptyString`s each carrying a different annotation (`[RegularExpression]`, `[Url]`, `[StringLength]`) plus `Email`, `Positive<int>`, and `NonEmptyEnumerable<Negative<decimal>>` with `[MinLength(2)]`, and a mixed form combining both kinds with caller annotations on each. Each test pins every property's full schema so a regression on either pipeline shows up as a per-property diff.

## Test plan

- [x] `dotnet build StrongTypes.slnx -c Release` — 0 warnings, 0 errors
- [x] `dotnet test StrongTypes.slnx -c Release` — **2272 passed**, 0 failed, 0 skipped (was 2260 on `main`; +12 new tests across the three pipelines)
  - StrongTypes.Tests: 1038
  - StrongTypes.Api.IntegrationTests (Testcontainers SQL Server + Postgres): 844
  - StrongTypes.OpenApi.IntegrationTests: 318 (+12)
  - StrongTypes.Analyzers.Tests: 39
  - StrongTypes.AspNetCore.IntegrationTests: 22
  - StrongTypes.Wpf.Tests: 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)