### PR TITLE
Pin license.txt link in packed readme to release tag

### DIFF
--- a/src/StrongTypes/StrongTypes.csproj
+++ b/src/StrongTypes/StrongTypes.csproj
@@ -83,6 +83,7 @@
         content = content.Replace("srcset=\"docs/diagrams/", "srcset=\"" + RawBaseUrl + "docs/diagrams/");
         content = content.Replace("](Skill/", "](" + RawBaseUrl + "Skill/");
         content = content.Replace("](src/", "](" + BlobBaseUrl + "src/");
+        content = content.Replace("](license.txt)", "](" + BlobBaseUrl + "license.txt)");
         content = content.Replace("https://github.com/KaliCZ/StrongTypes/releases/latest/download/", ReleaseAssetBaseUrl);
         System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(DestinationPath));
         System.IO.File.WriteAllText(DestinationPath, content);


### PR DESCRIPTION
## Summary
- The readme-rewrite task in `src/StrongTypes/StrongTypes.csproj` rewrites every relative path before packing (`docs/diagrams/`, `Skill/`, `src/`, the `releases/latest/download/` skill URL) so the nuget.org-rendered readme resolves them as absolute URLs pinned to the release tag.
- It missed `[MIT License](license.txt)` on the last line of the readme — on nuget.org that link resolves relative to the package page and 404s. This adds the rule alongside the others.

## Test plan
- [ ] `dotnet pack -c Release src/StrongTypes/StrongTypes.csproj /p:Version=0.x.y` and inspect `obj/.../readme.md` to confirm the license link is rewritten to `https://github.com/KaliCZ/StrongTypes/blob/v0.x.y/license.txt`.
- [ ] Build a dev pack (no version override) and confirm the link falls back to the `main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)