### PR TITLE
Keep nullability on nullable strong-type wrappers in Swashbuckle OpenAPI

### DIFF
--- a/Skill/references/openapi.md
+++ b/Skill/references/openapi.md
@@ -68,25 +68,12 @@ app.UseSwaggerUI();
 | `NonEmptyEnumerable<T>` / `INonEmptyEnumerable<T>`                | `{ "type": "array", "minItems": 1, "items": <T schema> }`                       |
 | `Maybe<T>`                                                        | `{ "type": "object", "properties": { "Value": <T schema> } }`                   |
 | `IEnumerable<T>` where `T` is a strong-type wrapper               | `{ "type": "array", "items": <T schema> }` (no `minItems` — element schema only) |
+| `T?` (any nullable wrapper, e.g. `NonEmptyString?`)               | the wrapper's shape above plus its nullability — `nullable: true` (3.0) or `"null"` joined into `type` (3.1), so `NonEmptyString?` → `{ "type": "string", "minLength": 1, "nullable": true }` |
 
 The `Maybe<T>` filter unwraps `Nullable<Maybe<T>>` internally — that
 matters because `Maybe<T>` implements `IEnumerable<T>`, so a
 `Maybe<T>?`-typed property would otherwise be coerced into an array
 shape before any filter can see it.
-
-### Nullable wrappers (`NonEmptyString?`, `Positive<int>?`, …)
-
-A nullable wrapper keeps the wire shape above *and* its nullability, so
-a generated client still sees the value can be `null`:
-
-- **3.0:** `nullable: true` is added — e.g. `NonEmptyString?` →
-  `{ "type": "string", "minLength": 1, "nullable": true }`.
-- **3.1:** `"null"` joins the `type` — e.g.
-  `{ "type": ["string", "null"], "minLength": 1 }`.
-
-Both adapters do this, so migrating a field from `string?` to
-`NonEmptyString?` tightens the contract without dropping `| null` from
-codegen.
 
 ## Data annotations on wrapper-typed properties
 

--- a/Skill/references/openapi.md
+++ b/Skill/references/openapi.md
@@ -74,6 +74,20 @@ matters because `Maybe<T>` implements `IEnumerable<T>`, so a
 `Maybe<T>?`-typed property would otherwise be coerced into an array
 shape before any filter can see it.
 
+### Nullable wrappers (`NonEmptyString?`, `Positive<int>?`, …)
+
+A nullable wrapper keeps the wire shape above *and* its nullability, so
+a generated client still sees the value can be `null`:
+
+- **3.0:** `nullable: true` is added — e.g. `NonEmptyString?` →
+  `{ "type": "string", "minLength": 1, "nullable": true }`.
+- **3.1:** `"null"` joins the `type` — e.g.
+  `{ "type": ["string", "null"], "minLength": 1 }`.
+
+Both adapters do this, so migrating a field from `string?` to
+`NonEmptyString?` tightens the contract without dropping `| null` from
+codegen.
+
 ## Data annotations on wrapper-typed properties
 
 ASP.NET Core's OpenAPI pipelines drop every `ValidationAttribute`

--- a/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
+++ b/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
@@ -217,6 +217,12 @@ public static class StrongTypeInliner
     {
         var result = CloneWireShape(wrapper);
 
+        // A nullable member (`NonEmptyString?`, `Positive<int>?`, …) carries the
+        // null bit on the use-site wrapper; the wrapper component is non-nullable.
+        // Carry it onto the inlined wire shape so the published contract keeps the
+        // member's nullability instead of silently dropping it.
+        if (SchemaPaint.IsNullable(useSite)) SchemaPaint.MarkNullable(result);
+
         if (useSite.MinLength is { } minL) SchemaPaint.TightenMinLength(result, minL);
         if (useSite.MaxLength is { } maxL) SchemaPaint.TightenMaxLength(result, maxL);
         if (useSite.MinItems is { } minI) SchemaPaint.TightenMinItems(result, minI);

--- a/src/StrongTypes.OpenApi.Core/SchemaPaint.cs
+++ b/src/StrongTypes.OpenApi.Core/SchemaPaint.cs
@@ -36,6 +36,24 @@ public static class SchemaPaint
         schema.Items = null;
     }
 
