### PR TITLE
Make non-SQL-Server API tests runnable without SQL Server (#103)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,13 @@ PostgreSQL (via Testcontainers). Every write endpoint persists to both
 `DbContext`s and every read endpoint reads from one specific provider,
 so tests can assert the full wire-to-DB path on each.
 
+Because writes hit both `DbContext`s, the harness needs both providers
+present. PostgreSQL is always required; SQL Server is required too, except
+that a local (non-CI) host may opt into skipping it when the amd64-only
+image won't start — see the "SQL Server availability and skipping" section
+of [`testing.md`](testing.md). CI never skips: a SQL Server that fails to
+start is always a hard failure there, never a silent skip.
+
 Current state: uses plain `string` / `string?`. Strong-type converters
 (EF Core value converters, JSON converters) will be wired in once the
 parallel work on those lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,10 +143,10 @@ so tests can assert the full wire-to-DB path on each.
 
 Because writes hit both `DbContext`s, the harness needs both providers
 present. PostgreSQL is always required; SQL Server is required too, except
-that a local (non-CI) host may opt into skipping it when the amd64-only
-image won't start — see the "SQL Server availability and skipping" section
-of [`testing.md`](testing.md). CI never skips: a SQL Server that fails to
-start is always a hard failure there, never a silent skip.
+that a host may opt into skipping it when the amd64-only image won't start
+— see the "SQL Server availability and skipping" section of
+[`testing.md`](testing.md). Absent the opt-in, a SQL Server that fails to
+start is always a hard failure, never a silent skip.
 
 Current state: uses plain `string` / `string?`. Strong-type converters
 (EF Core value converters, JSON converters) will be wired in once the

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -27,7 +27,35 @@ public abstract class IntegrationTestBase<TEntity, T, TNullable>(TestWebApplicat
     protected DbSet<TEntity> SqlSet => SqlDb.Set<TEntity>();
     protected DbSet<TEntity> PgSet => PgDb.Set<TEntity>();
 
+    /// <summary>
+    /// Whether the SQL Server provider is backed by a real SQL Server on this host.
+    /// <see langword="false"/> only on a local host that opted into skipping SQL Server.
+    /// Guard every SQL-Server-specific assertion with this.
+    /// </summary>
+    protected bool SqlServerAvailable => factory.SqlServerAvailable;
+
     protected static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    /// Asserts the SQL Server row matches when SQL Server is available; a no-op
+    /// otherwise. The in-memory stub used when SQL Server is skipped does not
+    /// exercise the real wire path, so asserting against it would be a false pass.
+    /// </summary>
+    protected async Task AssertSqlServerEntity(Guid id, T expectedValue, TNullable expectedNullableValue)
+    {
+        if (!SqlServerAvailable)
+        {
+            return;
+        }
+        await AssertEntity(SqlSet, id, expectedValue, expectedNullableValue);
+    }
+
+    /// <summary>
+    /// Skips a provider-parametrized test for the <c>sql-server</c> provider when
+    /// SQL Server is unavailable on this host; a no-op for any other provider.
+    /// </summary>
+    protected void SkipIfSqlServerUnavailable(string provider) =>
+        Assert.SkipWhen(provider == "sql-server" && !SqlServerAvailable, "SQL Server is not available on this host.");
 
     /// <summary>
     /// Fetches the entity with the given id from the supplied DbSet and asserts

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -37,17 +37,18 @@ public abstract class IntegrationTestBase<TEntity, T, TNullable>(TestWebApplicat
     protected static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     /// <summary>
-    /// Asserts the SQL Server row matches when SQL Server is available; a no-op
-    /// otherwise. The in-memory stub used when SQL Server is skipped does not
-    /// exercise the real wire path, so asserting against it would be a false pass.
+    /// Asserts the persisted row matches in both providers: PostgreSQL always, and
+    /// SQL Server only when it is available on this host. When SQL Server is skipped
+    /// its in-memory stub is not asserted against — it does not exercise the real
+    /// wire path, so a match there would be a false pass.
     /// </summary>
-    protected async Task AssertSqlServerEntity(Guid id, T expectedValue, TNullable expectedNullableValue)
+    protected async Task AssertEntity(Guid id, T expectedValue, TNullable expectedNullableValue)
     {
-        if (!SqlServerAvailable)
+        await AssertEntity(PgSet, id, expectedValue, expectedNullableValue);
+        if (SqlServerAvailable)
         {
-            return;
+            await AssertEntity(SqlSet, id, expectedValue, expectedNullableValue);
         }
-        await AssertEntity(SqlSet, id, expectedValue, expectedNullableValue);
     }
 
     /// <summary>
@@ -57,11 +58,7 @@ public abstract class IntegrationTestBase<TEntity, T, TNullable>(TestWebApplicat
     protected void SkipIfSqlServerUnavailable(string provider) =>
         Assert.SkipWhen(provider == "sql-server" && !SqlServerAvailable, "SQL Server is not available on this host.");
 
-    /// <summary>
-    /// Fetches the entity with the given id from the supplied DbSet and asserts
-    /// that its Value and NullableValue match the expected values.
-    /// </summary>
-    protected static async Task AssertEntity(
+    private static async Task AssertEntity(
         DbSet<TEntity> set,
         Guid id,
         T expectedValue,

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -56,7 +56,9 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        SqlServerAvailable = !SqlServerSkipped;
+        // Skipping SQL Server is opt-in; absent the flag the container is started
+        // and any failure to start is a hard crash (see StartContainerAsync).
+        SqlServerAvailable = Environment.GetEnvironmentVariable(SkipSqlServerEnvVar) != "1";
 
         // PostgreSQL is mandatory on every host; SQL Server too unless skipped.
         // Start them concurrently — a start failure or timeout on either throws.
@@ -75,10 +77,6 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         await sp.GetRequiredService<SqlServerDbContext>().Database.EnsureCreatedAsync();
         await sp.GetRequiredService<PostgreSqlDbContext>().Database.EnsureCreatedAsync();
     }
-
-    // Skipping SQL Server is opt-in; absent the flag, the container is started
-    // and any start failure or timeout is a hard crash.
-    private static bool SqlServerSkipped => Environment.GetEnvironmentVariable(SkipSqlServerEnvVar) == "1";
 
     private static async Task StartContainerAsync(IContainer container, string name, string? skipHint = null)
     {

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -1,9 +1,10 @@
 using DotNet.Testcontainers.Containers;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using StrongTypes.Api.Data;
+using StrongTypes.EfCore;
 using Testcontainers.MsSql;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -11,14 +12,26 @@ using Xunit;
 namespace StrongTypes.Api.IntegrationTests.Infrastructure;
 
 /// <summary>
-/// Shared fixture that boots both database containers once per test collection,
+/// Shared fixture that boots the database containers once per test collection,
 /// overrides the connection strings via configuration (so Program.cs's DbContext
 /// registrations pick them up unchanged), and creates the schema via EnsureCreated.
 /// </summary>
+/// <remarks>
+/// PostgreSQL is required everywhere. SQL Server is required too — except on a
+/// local host that cannot run the amd64-only <c>mssql/server</c> image (e.g. an
+/// ARM64 dev box), where it may be skipped via an explicit opt-in. See
+/// <see cref="SqlServerAvailable"/> for what callers must guard, and the
+/// <c>STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE</c> env var below for the gate.
+/// CI never takes the skip path: there, a SQL Server that fails to start is a
+/// hard failure of the whole test run, never a silent skip.
+/// </remarks>
 public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
     private const string DockerGroupLabel = "com.docker.compose.project";
     private const string DockerGroupName = "StrongTypes";
+
+    // Local, non-CI opt-in to skip SQL Server; the gate is SqlServerSkipPermitted.
+    private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE";
 
     private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(45);
 
@@ -30,13 +43,38 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         .WithLabel(DockerGroupLabel, DockerGroupName)
         .Build();
 
+    /// <summary>
+    /// Whether the SQL Server container is up and backed by a real SQL Server.
+    /// <see langword="false"/> only on a local host that opted into skipping and
+    /// where SQL Server could not start — in CI this is always <see langword="true"/>
+    /// or the fixture throws. Tests must skip every SQL-Server-specific assertion
+    /// when this is <see langword="false"/>; the in-memory stub that keeps the
+    /// dual-write API booting does not exercise the real SQL Server wire path.
+    /// </summary>
+    public bool SqlServerAvailable { get; private set; }
+
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        // Start both containers in parallel; containers must be up before the
-        // host is built so that ConfigureAppConfiguration can read their connection strings.
-        await Task.WhenAll(
-            StartContainerAsync(_sqlContainer, "SQL Server"),
-            StartContainerAsync(_pgContainer, "PostgreSQL"));
+        // PostgreSQL is mandatory on every host; a start failure always throws.
+        await StartContainerAsync(_pgContainer, "PostgreSQL");
+
+        try
+        {
+            await StartContainerAsync(_sqlContainer, "SQL Server");
+            SqlServerAvailable = true;
+        }
+        catch (Exception ex)
+        {
+            if (!SqlServerSkipPermitted)
+            {
+                throw new InvalidOperationException(
+                    "The SQL Server test container failed to start and skipping is not permitted in this environment. " +
+                    $"Set {SkipSqlServerEnvVar}=1 to allow skipping the SQL-Server-backed tests on a local, non-CI host " +
+                    "(e.g. an ARM64 box that cannot run the amd64-only mssql/server image). CI always requires SQL Server.",
+                    ex);
+            }
+            SqlServerAvailable = false;
+        }
 
         // Accessing Services triggers the lazy host build.
         using var scope = Services.CreateScope();
@@ -44,6 +82,21 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         await sp.GetRequiredService<SqlServerDbContext>().Database.EnsureCreatedAsync();
         await sp.GetRequiredService<PostgreSqlDbContext>().Database.EnsureCreatedAsync();
     }
+
+    // Opt-in set AND not CI. Default and any CI env both forbid skipping, so a
+    // missing or stray flag fails safe toward a hard crash rather than a skip.
+    private static bool SqlServerSkipPermitted => SkipOptIn && !RunningInCi;
+
+    private static bool SkipOptIn => EnvFlag(SkipSqlServerEnvVar);
+
+    private static bool RunningInCi =>
+        EnvFlag("CI")
+        || Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is { Length: > 0 }
+        || Environment.GetEnvironmentVariable("TF_BUILD") is { Length: > 0 };
+
+    private static bool EnvFlag(string name) =>
+        Environment.GetEnvironmentVariable(name) is { } value
+        && (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
 
     private static async Task StartContainerAsync(IContainer container, string name)
     {
@@ -67,10 +120,33 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ConnectionStrings:SqlServer"] = _sqlContainer.GetConnectionString(),
                 ["ConnectionStrings:PostgreSql"] = _pgContainer.GetConnectionString(),
+                ["ConnectionStrings:SqlServer"] = SqlServerAvailable ? _sqlContainer.GetConnectionString() : "unused",
             });
         });
+
+        if (!SqlServerAvailable)
+        {
+            // Swap SQL Server for an in-memory stub so the dual-write endpoints
+            // still boot. Drop every registration keyed by SqlServerDbContext
+            // first — otherwise the original UseSqlServer call survives in its
+            // options-configuration service and collides with the stub provider.
+            builder.ConfigureServices(services =>
+            {
+                var stale = services
+                    .Where(d => d.ServiceType == typeof(SqlServerDbContext)
+                        || (d.ServiceType.IsGenericType
+                            && d.ServiceType.GetGenericArguments().Contains(typeof(SqlServerDbContext))))
+                    .ToList();
+                foreach (var descriptor in stale)
+                {
+                    services.Remove(descriptor);
+                }
+                services.AddDbContext<SqlServerDbContext>(options => options
+                    .UseInMemoryDatabase("sqlserver-unavailable")
+                    .UseStrongTypes());
+            });
+        }
     }
 
     public override async ValueTask DisposeAsync()

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -19,19 +19,19 @@ namespace StrongTypes.Api.IntegrationTests.Infrastructure;
 /// </summary>
 /// <remarks>
 /// PostgreSQL is required everywhere. SQL Server is required too — except on a
-/// local host that cannot run the amd64-only <c>mssql/server</c> image (e.g. an
-/// ARM64 dev box), where it may be skipped via an explicit opt-in. See
+/// host that cannot run the amd64-only <c>mssql/server</c> image (e.g. an ARM64
+/// dev box), where it may be skipped via an explicit opt-in. See
 /// <see cref="SqlServerAvailable"/> for what callers must guard, and the
 /// <c>STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE</c> env var below for the gate.
-/// CI never takes the skip path: there, a SQL Server that fails to start is a
-/// hard failure of the whole test run, never a silent skip.
+/// Absent the opt-in, a SQL Server that fails to start is a hard failure of the
+/// whole test run, never a silent skip.
 /// </remarks>
 public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
     private const string DockerGroupLabel = "com.docker.compose.project";
     private const string DockerGroupName = "StrongTypes";
 
-    // Local, non-CI opt-in to skip SQL Server; the gate is SqlServerSkipPermitted.
+    // Opt-in to skip SQL Server when it can't start; the gate is SqlServerSkipPermitted.
     private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE";
 
     private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(45);
@@ -46,11 +46,11 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
 
     /// <summary>
     /// Whether the SQL Server container is up and backed by a real SQL Server.
-    /// <see langword="false"/> only on a local host that opted into skipping and
-    /// where SQL Server could not start — in CI this is always <see langword="true"/>
-    /// or the fixture throws. Tests must skip every SQL-Server-specific assertion
-    /// when this is <see langword="false"/>; the in-memory stub that keeps the
-    /// dual-write API booting does not exercise the real SQL Server wire path.
+    /// <see langword="false"/> only on a host that opted into skipping and where
+    /// SQL Server could not start — without the opt-in the fixture throws instead.
+    /// Tests must skip every SQL-Server-specific assertion when this is
+    /// <see langword="false"/>; the in-memory stub that keeps the dual-write API
+    /// booting does not exercise the real SQL Server wire path.
     /// </summary>
     public bool SqlServerAvailable { get; private set; }
 
@@ -69,9 +69,9 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
             if (!SqlServerSkipPermitted)
             {
                 throw new InvalidOperationException(
-                    "The SQL Server test container failed to start and skipping is not permitted in this environment. " +
-                    $"Set {SkipSqlServerEnvVar}=1 to allow skipping the SQL-Server-backed tests on a local, non-CI host " +
-                    "(e.g. an ARM64 box that cannot run the amd64-only mssql/server image). CI always requires SQL Server.",
+                    "The SQL Server test container failed to start and skipping is not permitted. " +
+                    $"Set {SkipSqlServerEnvVar}=1 to allow skipping the SQL-Server-backed tests on a host " +
+                    "that cannot run the amd64-only mssql/server image (e.g. an ARM64 box).",
                     ex);
             }
             SqlServerAvailable = false;
@@ -84,16 +84,9 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         await sp.GetRequiredService<PostgreSqlDbContext>().Database.EnsureCreatedAsync();
     }
 
-    // Opt-in set AND not CI. Default and any CI env both forbid skipping, so a
-    // missing or stray flag fails safe toward a hard crash rather than a skip.
-    private static bool SqlServerSkipPermitted => SkipOptIn && !RunningInCi;
-
-    private static bool SkipOptIn => EnvFlag(SkipSqlServerEnvVar);
-
-    private static bool RunningInCi =>
-        EnvFlag("CI")
-        || Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is { Length: > 0 }
-        || Environment.GetEnvironmentVariable("TF_BUILD") is { Length: > 0 };
+    // Skipping is opt-in via the env flag. Absent the flag, a SQL Server that
+    // fails to start is a hard crash — the default fails safe toward a crash.
+    private static bool SqlServerSkipPermitted => EnvFlag(SkipSqlServerEnvVar);
 
     private static bool EnvFlag(string name) =>
         Environment.GetEnvironmentVariable(name) is { } value

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -20,19 +20,19 @@ namespace StrongTypes.Api.IntegrationTests.Infrastructure;
 /// <remarks>
 /// PostgreSQL is required everywhere. SQL Server is required too — except on a
 /// host that cannot run the amd64-only <c>mssql/server</c> image (e.g. an ARM64
-/// dev box), where it may be skipped via an explicit opt-in. See
+/// dev box), where it can be skipped via an explicit opt-in. See
 /// <see cref="SqlServerAvailable"/> for what callers must guard, and the
-/// <c>STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE</c> env var below for the gate.
-/// Absent the opt-in, a SQL Server that fails to start is a hard failure of the
-/// whole test run, never a silent skip.
+/// <c>STRONGTYPES_SKIP_SQLSERVER</c> env var below for the gate. Absent the
+/// opt-in the container is started, and any failure to start is a hard failure
+/// of the whole test run, never a silent skip.
 /// </remarks>
 public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
     private const string DockerGroupLabel = "com.docker.compose.project";
     private const string DockerGroupName = "StrongTypes";
 
-    // Opt-in to skip SQL Server when it can't start; the gate is SqlServerSkipPermitted.
-    private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE";
+    // Opt-in to skip SQL Server entirely (the container is never started).
+    private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER";
 
     private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(45);
 
@@ -46,36 +46,28 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
 
     /// <summary>
     /// Whether the SQL Server container is up and backed by a real SQL Server.
-    /// <see langword="false"/> only on a host that opted into skipping and where
-    /// SQL Server could not start — without the opt-in the fixture throws instead.
-    /// Tests must skip every SQL-Server-specific assertion when this is
-    /// <see langword="false"/>; the in-memory stub that keeps the dual-write API
-    /// booting does not exercise the real SQL Server wire path.
+    /// <see langword="false"/> only on a host that opted into skipping via the
+    /// env var, where the container is never started. Tests must skip every
+    /// SQL-Server-specific assertion when this is <see langword="false"/>; the
+    /// in-memory stub that keeps the dual-write API booting does not exercise
+    /// the real SQL Server wire path.
     /// </summary>
     public bool SqlServerAvailable { get; private set; }
 
     async ValueTask IAsyncLifetime.InitializeAsync()
     {
-        // PostgreSQL is mandatory on every host; a start failure always throws.
-        await StartContainerAsync(_pgContainer, "PostgreSQL");
+        SqlServerAvailable = !SqlServerSkipped;
 
-        try
+        // PostgreSQL is mandatory on every host; SQL Server too unless skipped.
+        // Start them concurrently — a start failure or timeout on either throws.
+        var startups = new List<Task> { StartContainerAsync(_pgContainer, "PostgreSQL") };
+        if (SqlServerAvailable)
         {
-            await StartContainerAsync(_sqlContainer, "SQL Server");
-            SqlServerAvailable = true;
+            startups.Add(StartContainerAsync(_sqlContainer, "SQL Server",
+                $"If this host cannot run the amd64-only mssql/server image (e.g. an ARM64 box), "
+                + $"set {SkipSqlServerEnvVar}=1 to skip the SQL-Server-backed tests."));
         }
-        catch (Exception ex)
-        {
-            if (!SqlServerSkipPermitted)
-            {
-                throw new InvalidOperationException(
-                    "The SQL Server test container failed to start and skipping is not permitted. " +
-                    $"Set {SkipSqlServerEnvVar}=1 to allow skipping the SQL-Server-backed tests on a host " +
-                    "that cannot run the amd64-only mssql/server image (e.g. an ARM64 box).",
-                    ex);
-            }
-            SqlServerAvailable = false;
-        }
+        await Task.WhenAll(startups);
 
         // Accessing Services triggers the lazy host build.
         using var scope = Services.CreateScope();
@@ -84,11 +76,11 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         await sp.GetRequiredService<PostgreSqlDbContext>().Database.EnsureCreatedAsync();
     }
 
-    // Skipping is opt-in via the env flag. Absent the flag, a SQL Server that
-    // fails to start is a hard crash — the default fails safe toward a crash.
-    private static bool SqlServerSkipPermitted => Environment.GetEnvironmentVariable(SkipSqlServerEnvVar) == "1";
+    // Skipping SQL Server is opt-in; absent the flag, the container is started
+    // and any start failure or timeout is a hard crash.
+    private static bool SqlServerSkipped => Environment.GetEnvironmentVariable(SkipSqlServerEnvVar) == "1";
 
-    private static async Task StartContainerAsync(IContainer container, string name)
+    private static async Task StartContainerAsync(IContainer container, string name, string? skipHint = null)
     {
         using var cts = new CancellationTokenSource(ContainerStartTimeout);
         try
@@ -98,9 +90,9 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
             throw new TimeoutException(
-                $"The {name} test container did not start within {ContainerStartTimeout.TotalSeconds:0}s. " +
-                "It either failed to start or never began accepting connections — check the container logs. " +
-                "On ARM64 hosts this can also happen when the image has no native ARM build, as the emulated process may crash on startup.");
+                $"The {name} test container did not start within {ContainerStartTimeout.TotalSeconds:0}s. "
+                + "It either failed to start or never began accepting connections — check the container logs."
+                + (skipHint is null ? "" : " " + skipHint));
         }
     }
 

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -34,7 +34,7 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
     // Opt-in to skip SQL Server entirely (the container is never started).
     private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER";
 
