### PR TITLE
OpenApi: drop the storage-type component orphaned by inlining a strong-type wrapper

### DIFF
--- a/StrongTypes.slnx
+++ b/StrongTypes.slnx
@@ -16,6 +16,7 @@
   </Folder>
   <Folder Name="/OpenApi packages/">
     <Project Path="src/StrongTypes.OpenApi.Core/StrongTypes.OpenApi.Core.csproj" />
+    <Project Path="src/StrongTypes.OpenApi.Core.Tests/StrongTypes.OpenApi.Core.Tests.csproj" />
     <Project Path="src/StrongTypes.OpenApi.Microsoft/StrongTypes.OpenApi.Microsoft.csproj" />
     <Project Path="src/StrongTypes.OpenApi.Swashbuckle/StrongTypes.OpenApi.Swashbuckle.csproj" />
     <Project Path="src/StrongTypes.OpenApi.TestApi.Shared/StrongTypes.OpenApi.TestApi.Shared.csproj" />

--- a/src/StrongTypes.OpenApi.Core.Tests/StrongTypeInlinerScopingTests.cs
+++ b/src/StrongTypes.OpenApi.Core.Tests/StrongTypeInlinerScopingTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.OpenApi;
+using StrongTypes.OpenApi.Core;
+using Xunit;
+
+namespace StrongTypes.OpenApi.Core.Tests;
+
+/// <summary>
+/// The storage-component cleanup that follows inlining only touches the
+/// known generated storage types (e.g. MailAddress behind Email) and only
+/// when nothing references them — it must never reach for a consumer's own
+/// schema, and must keep a storage type a consumer still uses. Pinned
+/// directly on the inliner, independent of either HTTP pipeline.
+/// </summary>
+public sealed class StrongTypeInlinerScopingTests
+{
+    [Fact]
+    public void Removes_Unreferenced_Storage_Component_But_Preserves_Unrelated_Orphan()
+    {
+        var profileDto = ObjectWith(("email", new OpenApiSchemaReference("Email")));
+        var document = DocumentWith(
+            ("Email", InlineableEmail()),
+            ("MailAddress", ObjectWith(("address", String()))),
+            ("OrphanDto", ObjectWith(("name", String()))),
+            ("ProfileDto", profileDto));
+
+        StrongTypeInliner.Inline(document);
+        var schemas = document.Components!.Schemas!;
+
+        Assert.False(schemas.ContainsKey("Email"), "the inlined wrapper itself is removed");
+        Assert.False(schemas.ContainsKey("MailAddress"), "the unreferenced storage type is GC'd");
+        Assert.True(schemas.ContainsKey("OrphanDto"), "an unrelated, unreferenced consumer schema must be left untouched");
+
+        var inlinedEmail = Assert.IsType<OpenApiSchema>(profileDto.Properties!["email"]);
+        Assert.True(inlinedEmail.Type == JsonSchemaType.String);
+    }
+
+    [Fact]
+    public void Keeps_Storage_Component_A_Consumer_Still_References()
+    {
+        var document = DocumentWith(
+            ("Email", InlineableEmail()),
+            ("MailAddress", ObjectWith(("address", String()))),
+            // A consumer DTO that uses MailAddress directly, unrelated to Email.
+            ("ContactDto", ObjectWith(("addr", new OpenApiSchemaReference("MailAddress")))));
+
+        StrongTypeInliner.Inline(document);
+
+        Assert.True(document.Components!.Schemas!.ContainsKey("MailAddress"),
+            "a storage type still referenced by a consumer schema must be kept");
+    }
+
+    private static OpenApiSchema InlineableEmail()
+    {
+        var email = new OpenApiSchema { Type = JsonSchemaType.String, Format = "email", MinLength = 1, MaxLength = 254 };
+        StrongTypeInlineMarker.Set(email);
+        return email;
+    }
+
+    private static OpenApiSchema String() => new() { Type = JsonSchemaType.String };
+
+    private static OpenApiSchema ObjectWith(params (string Name, IOpenApiSchema Schema)[] properties) => new()
+    {
+        Type = JsonSchemaType.Object,
+        Properties = properties.ToDictionary(p => p.Name, p => p.Schema, StringComparer.Ordinal),
+    };
+
+    private static OpenApiDocument DocumentWith(params (string Name, IOpenApiSchema Schema)[] schemas) => new()
+    {
+        Components = new OpenApiComponents
+        {
+            Schemas = schemas.ToDictionary(s => s.Name, s => s.Schema, StringComparer.Ordinal),
+        },
+    };
+}

