### PR TITLE
Support storing the Email strong type in EF Core

### DIFF
--- a/Skill/references/efcore.md
+++ b/Skill/references/efcore.md
@@ -30,14 +30,18 @@ public sealed class User
     public Guid Id { get; init; }
     public NonEmptyString Name { get; init; }
     public NonEmptyString? Nickname { get; init; }
+    public Email? ContactEmail { get; init; }
     public Positive<int>   LoginCount { get; init; }
     public NonNegative<decimal> Balance { get; init; }
 }
 ```
 
-Columns are the underlying type — `nvarchar` for `NonEmptyString`, `int`
-for `Positive<int>`, `decimal(...)` for `NonNegative<decimal>`, and the
-nullable form becomes a nullable column.
+Columns are the underlying type — `nvarchar` for `NonEmptyString` and for
+`Email` / `MailAddress` (the address string), `int` for `Positive<int>`,
+`decimal(...)` for `NonNegative<decimal>`, and the nullable form becomes a
+nullable column. An email column can be `Email` (the wrapper — re-checks the
+254-char cap on read) or the BCL `MailAddress`; they convert to each other
+implicitly, so store whichever your domain already holds.
 
 ### Non-public backing properties
 

--- a/Skill/references/efcore.md
+++ b/Skill/references/efcore.md
@@ -31,6 +31,7 @@ public sealed class User
     public NonEmptyString Name { get; init; }
     public NonEmptyString? Nickname { get; init; }
     public Email? ContactEmail { get; init; }
+    public MailAddress? BackupEmail { get; init; }
     public Positive<int>   LoginCount { get; init; }
     public NonNegative<decimal> Balance { get; init; }
 }

--- a/src/StrongTypes.Analyzers.Tests/MissingEfCorePackageAnalyzerTests.cs
+++ b/src/StrongTypes.Analyzers.Tests/MissingEfCorePackageAnalyzerTests.cs
@@ -133,6 +133,35 @@ public class MissingEfCorePackageAnalyzerTests
         Assert.NotEmpty(diagnostics.WhereId(MissingEfCorePackageAnalyzer.DiagnosticId));
     }
 
+    [Fact]
+    public async Task Detects_email_wrapper()
+    {
+        const string source = """
+            using Microsoft.EntityFrameworkCore;
+            using StrongTypes;
+
+            namespace Sample;
+
+            public class Contact
+            {
+                public int Id { get; set; }
+                public Email Address { get; set; } = null!;
+            }
+
+            public class SampleContext : DbContext
+            {
+                public DbSet<Contact> Contacts { get; set; } = null!;
+            }
+            """;
+
+        var diagnostics = await AnalyzerTester.RunAsync(
+            new MissingEfCorePackageAnalyzer(),
+            source,
+            TestReferences.With(TestReferences.EntityFrameworkCore));
+
+        Assert.NotEmpty(diagnostics.WhereId(MissingEfCorePackageAnalyzer.DiagnosticId));
+    }
+
     [Theory]
     [InlineData("Positive<int>")]
     [InlineData("NonNegative<long>")]

--- a/src/StrongTypes.Analyzers/MissingEfCorePackageAnalyzer.cs
+++ b/src/StrongTypes.Analyzers/MissingEfCorePackageAnalyzer.cs
@@ -37,13 +37,14 @@ public sealed class MissingEfCorePackageAnalyzer : DiagnosticAnalyzer
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Kalicz.StrongTypes.EfCore ships value converters and the Unwrap() LINQ translator needed for EF Core to round-trip NonEmptyString, Positive<T>, NonNegative<T>, Negative<T>, and NonPositive<T> to a database column. Without the package, EF Core infers the wrapper as an owned entity type and fails at model-build time.",
+        description: "Kalicz.StrongTypes.EfCore ships value converters and the Unwrap() LINQ translator needed for EF Core to round-trip NonEmptyString, Email, Positive<T>, NonNegative<T>, Negative<T>, and NonPositive<T> to a database column. Without the package, EF Core infers the wrapper as an owned entity type and fails at model-build time.",
         helpLinkUri: "https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore");
 
     // Canonical names in metadata form so compiled generics match
     // (`StrongTypes.Positive\`1`, etc.).
     private static readonly ImmutableHashSet<string> StrongTypeMetadataNames = ImmutableHashSet.Create(
         "StrongTypes.NonEmptyString",
+        "StrongTypes.Email",
         "StrongTypes.Positive`1",
         "StrongTypes.NonNegative`1",
         "StrongTypes.Negative`1",

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Emails/EmailEntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Emails/EmailEntityTests.cs
@@ -14,11 +14,6 @@ public sealed class EmailEntityTests(TestWebApplicationFactory factory)
     protected override string FirstValid => "alice@example.com";
     protected override string UpdatedValid => "bob@example.org";
 
-    // Email isn't IComparable; the column stores the address string, so the
-    // database orders by that. Mirror it here for the OrderBy assertion.
-    protected override IComparer<Email> ValueComparer =>
-        Comparer<Email>.Create((left, right) => string.CompareOrdinal(left.Address, right.Address));
-
     public static TheoryData<string> ValidInputs => new()
     {
         "alice@example.com",

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Emails/MailAddressEntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Emails/MailAddressEntityTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Mail;
 using StrongTypes.Api.Entities;
 using StrongTypes.Api.IntegrationTests.Infrastructure;
 using Xunit;
@@ -5,19 +6,19 @@ using Xunit;
 namespace StrongTypes.Api.IntegrationTests.Tests;
 
 [Collection(IntegrationTestCollection.Name)]
-public sealed class EmailEntityTests(TestWebApplicationFactory factory)
-    : EntityTests<EmailEntityTests, EmailEntity, Email, Email?, string>(factory),
+public sealed class MailAddressEntityTests(TestWebApplicationFactory factory)
+    : EntityTests<MailAddressEntityTests, MailAddressEntity, MailAddress, MailAddress?, string>(factory),
       IEntityTestData<string>
 {
-    protected override string RoutePrefix => "email-entities";
-    protected override Email Create(string raw) => Email.Create(raw);
+    protected override string RoutePrefix => "mail-address-entities";
+    protected override MailAddress Create(string raw) => new(raw);
     protected override string FirstValid => "alice@example.com";
     protected override string UpdatedValid => "bob@example.org";
 
-    // Email isn't IComparable; the column stores the address string, so the
+    // MailAddress isn't IComparable; the column stores the address string, so the
     // database orders by that. Mirror it here for the OrderBy assertion.
-    protected override IComparer<Email> ValueComparer =>
-        Comparer<Email>.Create((left, right) => string.CompareOrdinal(left.Address, right.Address));
+    protected override IComparer<MailAddress> ValueComparer =>
+        Comparer<MailAddress>.Create((left, right) => string.CompareOrdinal(left.Address, right.Address));
 
     public static TheoryData<string> ValidInputs => new()
     {

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Emails/MailAddressFilterTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ConverterTests/Emails/MailAddressFilterTests.cs
@@ -9,7 +9,7 @@ namespace StrongTypes.Api.IntegrationTests.Tests;
 /// <summary>
 /// Verifies <c>MailAddress.Unwrap()</c> (plus equality and EF.Functions.Like)
 /// translates to server-side SQL on both providers when applied to the
-/// <see cref="EmailEntity"/>'s <see cref="MailAddress"/> column. Tests query
+/// <see cref="MailAddressEntity"/>'s <see cref="MailAddress"/> column. Tests query
 /// the <see cref="DbContext"/> directly so the LINQ translator is what we
 /// exercise — no HTTP plumbing in the way. Each test seeds rows with a
 /// unique local-part prefix and scopes assertions to those rows so it
@@ -17,11 +17,11 @@ namespace StrongTypes.Api.IntegrationTests.Tests;
 /// </summary>
 [Collection(IntegrationTestCollection.Name)]
 public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
-    : IntegrationTestBase<EmailEntity, MailAddress, MailAddress?>(factory)
+    : IntegrationTestBase<MailAddressEntity, MailAddress, MailAddress?>(factory)
 {
     public static TheoryData<string> Providers => new() { "sql-server", "postgresql" };
 
-    private DbSet<EmailEntity> Set(string provider) =>
+    private DbSet<MailAddressEntity> Set(string provider) =>
         provider == "sql-server" ? SqlSet : PgSet;
 
     // Unique per-test local-part prefix so each test's assertions are
@@ -30,7 +30,7 @@ public sealed class MailAddressFilterTests(TestWebApplicationFactory factory)
 
     private async Task<Guid> Seed(string localPart, MailAddress? nullableValue)
     {
-        var entity = EmailEntity.Create(MailAddress.Create($"{Prefix}{localPart}@example.com"), nullableValue);
+        var entity = MailAddressEntity.Create(MailAddress.Create($"{Prefix}{localPart}@example.com"), nullableValue);
         SqlSet.Add(entity);
         PgSet.Add(entity);
         await SqlDb.SaveChangesAsync(Ct);

--- a/src/StrongTypes.Api/Controllers/EmailEntityController.cs
+++ b/src/StrongTypes.Api/Controllers/EmailEntityController.cs
@@ -1,90 +1,10 @@
-using System.Net.Mail;
 using Microsoft.AspNetCore.Mvc;
 using StrongTypes.Api.Data;
 using StrongTypes.Api.Entities;
-using StrongTypes.Api.Models;
 
 namespace StrongTypes.Api.Controllers;
 
-/// <summary>
-/// Bespoke controller for <see cref="EmailEntity"/>: requests and responses are
-/// shaped in <see cref="Email"/> (so the wrapper's JSON converter enforces the
-/// 254-character cap and addr-spec parse on the way in) but the entity itself
-/// stores the BCL <see cref="MailAddress"/> — the validation contract belongs
-/// at the wire boundary, not on every read.
-/// </summary>
 [ApiController]
 [Route("email-entities")]
 public sealed class EmailEntityController(SqlServerDbContext sqlCtx, PostgreSqlDbContext pgCtx)
-    : EntityControllerBase<EmailEntity>(sqlCtx, pgCtx)
-{
-    [HttpGet("{id:guid}/sql-server")]
-    public async Task<IActionResult> GetFromSqlServer(Guid id)
-    {
-        var entity = await SqlSet.FindAsync(id);
-        return entity is null ? NotFound() : Ok(ToDto(entity));
-    }
-
-    [HttpGet("{id:guid}/postgresql")]
-    public async Task<IActionResult> GetFromPostgreSql(Guid id)
-    {
-        var entity = await PgSet.FindAsync(id);
-        return entity is null ? NotFound() : Ok(ToDto(entity));
-    }
-
-    [HttpPost]
-    public async Task<IActionResult> Create(ReferenceEntityRequest<Email> request)
-    {
-        var entity = EmailEntity.Create(request.Value, request.NullableValue?.Value);
-        SqlSet.Add(entity);
-        PgSet.Add(entity);
-        await SaveAllAsync();
-        return Created($"{Request.Path}/{entity.Id}", new EntityResponse(entity.Id));
-    }
-
-    [HttpPut("{id:guid}")]
-    public async Task<IActionResult> Update(Guid id, ReferenceEntityRequest<Email> request)
-    {
-        var sqlEntity = await SqlSet.FindAsync(id);
-        var pgEntity = await PgSet.FindAsync(id);
-        if (sqlEntity is null || pgEntity is null) return NotFound();
-        sqlEntity.Update(request.Value, request.NullableValue?.Value);
-        pgEntity.Update(request.Value, request.NullableValue?.Value);
-        await SaveAllAsync();
-        return Ok(new EntityResponse(id));
-    }
-
-    [HttpPatch("{id:guid}")]
-    public async Task<IActionResult> Patch(Guid id, ReferenceEntityPatchRequest<Email> request)
-    {
-        var sqlEntity = await SqlSet.FindAsync(id);
-        var pgEntity = await PgSet.FindAsync(id);
-        if (sqlEntity is null || pgEntity is null) return NotFound();
-
-        if (request.Value is { } value)
-        {
-            sqlEntity.Value = value;
-            pgEntity.Value = value;
-        }
-
-        if (request.NullableValue is { } nv)
-        {
-            sqlEntity.NullableValue = nv.Value?.Value;
-            pgEntity.NullableValue = nv.Value?.Value;
-        }
-
-        await SaveAllAsync();
-        return Ok(new EntityResponse(id));
-    }
-
-    /// <summary>
-    /// DTO for the Email response. Custom shape (rather than a generic
-    /// <see cref="StructEntityDto{T}"/>) because the entity stores a
-    /// <see cref="MailAddress"/> reference but the wire surface is the
-    /// <see cref="Email"/> wrapper.
-    /// </summary>
-    public sealed record EmailEntityDto(Guid Id, Email Value, Email? NullableValue);
-
-    private static EmailEntityDto ToDto(EmailEntity entity) =>
-        new(entity.Id, entity.Value, entity.NullableValue is { } nv ? (Email)nv : null);
-}
+    : ReferenceTypeEntityControllerBase<EmailEntity, Email>(sqlCtx, pgCtx);

--- a/src/StrongTypes.Api/Controllers/MailAddressEntityController.cs
+++ b/src/StrongTypes.Api/Controllers/MailAddressEntityController.cs
@@ -1,0 +1,90 @@
+using System.Net.Mail;
+using Microsoft.AspNetCore.Mvc;
+using StrongTypes.Api.Data;
+using StrongTypes.Api.Entities;
+using StrongTypes.Api.Models;
+
+namespace StrongTypes.Api.Controllers;
+
+/// <summary>
+/// Bespoke controller for <see cref="MailAddressEntity"/>: requests and responses are
+/// shaped in <see cref="Email"/> (so the wrapper's JSON converter enforces the
+/// 254-character cap and addr-spec parse on the way in) but the entity itself
+/// stores the BCL <see cref="MailAddress"/> — the validation contract belongs
+/// at the wire boundary, not on every read.
+/// </summary>
+[ApiController]
+[Route("mail-address-entities")]
+public sealed class MailAddressEntityController(SqlServerDbContext sqlCtx, PostgreSqlDbContext pgCtx)
+    : EntityControllerBase<MailAddressEntity>(sqlCtx, pgCtx)
+{
+    [HttpGet("{id:guid}/sql-server")]
+    public async Task<IActionResult> GetFromSqlServer(Guid id)
+    {
+        var entity = await SqlSet.FindAsync(id);
+        return entity is null ? NotFound() : Ok(ToDto(entity));
+    }
+
+    [HttpGet("{id:guid}/postgresql")]
+    public async Task<IActionResult> GetFromPostgreSql(Guid id)
+    {
+        var entity = await PgSet.FindAsync(id);
+        return entity is null ? NotFound() : Ok(ToDto(entity));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(ReferenceEntityRequest<Email> request)
+    {
+        var entity = MailAddressEntity.Create(request.Value, request.NullableValue?.Value);
+        SqlSet.Add(entity);
+        PgSet.Add(entity);
+        await SaveAllAsync();
+        return Created($"{Request.Path}/{entity.Id}", new EntityResponse(entity.Id));
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(Guid id, ReferenceEntityRequest<Email> request)
+    {
+        var sqlEntity = await SqlSet.FindAsync(id);
+        var pgEntity = await PgSet.FindAsync(id);
+        if (sqlEntity is null || pgEntity is null) return NotFound();
+        sqlEntity.Update(request.Value, request.NullableValue?.Value);
+        pgEntity.Update(request.Value, request.NullableValue?.Value);
+        await SaveAllAsync();
+        return Ok(new EntityResponse(id));
+    }
+
+    [HttpPatch("{id:guid}")]
+    public async Task<IActionResult> Patch(Guid id, ReferenceEntityPatchRequest<Email> request)
+    {
+        var sqlEntity = await SqlSet.FindAsync(id);
+        var pgEntity = await PgSet.FindAsync(id);
+        if (sqlEntity is null || pgEntity is null) return NotFound();
+
+        if (request.Value is { } value)
+        {
+            sqlEntity.Value = value;
+            pgEntity.Value = value;
+        }
+
+        if (request.NullableValue is { } nv)
+        {
+            sqlEntity.NullableValue = nv.Value?.Value;
+            pgEntity.NullableValue = nv.Value?.Value;
+        }
+
+        await SaveAllAsync();
+        return Ok(new EntityResponse(id));
+    }
+
+    /// <summary>
+    /// DTO for the response. Custom shape (rather than a generic
+    /// <see cref="StructEntityDto{T}"/>) because the entity stores a
+    /// <see cref="MailAddress"/> reference but the wire surface is the
+    /// <see cref="Email"/> wrapper.
+    /// </summary>
+    public sealed record MailAddressEntityDto(Guid Id, Email Value, Email? NullableValue);
+
+    private static MailAddressEntityDto ToDto(MailAddressEntity entity) =>
+        new(entity.Id, entity.Value, entity.NullableValue is { } nv ? (Email)nv : null);
+}

--- a/src/StrongTypes.Api/Data/PostgreSqlDbContext.cs
+++ b/src/StrongTypes.Api/Data/PostgreSqlDbContext.cs
@@ -7,6 +7,7 @@ public class PostgreSqlDbContext(DbContextOptions<PostgreSqlDbContext> options) 
 {
     public DbSet<NonEmptyStringEntity> NonEmptyStringEntities { get; set; }
     public DbSet<EmailEntity> EmailEntities { get; set; }
+    public DbSet<MailAddressEntity> MailAddressEntities { get; set; }
 
     public DbSet<PositiveIntEntity> PositiveIntEntities { get; set; }
     public DbSet<NonNegativeIntEntity> NonNegativeIntEntities { get; set; }

--- a/src/StrongTypes.Api/Data/SqlServerDbContext.cs
+++ b/src/StrongTypes.Api/Data/SqlServerDbContext.cs
@@ -7,6 +7,7 @@ public class SqlServerDbContext(DbContextOptions<SqlServerDbContext> options) : 
 {
     public DbSet<NonEmptyStringEntity> NonEmptyStringEntities { get; set; }
     public DbSet<EmailEntity> EmailEntities { get; set; }
+    public DbSet<MailAddressEntity> MailAddressEntities { get; set; }
 
     public DbSet<PositiveIntEntity> PositiveIntEntities { get; set; }
     public DbSet<NonNegativeIntEntity> NonNegativeIntEntities { get; set; }

--- a/src/StrongTypes.Api/Entities/Entities.cs
+++ b/src/StrongTypes.Api/Entities/Entities.cs
@@ -4,7 +4,8 @@ namespace StrongTypes.Api.Entities;
 
 public sealed class NonEmptyStringEntity : EntityBase<NonEmptyStringEntity, NonEmptyString, NonEmptyString?>;
 
-public sealed class EmailEntity : EntityBase<EmailEntity, MailAddress, MailAddress?>;
+public sealed class EmailEntity : EntityBase<EmailEntity, Email, Email?>;
+public sealed class MailAddressEntity : EntityBase<MailAddressEntity, MailAddress, MailAddress?>;
 
 public sealed class PositiveIntEntity : EntityBase<PositiveIntEntity, Positive<int>, Positive<int>?>;
 public sealed class NonNegativeIntEntity : EntityBase<NonNegativeIntEntity, NonNegative<int>, NonNegative<int>?>;

--- a/src/StrongTypes.EfCore/EmailValueConverter.cs
+++ b/src/StrongTypes.EfCore/EmailValueConverter.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace StrongTypes.EfCore;
+
+/// <summary>EF Core value converter that round-trips <see cref="Email"/> through a plain <see cref="string"/> column; a stored value that no longer satisfies the email contract throws on read rather than materialising a broken wrapper.</summary>
+/// <remarks>The same instance serves both <c>Email</c> and <c>Email?</c> properties.</remarks>
+public sealed class EmailValueConverter : ValueConverter<Email, string>
+{
+    public EmailValueConverter()
+        : base(v => v.Address, v => Email.Create(v))
+    {
+    }
+}

--- a/src/StrongTypes.EfCore/StrongTypesConvention.cs
+++ b/src/StrongTypes.EfCore/StrongTypesConvention.cs
@@ -60,14 +60,15 @@ internal sealed class StrongTypesConvention : IEntityTypeAddedConvention, IPrope
     private static ValueConverter? ResolveConverter(Type clrType)
     {
         var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        return unwrapped switch
-        {
-            _ when unwrapped == typeof(NonEmptyString) => new NonEmptyStringValueConverter(),
-            _ when unwrapped == typeof(Email) => new EmailValueConverter(),
-            _ when unwrapped == typeof(MailAddress) => new MailAddressValueConverter(),
-            { IsGenericType: true } when IsNumericWrapper(unwrapped) => CreateNumericConverter(unwrapped),
-            _ => null,
-        };
+        if (unwrapped == typeof(NonEmptyString))
+            return new NonEmptyStringValueConverter();
+        if (unwrapped == typeof(Email))
+            return new EmailValueConverter();
+        if (unwrapped == typeof(MailAddress))
+            return new MailAddressValueConverter();
+        if (unwrapped.IsGenericType && IsNumericWrapper(unwrapped))
+            return CreateNumericConverter(unwrapped);
+        return null;
     }
 
     private static bool IsNumericWrapper(Type unwrapped)

--- a/src/StrongTypes.EfCore/StrongTypesConvention.cs
+++ b/src/StrongTypes.EfCore/StrongTypesConvention.cs
@@ -52,23 +52,7 @@ internal sealed class StrongTypesConvention : IEntityTypeAddedConvention, IPrope
         }
     }
 
-    private static bool IsStrongType(Type clrType)
-    {
-        var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(MailAddress))
-        {
-            return true;
-        }
-        if (unwrapped.IsGenericType)
-        {
-            var definition = unwrapped.GetGenericTypeDefinition();
-            return definition == typeof(Positive<>)
-                || definition == typeof(NonNegative<>)
-                || definition == typeof(Negative<>)
-                || definition == typeof(NonPositive<>);
-        }
-        return false;
-    }
+    private static bool IsStrongType(Type clrType) => ResolveConverter(clrType) is not null;
 
     // EF Core applies ValueConverter only to non-null values, so the same
     // converter instance works for both Wrapper and Nullable<Wrapper> (and for
@@ -76,32 +60,30 @@ internal sealed class StrongTypesConvention : IEntityTypeAddedConvention, IPrope
     private static ValueConverter? ResolveConverter(Type clrType)
     {
         var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString))
+        return unwrapped switch
         {
-            return new NonEmptyStringValueConverter();
-        }
-        if (unwrapped == typeof(Email))
-        {
-            return new EmailValueConverter();
-        }
-        if (unwrapped == typeof(MailAddress))
-        {
-            return new MailAddressValueConverter();
-        }
-        if (unwrapped.IsGenericType)
-        {
-            var definition = unwrapped.GetGenericTypeDefinition();
-            if (definition == typeof(Positive<>) ||
-                definition == typeof(NonNegative<>) ||
-                definition == typeof(Negative<>) ||
-                definition == typeof(NonPositive<>))
-            {
-                var underlying = unwrapped.GetGenericArguments()[0];
-                var converterType = typeof(NumericStrongTypeValueConverter<,>).MakeGenericType(unwrapped, underlying);
-                return (ValueConverter)Activator.CreateInstance(converterType)!;
-            }
-        }
-        return null;
+            _ when unwrapped == typeof(NonEmptyString) => new NonEmptyStringValueConverter(),
+            _ when unwrapped == typeof(Email) => new EmailValueConverter(),
+            _ when unwrapped == typeof(MailAddress) => new MailAddressValueConverter(),
+            { IsGenericType: true } when IsNumericWrapper(unwrapped) => CreateNumericConverter(unwrapped),
+            _ => null,
+        };
+    }
+
+    private static bool IsNumericWrapper(Type unwrapped)
+    {
+        var definition = unwrapped.GetGenericTypeDefinition();
+        return definition == typeof(Positive<>)
+            || definition == typeof(NonNegative<>)
+            || definition == typeof(Negative<>)
+            || definition == typeof(NonPositive<>);
+    }
+
+    private static ValueConverter CreateNumericConverter(Type unwrapped)
+    {
+        var underlying = unwrapped.GetGenericArguments()[0];
+        var converterType = typeof(NumericStrongTypeValueConverter<,>).MakeGenericType(unwrapped, underlying);
+        return (ValueConverter)Activator.CreateInstance(converterType)!;
     }
 }
 

--- a/src/StrongTypes.EfCore/StrongTypesConvention.cs
+++ b/src/StrongTypes.EfCore/StrongTypesConvention.cs
@@ -55,7 +55,7 @@ internal sealed class StrongTypesConvention : IEntityTypeAddedConvention, IPrope
     private static bool IsStrongType(Type clrType)
     {
         var unwrapped = Nullable.GetUnderlyingType(clrType) ?? clrType;
-        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(MailAddress))
+        if (unwrapped == typeof(NonEmptyString) || unwrapped == typeof(Email) || unwrapped == typeof(MailAddress))
         {
             return true;
         }
@@ -79,6 +79,10 @@ internal sealed class StrongTypesConvention : IEntityTypeAddedConvention, IPrope
         if (unwrapped == typeof(NonEmptyString))
         {
             return new NonEmptyStringValueConverter();
+        }
+        if (unwrapped == typeof(Email))
+        {
+            return new EmailValueConverter();
         }
         if (unwrapped == typeof(MailAddress))
         {

--- a/src/StrongTypes.EfCore/readme.md
+++ b/src/StrongTypes.EfCore/readme.md
@@ -3,9 +3,10 @@
 [![NuGet version](https://img.shields.io/nuget/v/Kalicz.StrongTypes.EfCore?label=nuget)](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/) [![Downloads](https://img.shields.io/nuget/dt/Kalicz.StrongTypes.EfCore?label=downloads)](https://www.nuget.org/packages/Kalicz.StrongTypes.EfCore/) [![License](https://img.shields.io/github/license/KaliCZ/StrongTypes)](https://github.com/KaliCZ/StrongTypes/blob/main/license.txt)
 
 EF Core plumbing for [Kalicz.StrongTypes](https://www.nuget.org/packages/Kalicz.StrongTypes).
-Lets you use `NonEmptyString`, `Positive<T>`, `NonNegative<T>`, `Negative<T>`, and
-`NonPositive<T>` as regular entity properties — they round-trip through scalar
-columns, and LINQ predicates over them translate to server-side SQL.
+Lets you use `NonEmptyString`, `Email`, `MailAddress`, `Positive<T>`,
+`NonNegative<T>`, `Negative<T>`, and `NonPositive<T>` as regular entity
+properties — they round-trip through scalar columns, and LINQ predicates over
+them translate to server-side SQL.
 
 ## Install
 
@@ -49,6 +50,7 @@ public sealed class User
     public Guid Id { get; init; }
     public NonEmptyString Name { get; init; }
     public NonEmptyString? Nickname { get; init; }
+    public Email? ContactEmail { get; init; }
     public Positive<int> LoginCount { get; init; }
     public NonNegative<decimal> Balance { get; init; }
 }
@@ -60,9 +62,14 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 ```
 
 Column shape on the database is the underlying type — `nvarchar` for
-`NonEmptyString`, `int` for `Positive<int>`, `decimal(18,2)` for
-`NonNegative<decimal>`, etc. Same for the nullable form
-(`NonEmptyString?`, `Positive<int>?`) — EF maps it to a nullable column.
+`NonEmptyString` and for `Email` / `MailAddress` (the address string), `int`
+for `Positive<int>`, `decimal(18,2)` for `NonNegative<decimal>`, etc. Same for
+the nullable form (`NonEmptyString?`, `Email?`, `Positive<int>?`) — EF maps it
+to a nullable column.
+
+An email column can be either `Email` (the wrapper — re-checks the 254-char cap
+on read) or the BCL `MailAddress`; the two convert to each other implicitly, so
+store whichever your domain already holds.
 
 Non-public properties are wired too. An `internal`/`private` EF-mapped
 backing property — the usual DDD pattern behind a computed public view —

--- a/src/StrongTypes.EfCore/readme.md
+++ b/src/StrongTypes.EfCore/readme.md
@@ -51,6 +51,7 @@ public sealed class User
     public NonEmptyString Name { get; init; }
     public NonEmptyString? Nickname { get; init; }
     public Email? ContactEmail { get; init; }
+    public MailAddress? BackupEmail { get; init; }
     public Positive<int> LoginCount { get; init; }
     public NonNegative<decimal> Balance { get; init; }
 }

--- a/src/StrongTypes.Tests/Emails/EmailTests.cs
+++ b/src/StrongTypes.Tests/Emails/EmailTests.cs
@@ -252,6 +252,47 @@ public class EmailTests
     public void Equals_String_Null_False(Email email) =>
         Assert.False(email.Equals((string?)null));
 
+    // ── Comparison ────────────────────────────────────────────────────────
+    // Ordinal-ignore-case on the address, matching Equals so CompareTo == 0
+    // agrees with equality.
+
+    [Property]
+    public void CompareTo_SameAddress_Zero(Email email) =>
+        Assert.Equal(0, email.CompareTo(Email.Create(email.Address)));
+
+    [Property]
+    public void CompareTo_CaseInsensitive_Zero(Email email) =>
+        Assert.Equal(0, email.CompareTo(Email.Create(email.Address.ToUpperInvariant())));
+
+    [Property]
+    public void CompareTo_OrdersByAddressIgnoringCase(Email a, Email b)
+    {
+        var expected = string.Compare(a.Address, b.Address, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Math.Sign(expected), Math.Sign(a.CompareTo(b)));
+    }
+
+    [Property]
+    public void CompareTo_Null_Positive(Email email) =>
+        Assert.True(email.CompareTo(null) > 0);
+
+    [Fact]
+    public void Sort_OrdersByAddressIgnoringCase()
+    {
+        var emails = new[] { Email.Create("charlie@x.com"), Email.Create("Alice@x.com"), Email.Create("bob@x.com") };
+        Array.Sort(emails);
+        Assert.Equal("Alice@x.com", emails[0].Address);
+        Assert.Equal("bob@x.com", emails[1].Address);
+        Assert.Equal("charlie@x.com", emails[2].Address);
+    }
+
+    [Property]
+    public void IComparable_CompareTo_Null_Positive(Email email) =>
+        Assert.True(((IComparable)email).CompareTo(null) > 0);
+
+    [Property]
+    public void IComparable_CompareTo_ForeignType_Throws(Email email) =>
+        Assert.Throws<ArgumentException>(() => ((IComparable)email).CompareTo(42));
+
     // ── Cross-type operators with NonEmptyString ──────────────────────────
 
     [Property]

--- a/src/StrongTypes/Emails/Email.cs
+++ b/src/StrongTypes/Emails/Email.cs
@@ -13,6 +13,8 @@ public sealed class Email :
     IEquatable<Email>,
     IEquatable<MailAddress>,
     IEquatable<string>,
+    IComparable<Email>,
+    IComparable,
     IParsable<Email>
 {
     /// <summary>RFC 5321 deliverable cap. The forwarder path can be longer; this is the addr-spec limit clients should enforce on input.</summary>
@@ -94,6 +96,18 @@ public sealed class Email :
 
     [Pure]
     public override string ToString() => Address;
+
+    [Pure]
+    public int CompareTo(Email? other) =>
+        other is null ? 1 : string.Compare(Address, other.Address, StringComparison.OrdinalIgnoreCase);
+
+    int IComparable.CompareTo(object? obj) =>
+        obj switch
+        {
+            null => 1,
+            Email other => CompareTo(other),
+            _ => throw new ArgumentException($"Object must be of type {nameof(Email)}.", nameof(obj)),
+        };
 
     public static bool operator ==(Email? left, Email? right) =>
         left is null ? right is null : left.Equals(right);


### PR DESCRIPTION
## What

Makes the `Email` strong type EF Core–storable. Previously only the BCL `MailAddress` could go in a database column; an `Email` property failed at model build (EF treated the wrapper as an owned type, "No suitable constructor for the type 'Email'"). Storing an email meant using `MailAddress` as an undocumented workaround — which the `Email` XML doc even contradicted by claiming EF-column support.

## Changes

- **`EmailValueConverter`** — round-trips `Email` ⇄ `string` via the address, re-validating on read (a stored value that violates the email contract throws rather than materialising a broken wrapper, consistent with the other converters).
- **Convention wiring** — `ResolveConverter`/`IsStrongType` now recognise `Email`, so the converter attaches automatically. No `HasConversion` by hand.
- **Both storage types tested** — the harness entity that stores `MailAddress` is renamed `EmailEntity` → `MailAddressEntity` (its name now matches its column), and a new `EmailEntity` stores the `Email` wrapper. Both run the full entity-test matrix (round-trip of value + null, `NULL`/value filtering, ordering, read-invalid) for their nullable forms.
- **Analyzer** — `MissingEfCorePackageAnalyzer` (ST0001) now flags `Email` properties on EF entities, like `NonEmptyString`. `MailAddress` stays out — it's a BCL type, not a StrongTypes wrapper.
- **Docs** — `efcore.md` and the EfCore readme list `Email`/`MailAddress` as storable, and note the two are interchangeable (store whichever your domain holds). The `Email` `<remarks>` claim about EF columns is now true.

## Verification

- Full solution build: 0 warnings, 0 errors.
- Full `StrongTypes.Api.IntegrationTests` on PostgreSQL: **1070 passed, 17 skipped, 0 failed** (the 17 are SQL-Server rows under the local opt-out; CI runs both providers).
  - New `EmailEntityTests` (stores `Email`): 37 passed.
  - `MailAddressEntityTests` + `MailAddressFilterTests` (renamed): 41 passed / 4 skipped.
- Analyzer tests: 12 passed (incl. the new `Detects_email_wrapper`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)