-    private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(30);
 
     private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder()
         .WithLabel(DockerGroupLabel, DockerGroupName)
@@ -87,12 +87,12 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
         {
             await container.StartAsync(cts.Token);
         }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        catch (Exception e)
         {
-            throw new TimeoutException(
-                $"The {name} test container did not start within {ContainerStartTimeout.TotalSeconds:0}s. "
-                + "It either failed to start or never began accepting connections — check the container logs."
-                + (skipHint is null ? "" : " " + skipHint));
+            throw new Exception(
+                $"The {name} test container failed to start — check the container logs."
+                + (skipHint is null ? "" : " " + skipHint),
+                e);
         }
     }
 

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -1,5 +1,6 @@
 using DotNet.Testcontainers.Containers;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -86,11 +86,7 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
 
     // Skipping is opt-in via the env flag. Absent the flag, a SQL Server that
     // fails to start is a hard crash — the default fails safe toward a crash.
-    private static bool SqlServerSkipPermitted => EnvFlag(SkipSqlServerEnvVar);
-
-    private static bool EnvFlag(string name) =>
-        Environment.GetEnvironmentVariable(name) is { } value
-        && (value == "1" || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+    private static bool SqlServerSkipPermitted => Environment.GetEnvironmentVariable(SkipSqlServerEnvVar) == "1";
 
     private static async Task StartContainerAsync(IContainer container, string name)
     {

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -34,7 +34,7 @@ public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>, 
     // Opt-in to skip SQL Server entirely (the container is never started).
     private const string SkipSqlServerEnvVar = "STRONGTYPES_SKIP_SQLSERVER";
 
-    private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ContainerStartTimeout = TimeSpan.FromSeconds(45);
 
     private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder()
         .WithLabel(DockerGroupLabel, DockerGroupName)

--- a/src/StrongTypes.Api.IntegrationTests/StrongTypes.Api.IntegrationTests.csproj
+++ b/src/StrongTypes.Api.IntegrationTests/StrongTypes.Api.IntegrationTests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.0.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.0.0" />

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
@@ -123,7 +123,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     {
         var created = await Post(CreateEndpoint, new { value, nullableValue = value });
         var expected = Create(value);
-        await AssertEntity(SqlSet, created.Id, expected, ToNullable(expected));
+        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
         await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
     }
 
@@ -131,7 +131,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     public async Task ValidValueWithNullNullable_PersistsInBothDatabases()
     {
         var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
         await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
     }
 
@@ -180,10 +180,13 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         await SqlDb.SaveChangesAsync(Ct);
         await PgDb.SaveChangesAsync(Ct);
 
-        var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-        Assert.Equal(entity.Id, sqlJson.GetProperty("id").GetGuid());
-        AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
-        AssertJsonEquals(sqlJson.GetProperty("nullableValue"), FirstValid);
+        if (SqlServerAvailable)
+        {
+            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
+            Assert.Equal(entity.Id, sqlJson.GetProperty("id").GetGuid());
+            AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
+            AssertJsonEquals(sqlJson.GetProperty("nullableValue"), FirstValid);
+        }
 
         var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
         Assert.Equal(entity.Id, pgJson.GetProperty("id").GetGuid());
@@ -200,9 +203,12 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         await SqlDb.SaveChangesAsync(Ct);
         await PgDb.SaveChangesAsync(Ct);
 
-        var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-        Assert.Equal(JsonValueKind.Null, sqlJson.GetProperty("nullableValue").ValueKind);
-        AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
+        if (SqlServerAvailable)
+        {
+            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
+            Assert.Equal(JsonValueKind.Null, sqlJson.GetProperty("nullableValue").ValueKind);
+            AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
+        }
 
         var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
         Assert.Equal(JsonValueKind.Null, pgJson.GetProperty("nullableValue").ValueKind);
@@ -218,7 +224,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         await Put(UpdateEndpoint(created.Id), new { value = UpdatedValid, nullableValue = UpdatedValid });
 
         var updated = Create(UpdatedValid);
-        await AssertEntity(SqlSet, created.Id, updated, ToNullable(updated));
+        await AssertSqlServerEntity(created.Id, updated, ToNullable(updated));
         await AssertEntity(PgSet, created.Id, updated, ToNullable(updated));
     }
 
@@ -228,7 +234,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
         await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)UpdatedValid });
 
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
         await AssertEntity(PgSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
     }
 