--- a/src/StrongTypes.OpenApi.Core.Tests/StrongTypes.OpenApi.Core.Tests.csproj
+++ b/src/StrongTypes.OpenApi.Core.Tests/StrongTypes.OpenApi.Core.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>14.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>CS1591</NoWarn>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <RootNamespace>StrongTypes.OpenApi.Core.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StrongTypes.OpenApi.Core\StrongTypes.OpenApi.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
+++ b/src/StrongTypes.OpenApi.Core/Inlining/StrongTypeInliner.cs
@@ -28,7 +28,10 @@ public static class StrongTypeInliner
         }
         if (inlineable.Count == 0) return;
 
-        var ctx = new RewriteContext(inlineable, logger);
+        // `Referenced` accumulates every $ref the walk leaves in place (i.e.
+        // not inlined) so we can tell afterwards which components are still in
+        // use. The HashSet is shared across the by-value context copies.
+        var ctx = new RewriteContext(inlineable, new HashSet<string>(StringComparer.Ordinal), logger);
 
         // Walk every component (including the inlineable bodies themselves)
         // so refs to other inlineable wrappers nested inside an array
@@ -47,9 +50,31 @@ public static class StrongTypeInliner
 
         foreach (var name in inlineable.Keys)
             schemas.Remove(name);
+
+        RemoveUnreferencedStorageComponents(schemas, ctx.Referenced);
     }
 
-    private readonly record struct RewriteContext(IReadOnlyDictionary<string, OpenApiSchema> Inlineable, ILogger? Logger);
+    // Storage types that a strong-type wrapper exposes as a public property
+    // and that the generator therefore registers as their own component
+    // (e.g. Email.Value is a System.Net.Mail.MailAddress → a "MailAddress"
+    // component). Once the wrapper is inlined and dropped, nothing references
+    // these any more and downstream tools (openapi-typescript) emit them as
+    // dead noise. Extend this list when a new wrapper drags in another type.
+    private static readonly string[] GeneratedStorageComponentNames = ["MailAddress"];
+
+    // Drop a known storage component only when no surviving $ref points at it,
+    // so a consumer that genuinely uses the type (e.g. a DTO with a
+    // MailAddress property of its own) keeps its component.
+    private static void RemoveUnreferencedStorageComponents(IDictionary<string, IOpenApiSchema> schemas, HashSet<string> referenced)
+    {
+        foreach (var name in GeneratedStorageComponentNames)
+        {
+            if (!referenced.Contains(name)) schemas.Remove(name);
+        }
+    }
+
+    private readonly record struct RewriteContext(
+        IReadOnlyDictionary<string, OpenApiSchema> Inlineable, HashSet<string> Referenced, ILogger? Logger);
 
     private static void RewritePathItem(IOpenApiPathItem pathItem, RewriteContext ctx)
     {
@@ -152,8 +177,14 @@ public static class StrongTypeInliner
 
     private static IOpenApiSchema RewriteSlot(IOpenApiSchema slot, RewriteContext ctx)
     {
-        if (slot is OpenApiSchemaReference sref && ctx.Inlineable.TryGetValue(sref.Reference?.Id ?? string.Empty, out var refTarget))
-            return CloneWireShape(refTarget);
+        if (slot is OpenApiSchemaReference sref && sref.Reference?.Id is { } refId)
+        {
+            if (ctx.Inlineable.TryGetValue(refId, out var refTarget))
+                return CloneWireShape(refTarget);
+
+            ctx.Referenced.Add(refId);
+            return slot;
+        }
 
         if (slot is OpenApiSchema concrete)
         {

--- a/src/StrongTypes.OpenApi.IntegrationTests/Helpers/ComponentSchemas.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Helpers/ComponentSchemas.cs
@@ -21,6 +21,40 @@ internal static class ComponentSchemas
     }
 
     /// <summary>
+    /// Returns the set of <c>components.schemas</c> names that some
+    /// <c>$ref</c> in the document points at. A component name absent
+    /// from this set is an orphan — defined but never referenced.
+    /// </summary>
+    internal static HashSet<string> ReadReferencedSchemaNames(JsonElement doc)
+    {
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+        CollectRefs(doc, referenced);
+        return referenced;
+    }
+
+    private static void CollectRefs(JsonElement element, HashSet<string> referenced)
+    {
+        const string prefix = "#/components/schemas/";
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    if (prop.NameEquals("$ref") && prop.Value.ValueKind == JsonValueKind.String
+                        && prop.Value.GetString() is { } path && path.StartsWith(prefix, StringComparison.Ordinal))
+                        referenced.Add(path[prefix.Length..]);
+                    else
+                        CollectRefs(prop.Value, referenced);
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                    CollectRefs(item, referenced);
+                break;
+        }
+    }
+
+    /// <summary>
     /// Identifies a component schema name as one of the wrapper types
     /// the inliner is expected to remove. Recognises both the Microsoft
     /// prefix style (<c>PositiveOf…</c>, <c>MaybeOf…</c>) and the

--- a/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Components.cs
+++ b/src/StrongTypes.OpenApi.IntegrationTests/Tests/OpenApiDocumentTestsBase.Components.cs
@@ -50,4 +50,24 @@ public abstract partial class OpenApiDocumentTestsBase
                 $"Inlineable wrapper component '{name}' should have been removed from components.schemas.");
         }
     }
