### PR TITLE
Group integration-test containers under StrongTypes in Docker Desktop

### DIFF
--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -16,8 +16,16 @@ namespace StrongTypes.Api.IntegrationTests.Infrastructure;
 /// </summary>
 public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
-    private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder().Build();
-    private readonly PostgreSqlContainer _pgContainer = new PostgreSqlBuilder().Build();
+    private const string DockerGroupLabel = "com.docker.compose.project";
+    private const string DockerGroupName = "StrongTypes";
+
+    private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder()
+        .WithLabel(DockerGroupLabel, DockerGroupName)
+        .Build();
+
+    private readonly PostgreSqlContainer _pgContainer = new PostgreSqlBuilder()
+        .WithLabel(DockerGroupLabel, DockerGroupName)
+        .Build();
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {


### PR DESCRIPTION
Stamp the SQL Server and PostgreSQL Testcontainers with the `com.docker.compose.project=StrongTypes` label so Docker Desktop nests them under a single collapsible **StrongTypes** group instead of listing them as loose, random-named containers.

The Ryuk resource reaper container is intentionally left ungrouped: Testcontainers 4.0.0 builds it internally with no label hook, and it is shared infrastructure rather than part of this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)