+    /// <summary>
+    /// True when the schema's <c>type</c> carries the <c>null</c> bit — the
+    /// wire encoding of a nullable member. Serialized as <c>nullable: true</c>
+    /// in OpenAPI 3.0 and as a <c>"null"</c> member of the <c>type</c> array
+    /// in 3.1.
+    /// </summary>
+    public static bool IsNullable(OpenApiSchema schema)
+        => schema.Type is { } type && type.HasFlag(JsonSchemaType.Null);
+
+    /// <summary>
+    /// Adds the <c>null</c> bit to the schema's <c>type</c> while preserving
+    /// the existing primitive bits. Idempotent; the OpenAPI serializer maps
+    /// the bit to <c>nullable: true</c> (3.0) or a <c>"null"</c>-typed union
+    /// member (3.1) for the document version in force.
+    /// </summary>
+    public static void MarkNullable(OpenApiSchema schema)
+        => schema.Type = (schema.Type ?? JsonSchemaType.Null) | JsonSchemaType.Null;
+
     /// <summary>Raises <c>minLength</c> to <paramref name="floor"/>, keeping the caller's value when already at least as large.</summary>
     public static void TightenMinLength(OpenApiSchema schema, int floor)
     {

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/NullableUnwrap.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/NullableUnwrap.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace StrongTypes.OpenApi.IntegrationTests.Helpers;
@@ -72,6 +73,79 @@ internal static class NullableUnwrap
             return allOf[0];
 
         return schema;
+    }
+
+    /// <summary>
+    /// Asserts the property actually encodes <c>T?</c> nullability — in
+    /// whichever shape the pipeline uses for <paramref name="version"/> — and
+    /// returns the inner wire schema with the null marker stripped, ready for
+    /// a strict deep-compare against the wrapper's non-null wire form.
+    ///
+    /// Unlike <see cref="UnwrapNullableProperty"/>, which tolerates a missing
+    /// marker (returning the schema unchanged), this fails when no marker is
+    /// found — so it pins the bug fix: a nullable wrapper must keep its
+    /// nullability instead of silently dropping it. Accepted shapes:
+    /// <list type="bullet">
+    ///   <item>3.0 flat (Swashbuckle): <c>{ …wire, "nullable": true }</c>.</item>
+    ///   <item>3.0 union (Microsoft): <c>{ "oneOf": [ …wire ], "nullable": true }</c>.</item>
+    ///   <item>3.1 union (Microsoft): <c>{ "oneOf": [ {"type":"null"}, …wire ] }</c>.</item>
+    ///   <item>3.1 flat: <c>{ "type": ["X","null"], … }</c>.</item>
+    /// </list>
+    /// </summary>
+    internal static JsonElement AssertNullableAndUnwrap(JsonElement schema, OpenApiVersion version)
+    {
+        AssertVersionMarkers(schema, version);
+
+        foreach (var keyword in new[] { "oneOf", "anyOf" })
+        {
+            if (!schema.TryGetProperty(keyword, out var union) || union.ValueKind != JsonValueKind.Array) continue;
+
+            var wire = UnwrapNullableUnion(schema, keyword, version);
+            if (version == OpenApiVersion.V3_0)
+                Assert.True(IsFlatNullable3_0(schema), $"3.0 union nullable must carry nullable:true: {schema.GetRawText()}");
+            else
+                Assert.True(
+                    union.EnumerateArray().Any(IsNullBranch3_1),
+                    $"3.1 union must carry a {{\"type\":\"null\"}} branch: {schema.GetRawText()}");
+            return wire;
+        }
+
+        if (version == OpenApiVersion.V3_0)
+        {
+            Assert.True(IsFlatNullable3_0(schema), $"expected nullable:true on a nullable property: {schema.GetRawText()}");
+            return RemoveKey(schema, "nullable");
+        }
+
+        Assert.True(TypeArrayHasNull(schema), $"expected a \"null\" member in the type array: {schema.GetRawText()}");
+        return CollapseNullFromTypeArray(schema);
+    }
+
+    private static bool IsFlatNullable3_0(JsonElement schema) =>
+        schema.TryGetProperty("nullable", out var n) && n.ValueKind == JsonValueKind.True;
+
+    private static bool TypeArrayHasNull(JsonElement schema) =>
+        schema.TryGetProperty("type", out var t)
+        && t.ValueKind == JsonValueKind.Array
+        && t.EnumerateArray().Any(e => e.ValueKind == JsonValueKind.String && e.GetString() == "null");
+
+    private static JsonElement RemoveKey(JsonElement schema, string key)
+    {
+        var node = JsonNode.Parse(schema.GetRawText())!.AsObject();
+        node.Remove(key);
+        return JsonDocument.Parse(node.ToJsonString()).RootElement;
+    }
+
+    private static JsonElement CollapseNullFromTypeArray(JsonElement schema)
+    {
+        var node = JsonNode.Parse(schema.GetRawText())!.AsObject();
+        if (node["type"] is JsonArray arr)
+        {
+            var nonNull = arr.Where(e => e?.GetValue<string>() != "null").Select(e => e!.GetValue<string>()).ToList();
+            node["type"] = nonNull.Count == 1
+                ? JsonValue.Create(nonNull[0])
+                : new JsonArray(nonNull.Select(s => (JsonNode)JsonValue.Create(s)!).ToArray());
+        }
+        return JsonDocument.Parse(node.ToJsonString()).RootElement;
     }
 
     private static JsonElement UnwrapNullableUnion(JsonElement schema, string keyword, OpenApiVersion version)

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Collections.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Collections.cs
@@ -130,7 +130,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        var nullableArray = UnwrapNullableProperty(Property(body, "nullableNonEmptyStringArray"), Version);
+        var nullableArray = AssertNullableAndUnwrap(Property(body, "nullableNonEmptyStringArray"), Version);
 
         AssertInlineSchema(nullableArray);
         Assert.Equal("array", StringOrNull(nullableArray, "type"));