@@ -238,7 +244,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
         await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)null });
 
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
         await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
     }
 
@@ -258,7 +264,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var expected = Create(FirstValid);
-        await AssertEntity(SqlSet, created.Id, expected, ToNullable(expected));
+        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
         await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
     }
 
@@ -270,7 +276,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertEntity(SqlSet, created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
+        await AssertSqlServerEntity(created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
         await AssertEntity(PgSet, created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
     }
 
@@ -284,7 +290,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var expected = Create(FirstValid);
-        await AssertEntity(SqlSet, created.Id, expected, ToNullable(expected));
+        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
         await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
     }
 
@@ -296,7 +302,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = UpdatedValid } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
         await AssertEntity(PgSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
     }
 
@@ -308,7 +314,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
         await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
     }
 
@@ -320,7 +326,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = (object?)null } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertEntity(SqlSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
         await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
     }
 
@@ -332,7 +338,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid, nullableValue = new { Value = UpdatedValid } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertEntity(SqlSet, created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
+        await AssertSqlServerEntity(created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
         await AssertEntity(PgSet, created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
     }
 

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
@@ -123,16 +123,14 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
     {
         var created = await Post(CreateEndpoint, new { value, nullableValue = value });
         var expected = Create(value);
-        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
-        await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
+        await AssertEntity(created.Id, expected, ToNullable(expected));
     }
 
     [Fact]
     public async Task ValidValueWithNullNullable_PersistsInBothDatabases()
     {
         var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
     }
 
     // ── Create: invalid (non-null) ───────────────────────────────────────
@@ -224,8 +222,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         await Put(UpdateEndpoint(created.Id), new { value = UpdatedValid, nullableValue = UpdatedValid });
 
         var updated = Create(UpdatedValid);
-        await AssertSqlServerEntity(created.Id, updated, ToNullable(updated));
-        await AssertEntity(PgSet, created.Id, updated, ToNullable(updated));
+        await AssertEntity(created.Id, updated, ToNullable(updated));
     }
 
     [Fact]
@@ -234,8 +231,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
         await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)UpdatedValid });
 
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
+        await AssertEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
     }
 
     [Fact]
