### PR TITLE
Bump Microsoft.OpenApi to 2.7.5 (GHSA-v5pm-xwqc-g5wc)

### DIFF
--- a/src/StrongTypes.OpenApi.Core/StrongTypes.OpenApi.Core.csproj
+++ b/src/StrongTypes.OpenApi.Core/StrongTypes.OpenApi.Core.csproj
@@ -9,7 +9,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.0,11.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/StrongTypes.OpenApi.Microsoft/StrongTypes.OpenApi.Microsoft.csproj
+++ b/src/StrongTypes.OpenApi.Microsoft/StrongTypes.OpenApi.Microsoft.csproj
@@ -28,6 +28,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[10.0.0,11.0.0)" />
+    <!-- Explicit floor over the transitive Microsoft.OpenApi, vulnerable below 2.7.5 (GHSA-v5pm-xwqc-g5wc). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StrongTypes\StrongTypes.csproj" />

--- a/src/StrongTypes.OpenApi.Swashbuckle/StrongTypes.OpenApi.Swashbuckle.csproj
+++ b/src/StrongTypes.OpenApi.Swashbuckle/StrongTypes.OpenApi.Swashbuckle.csproj
@@ -27,6 +27,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="[10.0.0,11.0.0)" />
+    <!-- Explicit floor over the transitive Microsoft.OpenApi, vulnerable below 2.7.5 (GHSA-v5pm-xwqc-g5wc). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\StrongTypes\StrongTypes.csproj" />


### PR DESCRIPTION
## Problem

`Microsoft.OpenApi` 2.0.0–2.7.4 carries a **high-severity** advisory
([GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc)) —
circular schema references can terminate OpenAPI parsing (DoS). NuGet audit
promotes it to an error under `TreatWarningsAsErrors`, failing the build
across every OpenApi project: `OpenApi.Core` references it directly (2.0.0);
the rest pull it transitively via `Microsoft.AspNetCore.OpenApi` /
`Swashbuckle.AspNetCore*` (2.0.0–2.4.1).

## Fix

Pin an explicit `Microsoft.OpenApi` **2.7.5** floor (the first patched 2.x)
in the three packable OpenApi projects — `Core`, `Microsoft`, `Swashbuckle`.
These are non-private references, so the fixed version cascades through the
normal project references to every test and host project. `Core` already had
a direct reference (just bumped); `Microsoft` and `Swashbuckle` pull it
transitively, so the explicit floor also protects package consumers.

Confirmed every previously-flagged project now resolves 2.7.5 — including the
transitive-only `TestApi.Swashbuckle`, `TestApi.Microsoft`, and
`Analyzers.Tests`.

## Verification

- Full solution: **0 errors, 0 warnings** — advisory cleared, no
  `NU1605`/`NU1608` downgrade or constraint conflicts.
- **`OpenApi.IntegrationTests` (297)** pass — both the Microsoft and
  Swashbuckle pipelines generate real OpenAPI documents at runtime, so this
  rules out any schema drift or API break from 2.0 → 2.7.
- `OpenApi.Core.Tests` (2) and `Analyzers.Tests` (39) pass.

Stayed on the 2.x line (2.7.5, not the 3.x line the advisory also covers) to
keep the change a minimal in-major security bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