@@ -147,7 +147,7 @@ public abstract partial class OpenApiDocumentTestsBase
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        var nullableArray = UnwrapNullableProperty(Property(body, "nullableNonEmptyPositiveIntArray"), Version);
+        var nullableArray = AssertNullableAndUnwrap(Property(body, "nullableNonEmptyPositiveIntArray"), Version);
 
         AssertInlineSchema(nullableArray);
         Assert.Equal("array", StringOrNull(nullableArray, "type"));

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Emails.cs
@@ -16,10 +16,10 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task Nullable_Email_Property_Still_Renders_As_String_With_Format_Email_And_Length_Bounds()
+    public async Task Nullable_Email_Property_Keeps_Nullability_And_Renders_As_String_With_Format_Email_And_Length_Bounds()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/email-entities"));
-        AssertEmailSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version));
+        AssertEmailSchema(AssertNullableAndUnwrap(Property(body, "nullableValue"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Numerics.cs
@@ -49,26 +49,26 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task Nullable_Positive_Int_Property_Still_Renders_As_Integer_With_ExclusiveMinimum_Zero()
+    public async Task Nullable_Positive_Int_Property_Keeps_Nullability_And_Renders_As_Integer_With_ExclusiveMinimum_Zero()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/positive-int-entities"));
-        AssertPositiveIntSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version), Version);
+        AssertPositiveIntSchema(AssertNullableAndUnwrap(Property(body, "nullableValue"), Version), Version);
     }
 
     [Fact]
-    public async Task Nullable_Positive_Int_On_Dedicated_Nullables_Endpoint_Renders_As_Integer_With_ExclusiveMinimum_Zero()
+    public async Task Nullable_Positive_Int_On_Dedicated_Nullables_Endpoint_Keeps_Nullability_And_Renders_As_Integer_With_ExclusiveMinimum_Zero()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        AssertPositiveIntSchema(UnwrapNullableProperty(Property(body, "nullablePositiveInt"), Version), Version);
+        AssertPositiveIntSchema(AssertNullableAndUnwrap(Property(body, "nullablePositiveInt"), Version), Version);
     }
 
     [Fact]