+
+    // Inlining a wrapper whose storage type is itself an object (e.g.
+    // Email, backed by System.Net.Mail.MailAddress) makes the pipeline
+    // register that nested storage type as its own component. Once the
+    // wrapper is inlined and dropped, nothing references the nested
+    // component any more, so the inliner must GC it — leaving it behind
+    // is contract drift (openapi-typescript emits an unused interface).
+    [Fact]
+    public async Task No_Component_Schema_Is_Left_Unreferenced_After_Inlining()
+    {
+        var doc = await GetDocumentAsync();
+        var referenced = ReadReferencedSchemaNames(doc);
+
+        foreach (var name in ReadComponentSchemaNames(doc))
+        {
+            Assert.True(
+                referenced.Contains(name),
+                $"Component schema '{name}' is orphaned — no $ref points at it after inlining.");
+        }
+    }
 }

--- a/testing.md
+++ b/testing.md
@@ -189,6 +189,18 @@ Use `OpenApiVersion`-aware helpers in `Helpers/ExclusiveBounds.cs` for
 anything that differs between OpenAPI 3.0 and 3.1 (e.g. exclusive
 bounds). Don't write version-conditional asserts inline.
 
+## OpenAPI Core unit tests — `StrongTypes.OpenApi.Core.Tests`
+
+Pipeline-independent logic in `StrongTypes.OpenApi.Core` (e.g. the
+`StrongTypeInliner`) is unit-tested here against the `Microsoft.OpenApi`
+object model directly — build an `OpenApiDocument` in memory, run the
+operation, assert on the result. Reach for this when the behaviour is a
+property of the shared Core code itself rather than of either HTTP
+pipeline (for cross-cutting behaviour both pipelines must exhibit, prefer
+the shared `OpenApiDocumentTestsBase` suite so it's verified end-to-end on
+each). The integration suite stays HTTP/JSON-only and does not reference
+Core.
+
 ## Analyzer tests — `StrongTypes.Analyzers.Tests`
 
 For every diagnostic and code fix, write both a "reports the diagnostic"


### PR DESCRIPTION
## Summary

Fixes #110. Using the `Email` strong type on a DTO left an orphaned `MailAddress` component schema in the generated OpenAPI document. Swashbuckle registers `MailAddress` as its own component while walking `Email`'s CLR properties (`Email.Value` is a `System.Net.Mail.MailAddress`); painting `Email` down to its wire primitive severs the only edge to `MailAddress`, so once `Email` is inlined and dropped, `MailAddress` is an orphan with zero inbound `$ref`s. `openapi-typescript` then emits it as an unused interface.

## Approach

The inliner already visits every `$ref` while inlining, so it now records the ones it leaves in place. Afterwards it drops a small, explicit list of generated storage component names (currently just `MailAddress`) — but **only** those still unreferenced:

```csharp
private static readonly string[] GeneratedStorageComponentNames = ["MailAddress"];
```

- A consumer that uses the type directly (its own DTO with a `MailAddress` property) **keeps** it — the reference check sees it.
- A consumer's own schemas are **never** candidates — only names on the list are considered, so blanket pruning of unrelated unused components can't happen.
- Extend the list when a future wrapper drags in another storage type.

The production change is ~35 lines in the shared `StrongTypeInliner` (`StrongTypes.OpenApi.Core`), so both the Swashbuckle document filter and the Microsoft document transformer benefit. (Only Swashbuckle exhibited the orphan; the Microsoft pipeline derives `Email`'s schema from its JSON contract and never registers `MailAddress`.)

## Tests

- **Integration** (`No_Component_Schema_Is_Left_Unreferenced_After_Inlining`, runs on both pipelines) — the generated document carries no orphaned component schema. Failed only on Swashbuckle before the fix, reproducing the `MailAddress` orphan.
- **Core unit** — new pipeline-independent `StrongTypes.OpenApi.Core.Tests` project exercising the inliner against the `Microsoft.OpenApi` object model directly: the unreferenced storage type is removed, a still-referenced one is kept, and an unrelated unreferenced consumer schema is preserved. The integration suite stays HTTP/JSON-only and no longer references Core. `testing.md` documents the new project.

All tests pass (297 integration + 2 Core unit).

## Note on the runtime warning

The issue also flagged a `StrongTypeInliningDocumentFilter` warning as "likely the same root cause." It does not reproduce in this repo's test apps (zero occurrences in the test logs), and the reporter attributes it to another OpenAPI transformer in their environment mutating a schema after our adapter runs. The concrete, verifiable defect — the orphaned `MailAddress` — is what this PR fixes and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