@@ -244,8 +240,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
         await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)null });
 
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
     }
 
     // ── Patch ────────────────────────────────────────────────────────────
@@ -264,8 +259,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var expected = Create(FirstValid);
-        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
-        await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
+        await AssertEntity(created.Id, expected, ToNullable(expected));
     }
 
     [Fact]
@@ -276,8 +270,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertSqlServerEntity(created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
-        await AssertEntity(PgSet, created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
+        await AssertEntity(created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
     }
 
     [Fact]
@@ -290,8 +283,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var expected = Create(FirstValid);
-        await AssertSqlServerEntity(created.Id, expected, ToNullable(expected));
-        await AssertEntity(PgSet, created.Id, expected, ToNullable(expected));
+        await AssertEntity(created.Id, expected, ToNullable(expected));
     }
 
     [Fact]
@@ -302,8 +294,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = UpdatedValid } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
+        await AssertEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
     }
 
     [Fact]
@@ -314,8 +305,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
     }
 
     [Fact]
@@ -326,8 +316,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = (object?)null } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertSqlServerEntity(created.Id, Create(FirstValid), NullNullable);
-        await AssertEntity(PgSet, created.Id, Create(FirstValid), NullNullable);
+        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
     }
 
     [Fact]
@@ -338,8 +327,7 @@ public abstract class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebAp
         var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid, nullableValue = new { Value = UpdatedValid } });
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await AssertSqlServerEntity(created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
-        await AssertEntity(PgSet, created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
+        await AssertEntity(created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
     }
 
     [Fact]

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Emails/MailAddressFilterTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Emails/MailAddressFilterTests.cs
@@ -41,6 +41,8 @@ public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task EqualTo_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var a = await Seed("alpha", null);
         var b = await Seed("beta", null);
         var needle = MailAddress.Create($"{Prefix}alpha@example.com");
@@ -54,6 +56,8 @@ public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task UnwrapStartsWith_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed("prefix-match", null);
         var noMatch = await Seed("other", null);
 
@@ -69,6 +73,8 @@ public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task UnwrapContains_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed("needle-haystack", null);
         var noMatch = await Seed("other", null);
 
@@ -86,6 +92,8 @@ public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task EfFunctionsLike_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed("apple", null);
         var noMatch = await Seed("banana", null);
 

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Numeric/NumericUnwrapFilterTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Numeric/NumericUnwrapFilterTests.cs
@@ -28,6 +28,8 @@ public sealed class NumericUnwrapFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task Positive_UnwrapArithmetic_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var small = PositiveIntEntity.Create(Positive<int>.Create(3), null);
         var large = PositiveIntEntity.Create(Positive<int>.Create(7), null);
         SqlDb.Add(small); SqlDb.Add(large);
@@ -49,6 +51,8 @@ public sealed class NumericUnwrapFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task NonNegative_UnwrapArithmetic_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var zero = NonNegativeIntEntity.Create(NonNegative<int>.Create(0), null);
         var big = NonNegativeIntEntity.Create(NonNegative<int>.Create(10), null);
         SqlDb.Add(zero); SqlDb.Add(big);
@@ -70,6 +74,8 @@ public sealed class NumericUnwrapFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task Negative_UnwrapArithmetic_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var small = NegativeIntEntity.Create(Negative<int>.Create(-1), null);
         var large = NegativeIntEntity.Create(Negative<int>.Create(-100), null);
         SqlDb.Add(small); SqlDb.Add(large);
@@ -91,6 +97,8 @@ public sealed class NumericUnwrapFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task NonPositive_UnwrapArithmetic_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var zero = NonPositiveIntEntity.Create(NonPositive<int>.Create(0), null);
         var negative = NonPositiveIntEntity.Create(NonPositive<int>.Create(-5), null);
         SqlDb.Add(zero); SqlDb.Add(negative);

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Strings/NonEmptyStringFilterTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Strings/NonEmptyStringFilterTests.cs
@@ -40,6 +40,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task EqualTo_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var a = await Seed(Prefix + "alpha", null);
         var b = await Seed(Prefix + "beta", null);
         var needle = NonEmptyString.Create(Prefix + "alpha");
@@ -53,6 +55,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task NotEqualTo_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var a = await Seed(Prefix + "alpha", null);
         var b = await Seed(Prefix + "beta", null);
         var needle = NonEmptyString.Create(Prefix + "alpha");
@@ -69,6 +73,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task NullNullable_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var withNull = await Seed(Prefix + "null", null);
         var withValue = await Seed(Prefix + "nonnull", NonEmptyString.Create("x"));
 
@@ -84,6 +90,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task NotNullNullable_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var withNull = await Seed(Prefix + "null", null);
         var withValue = await Seed(Prefix + "nonnull", NonEmptyString.Create("x"));
 
@@ -99,6 +107,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task OrderBy_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var c = await Seed(Prefix + "c", null);
         var a = await Seed(Prefix + "a", null);
         var b = await Seed(Prefix + "b", null);
@@ -115,6 +125,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task UnwrapContains_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed(Prefix + "needle-haystack", null);
         var noMatch = await Seed(Prefix + "other", null);
 
@@ -130,6 +142,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task UnwrapStartsWith_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed(Prefix + "prefix-match", null);
         var noMatch = await Seed(Prefix + "other", null);
 
@@ -145,6 +159,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task UnwrapEndsWith_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var suffix = $"-{Guid.NewGuid():N}-tail";
         var match = await Seed(Prefix + "m" + suffix, null);
         var noMatch = await Seed(Prefix + "other", null);
@@ -163,6 +179,8 @@ public sealed class NonEmptyStringFilterTests(TestWebApplicationFactory factory)
     [Theory, MemberData(nameof(Providers))]
     public async Task EfFunctionsLike_TranslatesToSql(string provider)
     {
+        SkipIfSqlServerUnavailable(provider);
+
         var match = await Seed(Prefix + "apple", null);
         var noMatch = await Seed(Prefix + "banana", null);
 

--- a/testing.md
+++ b/testing.md
@@ -116,10 +116,11 @@ running. The stub does **not** exercise the real SQL Server wire path, so
 its assertions are *skipped*, never run green against it. Guard SQL-Server
 work accordingly:
 
-- In a test deriving from `IntegrationTestBase`, assert the SQL Server row
-  via `AssertSqlServerEntity(id, value, nullableValue)` (a no-op when SQL
-  Server is unavailable) rather than `AssertEntity(SqlSet, …)`; PostgreSQL
-  assertions stay unconditional via `AssertEntity(PgSet, …)`.
+- In a test deriving from `IntegrationTestBase`, assert the persisted row
+  via `AssertEntity(id, value, nullableValue)`. It checks PostgreSQL
+  unconditionally and SQL Server only when it is available on this host, so
+  a single call covers both providers without leaking the skip logic into
+  the test body.
 - In a provider-parametrized test (`[Theory]` over `Providers`), call
   `SkipIfSqlServerUnavailable(provider)` as the first statement.
 - For any other SQL-Server-only assertion, gate it on the

--- a/testing.md
+++ b/testing.md
@@ -103,8 +103,8 @@ deliberately narrow escape hatch:
   fixture throws and the whole run goes red. There is no
   warning-and-continue path.
 - **Skipping is opt-in.** Set `STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE=1`
-  (or `true`) to let a host fall back to skipping the SQL-Server-backed
-  assertions when the container can't start. Without the opt-in the fixture
+  to let a host fall back to skipping the SQL-Server-backed assertions when
+  the container can't start. Without the opt-in the fixture
   fails safe — toward a crash, never a skip. The flag is honoured wherever
   it is set, so do not set it in CI: there is no separate CI guard, and a
   stray value will silently downgrade a CI failure into a skip.

--- a/testing.md
+++ b/testing.md
@@ -93,37 +93,25 @@ custom JSON converter, add converter-only tests under `Tests/ConverterTests`.
 
 ### SQL Server availability and skipping
 
-The `mcr.microsoft.com/mssql/server` image is amd64-only; on an ARM64 host
-(e.g. a Snapdragon dev box) it starts under emulation and `sqlservr`
-segfaults, so the container never becomes ready. PostgreSQL has native ARM
-images and is **always required**. SQL Server is required too, with one
-deliberately narrow escape hatch:
+The `mcr.microsoft.com/mssql/server` image is amd64-only, so on an ARM64
+host (e.g. a Snapdragon dev box) `sqlservr` segfaults under emulation and
+the container never starts. PostgreSQL has native ARM images and is
+**always required**; SQL Server is too, with one narrow escape hatch: set
+`STRONGTYPES_SKIP_SQLSERVER=1` to skip it entirely (the container is never
+started). Without the opt-in, a SQL Server that fails to start is a hard
+failure — the fixture throws and the run goes red. The flag is honoured
+wherever it is set, so don't set it in CI: there is no separate CI guard.
 
-- **By default the SQL Server container is started and any failure to start
-  is a hard failure.** The fixture throws and the whole run goes red. There
-  is no warning-and-continue path.
-- **Skipping is opt-in.** Set `STRONGTYPES_SKIP_SQLSERVER=1` to skip SQL
-  Server entirely — the container is never started and the SQL-Server-backed
-  assertions are skipped. Without the opt-in the fixture fails safe — toward
-  a crash, never a skip. The flag is honoured wherever it is set, so do not
-  set it in CI: there is no separate CI guard, and a stray value will
-  silently downgrade a CI failure into a skip.
-
-When SQL Server is skipped, the fixture swaps it for an in-memory stub so
-the dual-write endpoints still boot and PostgreSQL round-trips keep
-running. The stub does **not** exercise the real SQL Server wire path, so
-its assertions are *skipped*, never run green against it. Guard SQL-Server
-work accordingly:
+When skipped, the fixture swaps in an in-memory stub so the dual-write
+endpoints still boot, but it does **not** exercise the real SQL Server wire
+path — guard every SQL-Server assertion accordingly:
 
 - In a test deriving from `IntegrationTestBase`, assert the persisted row
-  via `AssertEntity(id, value, nullableValue)`. It checks PostgreSQL
-  unconditionally and SQL Server only when it is available on this host, so
-  a single call covers both providers without leaking the skip logic into
-  the test body.
+  via `AssertEntity(id, value, nullableValue)` — it checks PostgreSQL
+  unconditionally and SQL Server only when available.
 - In a provider-parametrized test (`[Theory]` over `Providers`), call
   `SkipIfSqlServerUnavailable(provider)` as the first statement.
-- For any other SQL-Server-only assertion, gate it on the
-  `SqlServerAvailable` property.
+- For any other SQL-Server-only assertion, gate it on `SqlServerAvailable`.
 
 Tests that touch no database (the `BindingTests` and the collection-JSON
 round-trips) need neither provider's assertions and run on any host once

--- a/testing.md
+++ b/testing.md
@@ -99,15 +99,15 @@ segfaults, so the container never becomes ready. PostgreSQL has native ARM
 images and is **always required**. SQL Server is required too, with one
 deliberately narrow escape hatch:
 
-- **By default a SQL Server that fails to start is a hard failure.** The
-  fixture throws and the whole run goes red. There is no
-  warning-and-continue path.
-- **Skipping is opt-in.** Set `STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE=1`
-  to let a host fall back to skipping the SQL-Server-backed assertions when
-  the container can't start. Without the opt-in the fixture
-  fails safe — toward a crash, never a skip. The flag is honoured wherever
-  it is set, so do not set it in CI: there is no separate CI guard, and a
-  stray value will silently downgrade a CI failure into a skip.
+- **By default the SQL Server container is started and any failure to start
+  is a hard failure.** The fixture throws and the whole run goes red. There
+  is no warning-and-continue path.
+- **Skipping is opt-in.** Set `STRONGTYPES_SKIP_SQLSERVER=1` to skip SQL
+  Server entirely — the container is never started and the SQL-Server-backed
+  assertions are skipped. Without the opt-in the fixture fails safe — toward
+  a crash, never a skip. The flag is honoured wherever it is set, so do not
+  set it in CI: there is no separate CI guard, and a stray value will
+  silently downgrade a CI failure into a skip.
 
 When SQL Server is skipped, the fixture swaps it for an in-memory stub so
 the dual-write endpoints still boot and PostgreSQL round-trips keep

--- a/testing.md
+++ b/testing.md
@@ -91,6 +91,44 @@ persisted state on both `SqlSet` and `PgSet`), invalid payloads returning
 `400`, and `null` handling for the nullable variant. If the type has a
 custom JSON converter, add converter-only tests under `Tests/ConverterTests`.
 
+### SQL Server availability and skipping
+
+The `mcr.microsoft.com/mssql/server` image is amd64-only; on an ARM64 host
+(e.g. a Snapdragon dev box) it starts under emulation and `sqlservr`
+segfaults, so the container never becomes ready. PostgreSQL has native ARM
+images and is **always required**. SQL Server is required too, with one
+deliberately narrow escape hatch:
+
+- **By default — and always in CI — a SQL Server that fails to start is a
+  hard failure.** The fixture throws and the whole run goes red. There is
+  no warning-and-continue path.
+- **Skipping is opt-in and local-only.** Set
+  `STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE=1` to let a host fall back to
+  skipping the SQL-Server-backed assertions when the container can't start.
+  The opt-in is **ignored under CI** (`CI`, `GITHUB_ACTIONS`, or `TF_BUILD`
+  set), so a stray value can never downgrade a CI failure into a silent
+  skip. The default (no opt-in) and the CI guard both fail safe — toward a
+  crash, never a skip.
+
+When SQL Server is skipped, the fixture swaps it for an in-memory stub so
+the dual-write endpoints still boot and PostgreSQL round-trips keep
+running. The stub does **not** exercise the real SQL Server wire path, so
+its assertions are *skipped*, never run green against it. Guard SQL-Server
+work accordingly:
+
+- In a test deriving from `IntegrationTestBase`, assert the SQL Server row
+  via `AssertSqlServerEntity(id, value, nullableValue)` (a no-op when SQL
+  Server is unavailable) rather than `AssertEntity(SqlSet, …)`; PostgreSQL
+  assertions stay unconditional via `AssertEntity(PgSet, …)`.
+- In a provider-parametrized test (`[Theory]` over `Providers`), call
+  `SkipIfSqlServerUnavailable(provider)` as the first statement.
+- For any other SQL-Server-only assertion, gate it on the
+  `SqlServerAvailable` property.
+
+Tests that touch no database (the `BindingTests` and the collection-JSON
+round-trips) need neither provider's assertions and run on any host once
+the PostgreSQL container is up.
+
 ## OpenAPI integration tests — `StrongTypes.OpenApi.IntegrationTests`
 
 Verifies the schema each type produces in **both** supported OpenAPI

--- a/testing.md
+++ b/testing.md
@@ -99,16 +99,15 @@ segfaults, so the container never becomes ready. PostgreSQL has native ARM
 images and is **always required**. SQL Server is required too, with one
 deliberately narrow escape hatch:
 
-- **By default — and always in CI — a SQL Server that fails to start is a
-  hard failure.** The fixture throws and the whole run goes red. There is
-  no warning-and-continue path.
-- **Skipping is opt-in and local-only.** Set
-  `STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE=1` to let a host fall back to
-  skipping the SQL-Server-backed assertions when the container can't start.
-  The opt-in is **ignored under CI** (`CI`, `GITHUB_ACTIONS`, or `TF_BUILD`
-  set), so a stray value can never downgrade a CI failure into a silent
-  skip. The default (no opt-in) and the CI guard both fail safe — toward a
-  crash, never a skip.
+- **By default a SQL Server that fails to start is a hard failure.** The
+  fixture throws and the whole run goes red. There is no
+  warning-and-continue path.
+- **Skipping is opt-in.** Set `STRONGTYPES_SKIP_SQLSERVER_IF_UNAVAILABLE=1`
+  (or `true`) to let a host fall back to skipping the SQL-Server-backed
+  assertions when the container can't start. Without the opt-in the fixture
+  fails safe — toward a crash, never a skip. The flag is honoured wherever
+  it is set, so do not set it in CI: there is no separate CI guard, and a
+  stray value will silently downgrade a CI failure into a skip.
 
 When SQL Server is skipped, the fixture swaps it for an in-memory stub so
 the dual-write endpoints still boot and PostgreSQL round-trips keep


### PR DESCRIPTION
Closes #103.

## Problem

`StrongTypes.Api.IntegrationTests` boots **both** a SQL Server and a PostgreSQL Testcontainer in one shared `TestWebApplicationFactory` before any test runs. On a host that can't run the amd64-only `mcr.microsoft.com/mssql/server` image (e.g. an ARM64 dev box, where `sqlservr` segfaults under emulation), the shared fixture never became ready — so the **entire** project was unrunnable, even the binding tests that touch no database.

## Approach — single project + availability gate

No new projects and no file moves: SQL Server becomes capability-gated behind an explicit opt-in, the API dual-write keeps working via an in-memory stub when SQL Server is skipped, and the supporting test helpers / container startup are cleaned up along the way.

### Skipping model (fail-safe by default)

- **Opt-in only.** Set `STRONGTYPES_SKIP_SQLSERVER=1` to skip SQL Server **entirely** — the container is never started, so there is no wasted wait on a host that can't run the image.
- **Default is a hard crash.** Without the flag, SQL Server is mandatory and any failure to start throws — the fixture fails and the whole run goes red. There is no warning-and-continue path.
- **No separate CI guard.** The opt-in default *is* the safeguard: CI never sets the flag, so CI never skips. The flag is honoured wherever it is set, so it must not be set in a CI environment.

### Keeping PostgreSQL round-trips runnable when SQL Server is skipped

The API dual-writes to both `DbContext`s, so when SQL Server is skipped the fixture swaps its `DbContext` for an in-memory stub (test-only) so writes don't 500. The stub is **not** the real SQL Server wire path, so its assertions are genuinely *skipped* — never run green against it (that would be a false pass). Tests guard SQL-Server work via:

- `AssertEntity(id, value, nullableValue)` — asserts the persisted row in both providers from one call: PostgreSQL unconditionally, SQL Server only when available. (Replaces the previous `AssertSqlServerEntity` + `AssertEntity(SqlSet/PgSet, …)` pair.)
- `SkipIfSqlServerUnavailable(provider)` — first statement in provider-parametrized `[Theory]` tests.
- the `SqlServerAvailable` property for any other SQL-only assertion.

### Container startup

- PostgreSQL and SQL Server start **concurrently** via `Task.WhenAll` (SQL Server only when not skipped).
- Each start is bounded by a `CancellationTokenSource` timeout. Any start failure — including the bare `TimeoutException` Testcontainers throws from its own wait-strategy timers, independent of our token — is caught and rethrown with the container name, a skip hint, and the original as the inner exception.

## Result

- **No-DB tests** (`BindingTests`, collection-JSON round-trips) run on any host once PostgreSQL is up.
- **PostgreSQL round-trips + converter tests** run on ARM via the stub.
- **SQL Server** runs in CI as before; CI coverage on both providers is unchanged.
- A SQL Server start failure is fatal unless skipping is explicitly opted into (local-only).

## Docs

- `testing.md` — "SQL Server availability and skipping" section.
- `CLAUDE.md` — StrongTypes.Api purpose.

## Testing

Builds clean locally; a full container run depends on Docker and host architecture. The skip / in-memory-stub path is local-only and does not affect CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