-    public async Task Nullable_Digit_On_Dedicated_Nullables_Endpoint_Renders_As_Integer_With_Zero_To_Nine_Bounds()
+    public async Task Nullable_Digit_On_Dedicated_Nullables_Endpoint_Keeps_Nullability_And_Renders_As_Integer_With_Zero_To_Nine_Bounds()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        AssertDigitSchema(UnwrapNullableProperty(Property(body, "nullableDigit"), Version));
+        AssertDigitSchema(AssertNullableAndUnwrap(Property(body, "nullableDigit"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Strings.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Strings.cs
@@ -16,18 +16,18 @@ public abstract partial class OpenApiDocumentTestsBase
     }
 
     [Fact]
-    public async Task Nullable_NonEmptyString_Property_Still_Renders_As_String_With_MinLength_1()
+    public async Task Nullable_NonEmptyString_Property_Keeps_Nullability_And_Renders_As_String_With_MinLength_1()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/non-empty-string-entities"));
-        AssertNonEmptyStringSchema(UnwrapNullableProperty(Property(body, "nullableValue"), Version));
+        AssertNonEmptyStringSchema(AssertNullableAndUnwrap(Property(body, "nullableValue"), Version));
     }
 
     [Fact]
-    public async Task Nullable_NonEmptyString_On_Dedicated_Nullables_Endpoint_Renders_As_String_With_MinLength_1()
+    public async Task Nullable_NonEmptyString_On_Dedicated_Nullables_Endpoint_Keeps_Nullability_And_Renders_As_String_With_MinLength_1()
     {
         var doc = await GetDocumentAsync();
         var body = FollowRef(doc, RequestSchema(doc, "/nullable-strong-types"));
-        AssertNonEmptyStringSchema(UnwrapNullableProperty(Property(body, "nullableNonEmptyString"), Version));
+        AssertNonEmptyStringSchema(AssertNullableAndUnwrap(Property(body, "nullableNonEmptyString"), Version));
     }
 }

--- a/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
+++ b/src/StrongTypes.OpenApi.Swashbuckle/PropertyAnnotationSchemaFilter.cs
@@ -28,6 +28,12 @@ namespace StrongTypes.OpenApi.Swashbuckle;
 /// merged shape on the wire is <c>{ type: string, minLength: 1, maxLength: 50 }</c>.
 /// The wrapper-typed surface matches whatever Swashbuckle natively supports
 /// for the equivalent primitive-typed property — no more, no less.
+///
+/// The same property position is also where a nullable wrapper
+/// (<c>NonEmptyString?</c>, <c>Positive&lt;int&gt;?</c>, …) gets its null
+/// marker: Swashbuckle drops the member's nullability when it renders the
+/// property as a bare <c>$ref</c>, so this filter records it on the use-site
+/// wrapper for the inliner to carry onto the merged wire shape.
 /// </summary>
 public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
 {
@@ -37,32 +43,49 @@ public sealed class PropertyAnnotationSchemaFilter : ISchemaFilter
         if (concrete.Properties is null || concrete.Properties.Count == 0) return;
         if (context.MemberInfo is not null || context.ParameterInfo is not null) return;
 
+        var nullability = new NullabilityInfoContext();
         var clrProperties = context.Type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         foreach (var clrProperty in clrProperties)
         {
             var jsonName = ResolveJsonName(clrProperty);
             if (!concrete.Properties.TryGetValue(jsonName, out var propSchema)) continue;
 
-            var attrs = clrProperty.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
-            if (attrs.Length == 0) continue;
-
             var surrogate = StrongTypeSchemaTypes.ResolveWireType(clrProperty.PropertyType);
             if (surrogate is null) continue;
 
-            var generated = context.SchemaGenerator.GenerateSchema(surrogate, context.SchemaRepository, memberInfo: clrProperty);
-            if (generated is not OpenApiSchema source) continue;
+            var isNullable = IsNullableMember(clrProperty, nullability);
+
+            // Swashbuckle renders a wrapper-typed property as a bare `$ref` to
+            // the wrapper component, which in OpenAPI 3.0 cannot carry the
+            // member's caller annotations *or* its nullability. Only act when
+            // there is something to layer on — a caller annotation or a `T?`
+            // member; otherwise leave the bare `$ref` for the inliner.
+            OpenApiSchema? source = null;
+            if (clrProperty.GetCustomAttributes(inherit: true).OfType<Attribute>().Any())
+                source = context.SchemaGenerator.GenerateSchema(surrogate, context.SchemaRepository, memberInfo: clrProperty) as OpenApiSchema;
+
+            if (source is null && !isNullable) continue;
 
             if (propSchema is OpenApiSchema inline && inline.Type is not null)
             {
-                CopyAnnotationKeywords(source, inline);
+                if (source is not null) CopyAnnotationKeywords(source, inline);
+                if (isNullable) SchemaPaint.MarkNullable(inline);
                 continue;
             }
 
             var wrapper = new OpenApiSchema { AllOf = [propSchema] };
-            CopyAnnotationKeywords(source, wrapper);
+            if (source is not null) CopyAnnotationKeywords(source, wrapper);
+            if (isNullable) SchemaPaint.MarkNullable(wrapper);
             StrongTypeInlineMarker.Set(wrapper);
             concrete.Properties[jsonName] = wrapper;
         }
+    }
+
+    private static bool IsNullableMember(PropertyInfo property, NullabilityInfoContext context)
+    {
+        if (Nullable.GetUnderlyingType(property.PropertyType) is not null) return true;
+        if (property.PropertyType.IsValueType) return false;
+        return context.Create(property).ReadState == NullabilityState.Nullable;
     }
 
     private static void CopyAnnotationKeywords(OpenApiSchema source, OpenApiSchema target)


### PR DESCRIPTION
Fixes #108.

## Problem

Swashbuckle renders a wrapper-typed property (`NonEmptyString?`, `Positive<int>?`, `Digit?`, `Email?`, ...) as a bare `$ref` to the wrapper component. In OpenAPI 3.0 a bare `$ref` can''t carry the member''s nullability, and the inliner then collapsed the ref to the wrapper''s flat wire shape — dropping the null marker entirely. So a `NonEmptyString?` response field came out as non-nullable, and `openapi-typescript` dropped the `| null`, making the strong type *less* precise than a plain `string?`.

## Analysis — who was affected

I dumped the emitted document for all three pipelines (Swashbuckle 3.0, Microsoft 3.0, Microsoft 3.1) for every nullable wrapper:

| Wrapper (`T?`) | Microsoft 3.0 | Microsoft 3.1 | Swashbuckle 3.0 (before) |
| --- | --- | --- | --- |
| `NonEmptyString?`, `Email?`, `Positive<T>?`, `NonNegative<T>?`, `Negative<T>?`, `NonPositive<T>?`, `Digit?` | OK (`oneOf` + `nullable:true`) | OK (`oneOf` with `"null"` branch) | BUG: flat, no null marker |
| `NonEmptyEnumerable<T>?` | OK | OK | OK (array is inlined, not a `$ref`) |

So **Microsoft was already correct on both 3.0 and 3.1** — the framework wraps the member in its own `oneOf`+nullable form, which our transformer doesn''t disturb. The bug was **Swashbuckle-only**, and it hit every scalar wrapper (the ones rendered as components/`$ref`). Array wrappers were already fine because Swashbuckle inlines arrays and sets the marker there.

## Fix

- **`PropertyAnnotationSchemaFilter` (Swashbuckle)** now detects per-property nullability (value-type `Nullable<T>` and nullable reference types via `NullabilityInfoContext`) and records the null bit on the use-site wrapper — even when the member carries no validation annotations.
- **`StrongTypeInliner` (shared Core)** carries that null bit onto the merged wire shape when it inlines the wrapper.
- New `SchemaPaint.IsNullable` / `MarkNullable` helpers operate on the `JsonSchemaType.Null` bit, so the OpenAPI serializer emits the version-correct form automatically: `nullable: true` (3.0) or `"null"` in the `type` union (3.1).

The inliner change is gated on the use-site carrying the null bit, which the Microsoft pipeline never sets — so Microsoft output is unchanged (verified).

`Maybe<T>?` is intentionally out of scope: `Maybe<T>` already encodes absence and isn''t rendered through this path.

## Tests

Strengthened the shared OpenAPI shape contract (run against all three pipelines):

- Added `AssertNullableAndUnwrap`, which **fails** if a nullable property has no null marker (the previous helper tolerated its absence), then returns the bare wire shape for a strict deep-compare. It accepts every shape the pipelines use: 3.0 flat (`nullable:true`), 3.0 `oneOf`+`nullable:true`, 3.1 `oneOf` with a `"null"` branch, and 3.1 `type` arrays.
- The nullable `NonEmptyString` / `Positive<int>` / `Digit` / `Email` / `NonEmptyEnumerable` tests now assert nullability is actually present (and the inner shape is exact), across Swashbuckle 3.0, Microsoft 3.0, and Microsoft 3.1.

All 294 OpenAPI integration tests pass; full solution builds clean.

Also updated `Skill/references/openapi.md` to document that nullable wrappers keep their nullability on both pipelines.

Generated with [Claude Code](https://claude.com/claude-code)
