### PR TITLE
Unify the scalar and interval API CRUD/PATCH test harnesses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,12 +100,15 @@ will need tests** (a new strong type, a converter, an analyzer, an API
 endpoint, …). It is the single source of truth; do not infer testing
 conventions from existing tests without checking it first.
 
-**Parity invariant (don't let it drift):** the API CRUD/PATCH suite exists as
-two parallel harnesses — `EntityTests` (scalar wire) and `IntervalEntityTests`
-(object wire) — that must cover the same create/get/update/PATCH surface. A
-scenario added to one belongs in the other. This is easy to break silently, so
-it is flagged here as well as in the "Two parallel CRUD harnesses" section of
-[`testing.md`](testing.md) and in the XML docs on both base classes.
+**One shared CRUD surface (don't reintroduce drift):** the API CRUD/PATCH
+suite's create/get/update/PATCH scenarios live exactly once, in the abstract
+`EntityCrudTestsBase`, so the scalar and interval wire shapes cannot drift. Its
+two thin adapters — `EntityTests` (scalar wire) and `IntervalEntityTests`
+(object wire) — add only wire-shape-specific pieces (bodies, the read assertion,
+invalid-payload cases). A new shared scenario goes in `EntityCrudTestsBase`, not
+in an adapter. See the "One shared CRUD surface" section of
+[`testing.md`](testing.md) and the XML docs on `EntityCrudTestsBase` and its two
+adapters.
 
 ## Skill — keep it in sync
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ to touch, what to cover, how to write each kind of test — live in
 [`testing.md`](testing.md). Read it before writing tests or production
 code that will need them.
 
-The API CRUD/PATCH suite lives in two parallel harnesses — `EntityTests`
-(scalar wire types) and `IntervalEntityTests` (object wire) — that must stay at
-feature parity: a create/get/update/PATCH scenario added to one belongs in the
-other. See "Two parallel CRUD harnesses" in [`testing.md`](testing.md).
+The API CRUD/PATCH suite's shared create/get/update/PATCH scenarios live once in
+`EntityCrudTestsBase`, behind two thin wire-shape adapters — `EntityTests`
+(scalar wire types) and `IntervalEntityTests` (object wire). A new shared
+scenario goes in the base, so the two wire shapes cannot drift. See "One shared
+CRUD surface" in [`testing.md`](testing.md).
 
 ## Documentation
 

--- a/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -11,7 +11,7 @@ namespace StrongTypes.Api.IntegrationTests.Infrastructure;
 /// the HTTP Client, both DbContexts, the current CancellationToken, and the
 /// generic <see cref="AssertEntity"/> helper that reads from a
 /// <see cref="DbSet{TEntity}"/>. HTTP route/body helpers live on the
-/// subclass that actually uses them (<c>EntityTests</c>).
+/// <c>EntityCrudTestsBase</c> subclass that actually uses them.
 /// </summary>
 public abstract class IntegrationTestBase<TEntity, T, TNullable>(TestWebApplicationFactory factory) : IDisposable
     where TEntity : class, IEntity<TEntity, T, TNullable>

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityCrudTestsBase.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityCrudTestsBase.cs
@@ -1,0 +1,301 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using StrongTypes.Api.Entities;
+using StrongTypes.Api.IntegrationTests.Infrastructure;
+using StrongTypes.Api.Models;
+using Xunit;
+
+namespace StrongTypes.Api.IntegrationTests.Tests;
+
+/// <summary>
+/// The create / get / update / PATCH surface — including the null / value / clear-nullable
+/// semantics of the nullable slot — that every wire-to-DB entity test must cover, written
+/// once so the two wire shapes cannot drift apart. A concrete harness supplies only the
+/// wire-shape-specific pieces: the request body for a value
+/// (<see cref="ValidBody"/> / <see cref="UpdatedBody"/>), its strong-typed form
+/// (<see cref="ValidValue"/> / <see cref="UpdatedValue"/>), and the GET read assertion
+/// (<see cref="AssertJsonIsValidValue"/>).
+/// </summary>
+/// <remarks>
+/// Two harnesses derive from this base:
+/// <see cref="EntityTests{TSelf, TEntity, T, TNullable, TWire}"/> for scalar wire types (a
+/// value serializes as a single JSON scalar) and
+/// <see cref="IntervalEntityTests{TEntity, TInterval}"/> for intervals (a value serializes
+/// as a JSON object). Each adds only its own invalid-payload cases — a malformed scalar on
+/// one side, <c>Start &gt; End</c> / a missing required endpoint on the other. The shared
+/// scenarios below exist exactly once, so a scenario can no longer be present for one wire
+/// shape and silently missing for the other.
+/// </remarks>
+public abstract class EntityCrudTestsBase<TEntity, T, TNullable>(TestWebApplicationFactory factory)
+    : IntegrationTestBase<TEntity, T, TNullable>(factory)
+    where TEntity : class, IEntity<TEntity, T, TNullable>
+    where T : notnull
+{
+    /// <summary>Route segment this entity is exposed under, e.g. "positive-int-entities".</summary>
+    protected abstract string RoutePrefix { get; }
+
+    /// <summary>Request body for a valid value: a bare scalar, or a <c>{ start, end }</c> object.</summary>
+    protected abstract object ValidBody { get; }
+
+    /// <summary>The strong-typed form of <see cref="ValidBody"/>, for asserting persisted state.</summary>
+    protected abstract T ValidValue { get; }
+
+    /// <summary>A second valid value distinct from <see cref="ValidBody"/>, for update/PATCH tests.</summary>
+    protected abstract object UpdatedBody { get; }
+
+    /// <summary>The strong-typed form of <see cref="UpdatedBody"/>.</summary>
+    protected abstract T UpdatedValue { get; }
+
+    /// <summary>Asserts a GET response's <c>value</c>/<c>nullableValue</c> element equals <see cref="ValidValue"/>.</summary>
+    protected abstract void AssertJsonIsValidValue(JsonElement element);
+
+    protected string CreateEndpoint => $"/{RoutePrefix}";
+    protected string UpdateEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
+    protected string PatchEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
+    protected string SqlServerGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/sql-server";
+    protected string PostgreSqlGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/postgresql";
+
+    protected async Task<EntityResponse> Post(string url, object body)
+    {
+        var response = await Client.PostAsJsonAsync(url, body, Ct);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return (await response.Content.ReadFromJsonAsync<EntityResponse>(Ct))!;
+    }
+
+    protected async Task Put(string url, object body)
+    {
+        var response = await Client.PutAsJsonAsync(url, body, Ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    protected async Task<HttpResponseMessage> Patch(string url, object body)
+    {
+        using var content = JsonContent.Create(body);
+        return await Client.PatchAsync(url, content, Ct);
+    }
+
+    protected async Task<JsonElement> Get(string url)
+    {
+        var response = await Client.GetAsync(url, Ct);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
+    }
+
+    // T → TNullable bridge. For struct T with TNullable = Nullable<T>, boxing then unboxing to
+    // Nullable<T> is a supported CLR conversion; for class T with TNullable = T? it is identity.
+    // default! is null in both shapes.
+    protected static TNullable ToNullable(T value) => (TNullable)(object)value!;
+    protected static TNullable NullNullable => default!;
+
+    // ── Create ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ValidValue_PersistsInBothDatabases()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+        await AssertEntity(created.Id, ValidValue, ToNullable(ValidValue));
+    }
+
+    [Fact]
+    public async Task ValidValueWithNullNullable_PersistsInBothDatabases()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = (object?)null });
+        await AssertEntity(created.Id, ValidValue, NullNullable);
+    }
+
+    // Value is non-nullable, so a null Value is a 400. The error key is mechanism-dependent: a
+    // struct (or a reference converter that rejects null) fails at parse time -> "$.value"; a
+    // reference converter that maps null through trips the post-binding implicit-required check
+    // -> the C# name "Value". Accept the field key with or without the "$." prefix either way.
+    [Fact]
+    public async Task NullValue_ReturnsBadRequest()
+    {
+        var response = await Client.PostAsJsonAsync(
+            CreateEndpoint, new { value = (object?)null, nullableValue = ValidBody }, Ct);
+        var errors = await AssertValidationProblem(response);
+        var keys = errors.EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Contains(keys, k => k is "$.value" or "value" or "Value");
+    }
+
+    // ── Get ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_ReturnsEntityWithCamelCaseJsonFromBothDatabases()
+    {
+        var entity = TEntity.Create(ValidValue, ToNullable(ValidValue));
+        SqlSet.Add(entity);
+        PgSet.Add(entity);
+        await SqlDb.SaveChangesAsync(Ct);
+        await PgDb.SaveChangesAsync(Ct);
+
+        if (SqlServerAvailable)
+        {
+            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
+            Assert.Equal(entity.Id, sqlJson.GetProperty("id").GetGuid());
+            AssertJsonIsValidValue(sqlJson.GetProperty("value"));
+            AssertJsonIsValidValue(sqlJson.GetProperty("nullableValue"));
+        }
+
+        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
+        Assert.Equal(entity.Id, pgJson.GetProperty("id").GetGuid());
+        AssertJsonIsValidValue(pgJson.GetProperty("value"));
+        AssertJsonIsValidValue(pgJson.GetProperty("nullableValue"));
+    }
+
+    [Fact]
+    public async Task Get_SerializesNullNullableValueAsJsonNullFromBothDatabases()
+    {
+        var entity = TEntity.Create(ValidValue, NullNullable);
+        SqlSet.Add(entity);
+        PgSet.Add(entity);
+        await SqlDb.SaveChangesAsync(Ct);
+        await PgDb.SaveChangesAsync(Ct);
+
+        if (SqlServerAvailable)
+        {
+            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
+            Assert.Equal(JsonValueKind.Null, sqlJson.GetProperty("nullableValue").ValueKind);
+            AssertJsonIsValidValue(sqlJson.GetProperty("value"));
+        }
+
+        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
+        Assert.Equal(JsonValueKind.Null, pgJson.GetProperty("nullableValue").ValueKind);
+        AssertJsonIsValidValue(pgJson.GetProperty("value"));
+    }
+
+    // ── Update ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_PersistsNewValueAndNullableValueInBothDatabases()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+        await Put(UpdateEndpoint(created.Id), new { value = UpdatedBody, nullableValue = UpdatedBody });
+        await AssertEntity(created.Id, UpdatedValue, ToNullable(UpdatedValue));
+    }
+
+    [Fact]
+    public async Task Update_SetsNullableValueFromNullToValueInBothDatabases()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = (object?)null });
+        await Put(UpdateEndpoint(created.Id), new { value = ValidBody, nullableValue = UpdatedBody });
+        await AssertEntity(created.Id, ValidValue, ToNullable(UpdatedValue));
+    }
+
+    [Fact]
+    public async Task Update_ClearsNullableValueToNullInBothDatabases()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+        await Put(UpdateEndpoint(created.Id), new { value = ValidBody, nullableValue = (object?)null });
+        await AssertEntity(created.Id, ValidValue, NullNullable);
+    }
+
+    // ── Patch ────────────────────────────────────────────────────────────
+    // Wire semantics per field:
+    //   Value        — null/absent ⇒ skip;      non-null ⇒ update.
+    //   NullableValue — null/absent ⇒ skip; { Value: x } ⇒ set x; {} or { Value: null } ⇒ clear.
+
+    [Fact]
+    public async Task Patch_EmptyBody_LeavesBothFieldsUnchanged()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+
+        var response = await Patch(PatchEndpoint(created.Id), new { });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, ValidValue, ToNullable(ValidValue));
+    }
+
+    [Fact]
+    public async Task Patch_ValueOnly_UpdatesValueLeavesNullableValueUnchanged()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+
+        var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedBody });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, UpdatedValue, ToNullable(ValidValue));
+    }
+
+    [Fact]
+    public async Task Patch_ExplicitNullValue_LeavesValueUnchanged()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+
+        var response = await Patch(PatchEndpoint(created.Id),
+            new { value = (object?)null, nullableValue = (object?)null });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, ValidValue, ToNullable(ValidValue));
+    }
+
+    [Fact]
+    public async Task Patch_NullableValueSome_UpdatesNullableValueLeavesValueUnchanged()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = (object?)null });
+
+        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = UpdatedBody } });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, ValidValue, ToNullable(UpdatedValue));
+    }
+
+    [Fact]
+    public async Task Patch_NullableValueEmptyObject_ClearsNullableValue()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+
+        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { } });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, ValidValue, NullNullable);
+    }
+
+    [Fact]
+    public async Task Patch_NullableValueWithExplicitNullInner_ClearsNullableValue()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = ValidBody });
+
+        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = (object?)null } });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, ValidValue, NullNullable);
+    }
+
+    [Fact]
+    public async Task Patch_UpdatesBothFieldsIndependently()
+    {
+        var created = await Post(CreateEndpoint, new { value = ValidBody, nullableValue = (object?)null });
+
+        var response = await Patch(PatchEndpoint(created.Id),
+            new { value = UpdatedBody, nullableValue = new { Value = UpdatedBody } });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await AssertEntity(created.Id, UpdatedValue, ToNullable(UpdatedValue));
+    }
+
+    [Fact]
+    public async Task Patch_NonExistentId_ReturnsNotFound()
+    {
+        var response = await Patch(PatchEndpoint(Guid.NewGuid()), new { value = UpdatedBody });
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Asserts a 400 carrying a well-formed <c>ValidationProblemDetails</c> (RFC 9457
+    /// problem+json with a non-empty <c>errors</c> map) and returns the <c>errors</c>
+    /// object so callers can assert specific keys.
+    /// </summary>
+    protected static async Task<JsonElement> AssertValidationProblem(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
+        Assert.Equal(400, problem.GetProperty("status").GetInt32());
+        Assert.Equal("One or more validation errors occurred.", problem.GetProperty("title").GetString());
+        var errors = problem.GetProperty("errors");
+        Assert.Equal(JsonValueKind.Object, errors.ValueKind);
+        Assert.NotEmpty(errors.EnumerateObject());
+        return errors;
+    }
+}

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/EntityTests.cs
@@ -1,18 +1,16 @@
-using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using StrongTypes.Api.Entities;
 using StrongTypes.Api.IntegrationTests.Infrastructure;
-using StrongTypes.Api.Models;
 using Xunit;
 
 namespace StrongTypes.Api.IntegrationTests.Tests;
 
 /// <summary>
-/// Compile-time contract every entity test class must satisfy. <c>static abstract</c>
-/// members force each concrete subclass to supply the <see cref="TheoryData{T}"/>
-/// lists — a missing one is a build error, not a silently skipped test. xUnit
-/// resolves the actual members by reflection on the concrete type at discovery time.
+/// Compile-time contract every scalar entity test class must satisfy. <c>static abstract</c>
+/// members force each concrete subclass to supply the <see cref="TheoryData{T}"/> lists — a
+/// missing one is a build error, not a silently skipped test. xUnit resolves the actual
+/// members by reflection on the concrete type at discovery time.
 /// </summary>
 public interface IEntityTestData<TWire>
 {
@@ -21,107 +19,50 @@ public interface IEntityTestData<TWire>
 }
 
 /// <summary>
-/// Shared Create/Get/Update suite for every <see cref="IEntity{TSelf, T, TNullable}"/>.
-/// The test shape (valid inputs, invalid inputs, null handling) is identical for
-/// numeric and string strong types; only the wire-format raw type
-/// (<typeparamref name="TWire"/>) and the wrapper factory differ. Concrete
-/// subclasses plug in a <c>Create(TWire)</c> factory, two seed values
-/// (<see cref="FirstValid"/>, <see cref="UpdatedValid"/>), the <see cref="RoutePrefix"/>
-/// inherited from <see cref="IntegrationTestBase{TEntity, T, TNullable}"/>, and
-/// the two <see cref="TheoryData{T}"/> lists required by
-/// <see cref="IEntityTestData{TWire}"/>.
+/// The scalar-wire adapter over <see cref="EntityCrudTestsBase{TEntity, T, TNullable}"/>:
+/// numeric and reference strong types (<c>NonEmptyString</c> / <c>Email</c> /
+/// <c>MailAddress</c>) that serialize as a single JSON scalar. It plugs a
+/// <c>Create(TWire)</c> factory and two seeds (<see cref="FirstValid"/>,
+/// <see cref="UpdatedValid"/>) into the shared create / get / update / PATCH suite, and adds
+/// the scalar-only cases: the full <see cref="IEntityTestData{TWire}.ValidInputs"/> round-trip
+/// and the malformed-scalar invalid payloads.
 /// </summary>
 /// <remarks>
-/// <typeparamref name="TSelf"/> uses the curiously recurring template pattern so
-/// each concrete subclass passes itself and must implement
-/// <see cref="IEntityTestData{TWire}"/> — a missing data member is a CS0535
-/// build error instead of a silently skipped test.
-/// <para>
-/// This is the scalar-wire harness. Interval types serialize as an object and use the
-/// parallel <see cref="IntervalEntityTests{TEntity, TInterval}"/>, which covers the same
-/// create / get / update / PATCH surface for the object wire shape. The two must stay in
-/// lock-step — a scenario added here must be added there, and vice versa.
-/// </para>
+/// <typeparamref name="TSelf"/> uses the curiously recurring template pattern so each concrete
+/// subclass passes itself and must implement <see cref="IEntityTestData{TWire}"/> — a missing
+/// data member is a CS0535 build error instead of a silently skipped test.
 /// </remarks>
 public abstract partial class EntityTests<TSelf, TEntity, T, TNullable, TWire>(TestWebApplicationFactory factory)
-    : IntegrationTestBase<TEntity, T, TNullable>(factory)
+    : EntityCrudTestsBase<TEntity, T, TNullable>(factory)
     where TSelf : EntityTests<TSelf, TEntity, T, TNullable, TWire>, IEntityTestData<TWire>
     where TEntity : class, IEntity<TEntity, T, TNullable>
     where T : notnull
 {
-    /// <summary>Route segment this entity is exposed under, e.g. "non-empty-string-entities".</summary>
-    protected abstract string RoutePrefix { get; }
-
-    protected string CreateEndpoint => $"/{RoutePrefix}";
-    protected string UpdateEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
-    protected string PatchEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
-    protected string SqlServerGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/sql-server";
-    protected string PostgreSqlGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/postgresql";
-
-    /// <summary>
-    /// Builds the { Value, NullableValue } request body used by every write endpoint.
-    /// Generic over the wire types so tests can send plain scalars (int, string, …)
-    /// regardless of the strong type the server binds them into.
-    /// </summary>
-    protected static object Body<TValue, TNullableValue>(TValue value, TNullableValue nullableValue) =>
-        new { Value = value, NullableValue = nullableValue };
-
-    protected async Task<EntityResponse> Post(string url, object body)
-    {
-        var response = await Client.PostAsJsonAsync(url, body, Ct);
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return (await response.Content.ReadFromJsonAsync<EntityResponse>(Ct))!;
-    }
-
-    protected async Task Put(string url, object body)
-    {
-        var response = await Client.PutAsJsonAsync(url, body, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-    }
-
-    protected async Task<HttpResponseMessage> Patch(string url, object body)
-    {
-        using var content = JsonContent.Create(body);
-        return await Client.PatchAsync(url, content, Ct);
-    }
-
-    protected async Task<JsonElement> Get(string url)
-    {
-        var response = await Client.GetAsync(url, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        return await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
-    }
-
     /// <summary>Wraps a raw wire-format value in the strong type.</summary>
     protected abstract T Create(TWire raw);
 
-    /// <summary>
-    /// Seed valid value used as the "other" slot when testing one field in
-    /// isolation, and as the baseline for Get/Update tests.
-    /// </summary>
+    /// <summary>Baseline valid value seeding the shared create / get / update / PATCH suite.</summary>
     protected abstract TWire FirstValid { get; }
 
-    /// <summary>Target value for the update test; must differ from <see cref="FirstValid"/>.</summary>
+    /// <summary>Update/PATCH target; must differ from <see cref="FirstValid"/>.</summary>
     protected abstract TWire UpdatedValid { get; }
 
-    // T → TNullable bridge. For struct T with TNullable = Nullable<T>, boxing
-    // then unboxing to Nullable<T> is a supported CLR conversion. For class T
-    // with TNullable = T? (NRT annotation), it's identity.
-    private static TNullable ToNullable(T value) => (TNullable)(object)value!;
+    protected sealed override object ValidBody => FirstValid!;
+    protected sealed override T ValidValue => Create(FirstValid);
+    protected sealed override object UpdatedBody => UpdatedValid!;
+    protected sealed override T UpdatedValue => Create(UpdatedValid);
 
-    // Default of TNullable is null in both shapes: Nullable<T>.default == null,
-    // reference-type default == null.
-    private static TNullable NullNullable => default!;
+    protected sealed override void AssertJsonIsValidValue(JsonElement element) =>
+        Assert.Equal(FirstValid, element.Deserialize<TWire>());
 
-    // xUnit resolves these names on the concrete test class at runtime; the
-    // analyzer can't see through the static abstract + CRTP, so we suppress
-    // xUnit1015 where we reference them.
+    // xUnit resolves these names on the concrete test class at runtime; the analyzer can't see
+    // through the static abstract + CRTP, so we suppress xUnit1015 where we reference them.
     protected const string ValidInputsMember = nameof(IEntityTestData<TWire>.ValidInputs);
     protected const string InvalidInputsMember = nameof(IEntityTestData<TWire>.InvalidInputs);
 
 #pragma warning disable xUnit1015
 
-    // ── Create: valid ────────────────────────────────────────────────────
+    // ── Create: valid across the whole ValidInputs set ───────────────────
 
     [Theory]
     [MemberData(ValidInputsMember)]
@@ -132,28 +73,19 @@ public abstract partial class EntityTests<TSelf, TEntity, T, TNullable, TWire>(T
         await AssertEntity(created.Id, expected, ToNullable(expected));
     }
 
-    [Fact]
-    public async Task ValidValueWithNullNullable_PersistsInBothDatabases()
-    {
-        var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
-        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
-    }
-
-    // ── Create: invalid (non-null) ───────────────────────────────────────
-    // Each invalid value is tested in both slots independently; the other
-    // slot holds FirstValid so the test isolates the one field being checked.
-
-    // A malformed non-null value fails inside the JSON converter while positioned
-    // on the property, so System.Text.Json keys the error by its path: "$.value"
-    // / "$.nullableValue". This harness wires no normalization (it does not call
-    // AddStrongTypes), so these are the raw framework keys — uniform across every
-    // strong type, the same shape a malformed BCL primitive (int, Guid) produces.
+    // ── Create: invalid ──────────────────────────────────────────────────
+    // Each invalid value is tested in both slots independently; the other slot holds FirstValid
+    // so the test isolates the one field being checked. A malformed non-null value fails inside
+    // the JSON converter while positioned on the property, so System.Text.Json keys the error by
+    // its path ("$.value" / "$.nullableValue") — the raw framework key, since this harness does
+    // not call AddStrongTypes to normalize it.
 
     [Theory]
     [MemberData(InvalidInputsMember)]
     public async Task InvalidValue_ReturnsBadRequest(TWire invalid)
     {
-        var response = await Client.PostAsJsonAsync(CreateEndpoint, new { value = (object?)invalid, nullableValue = (object?)FirstValid }, Ct);
+        var response = await Client.PostAsJsonAsync(
+            CreateEndpoint, new { value = (object?)invalid, nullableValue = (object?)FirstValid }, Ct);
         var errors = await AssertValidationProblem(response);
         Assert.Contains("$.value", errors.EnumerateObject().Select(p => p.Name));
     }
@@ -162,223 +94,10 @@ public abstract partial class EntityTests<TSelf, TEntity, T, TNullable, TWire>(T
     [MemberData(InvalidInputsMember)]
     public async Task InvalidNullableValue_ReturnsBadRequest(TWire invalid)
     {
-        var response = await Client.PostAsJsonAsync(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)invalid }, Ct);
+        var response = await Client.PostAsJsonAsync(
+            CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)invalid }, Ct);
         var errors = await AssertValidationProblem(response);
         Assert.Contains("$.nullableValue", errors.EnumerateObject().Select(p => p.Name));
     }
 #pragma warning restore xUnit1015
-
-    // ── Create: null ─────────────────────────────────────────────────────
-    // Value is non-nullable, so null Value is a 400. Null NullableValue is the
-    // legit case covered by ValidValueWithNullNullable_PersistsInBothDatabases.
-    //
-    // The error key for a null value is mechanism-dependent: a struct (or a
-    // reference converter that rejects null) fails at parse time -> "$.value",
-    // while a reference converter that maps null through trips the post-binding
-    // implicit-required check -> the C# name "Value". Both are valid; this asserts
-    // the value field is flagged without pinning which mechanism caught it.
-
-    [Fact]
-    public async Task NullValue_ReturnsBadRequest()
-    {
-        var response = await Client.PostAsJsonAsync(
-            CreateEndpoint, new { value = (object?)null, nullableValue = (object?)FirstValid }, Ct);
-        var errors = await AssertValidationProblem(response);
-        var keys = errors.EnumerateObject().Select(p => p.Name).ToArray();
-        Assert.Contains(keys, k => k is "$.value" or "value" or "Value");
-    }
-
-    // ── Get ──────────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Get_ReturnsEntityWithCamelCaseJsonFromBothDatabases()
-    {
-        var wrapped = Create(FirstValid);
-        var entity = TEntity.Create(wrapped, ToNullable(wrapped));
-        SqlSet.Add(entity);
-        PgSet.Add(entity);
-        await SqlDb.SaveChangesAsync(Ct);
-        await PgDb.SaveChangesAsync(Ct);
-
-        if (SqlServerAvailable)
-        {
-            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-            Assert.Equal(entity.Id, sqlJson.GetProperty("id").GetGuid());
-            AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
-            AssertJsonEquals(sqlJson.GetProperty("nullableValue"), FirstValid);
-        }
-
-        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
-        Assert.Equal(entity.Id, pgJson.GetProperty("id").GetGuid());
-        AssertJsonEquals(pgJson.GetProperty("value"), FirstValid);
-        AssertJsonEquals(pgJson.GetProperty("nullableValue"), FirstValid);
-    }
-
-    [Fact]
-    public async Task Get_SerializesNullNullableValueAsJsonNullFromBothDatabases()
-    {
-        var entity = TEntity.Create(Create(FirstValid), NullNullable);
-        SqlSet.Add(entity);
-        PgSet.Add(entity);
-        await SqlDb.SaveChangesAsync(Ct);
-        await PgDb.SaveChangesAsync(Ct);
-
-        if (SqlServerAvailable)
-        {
-            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-            Assert.Equal(JsonValueKind.Null, sqlJson.GetProperty("nullableValue").ValueKind);
-            AssertJsonEquals(sqlJson.GetProperty("value"), FirstValid);
-        }
-
-        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
-        Assert.Equal(JsonValueKind.Null, pgJson.GetProperty("nullableValue").ValueKind);
-        AssertJsonEquals(pgJson.GetProperty("value"), FirstValid);
-    }
-
-    // ── Update ───────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Update_PersistsNewValueAndNullableValueInBothDatabases()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-        await Put(UpdateEndpoint(created.Id), new { value = UpdatedValid, nullableValue = UpdatedValid });
-
-        var updated = Create(UpdatedValid);
-        await AssertEntity(created.Id, updated, ToNullable(updated));
-    }
-
-    [Fact]
-    public async Task Update_SetsNullableValueFromNullToValueInBothDatabases()
-    {
-        var created = await Post(CreateEndpoint, new { value = (object?)FirstValid, nullableValue = (object?)null });
-        await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)UpdatedValid });
-
-        await AssertEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
-    }
-
-    [Fact]
-    public async Task Update_ClearsNullableValueToNullInBothDatabases()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-        await Put(UpdateEndpoint(created.Id), new { value = (object?)FirstValid, nullableValue = (object?)null });
-
-        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
-    }
-
-    // ── Patch ────────────────────────────────────────────────────────────
-    //
-    // Patch wire semantics:
-    //   Value        — null/absent ⇒ skip. Non-null ⇒ update.
-    //   NullableValue — null/absent ⇒ skip. Maybe Some ⇒ update. Maybe Empty ⇒ clear.
-    // "Empty" on the wire is any of {}, {"Value":null}, or {"value":null}.
-
-    [Fact]
-    public async Task Patch_EmptyBody_LeavesBothFieldsUnchanged()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var expected = Create(FirstValid);
-        await AssertEntity(created.Id, expected, ToNullable(expected));
-    }
-
-    [Fact]
-    public async Task Patch_ValueOnly_UpdatesValueLeavesNullableValueUnchanged()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(created.Id, Create(UpdatedValid), ToNullable(Create(FirstValid)));
-    }
-
-    [Fact]
-    public async Task Patch_ExplicitNullValue_LeavesValueUnchanged()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id),
-            new { value = (object?)null, nullableValue = (object?)null });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        var expected = Create(FirstValid);
-        await AssertEntity(created.Id, expected, ToNullable(expected));
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueSome_UpdatesNullableValueLeavesValueUnchanged()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = (object?)null });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = UpdatedValid } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(created.Id, Create(FirstValid), ToNullable(Create(UpdatedValid)));
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueEmptyObject_ClearsNullableValue()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueWithExplicitNullInner_ClearsNullableValue()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = FirstValid });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { nullableValue = new { Value = (object?)null } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(created.Id, Create(FirstValid), NullNullable);
-    }
-
-    [Fact]
-    public async Task Patch_UpdatesBothFieldsIndependently()
-    {
-        var created = await Post(CreateEndpoint, new { value = FirstValid, nullableValue = (object?)null });
-
-        var response = await Patch(PatchEndpoint(created.Id), new { value = UpdatedValid, nullableValue = new { Value = UpdatedValid } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(created.Id, Create(UpdatedValid), ToNullable(Create(UpdatedValid)));
-    }
-
-    [Fact]
-    public async Task Patch_NonExistentId_ReturnsNotFound()
-    {
-        var response = await Patch(PatchEndpoint(Guid.NewGuid()), new { value = UpdatedValid });
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    /// <summary>
-    /// Asserts a 400 carrying a well-formed <c>ValidationProblemDetails</c>
-    /// (RFC 9457 problem+json with a non-empty <c>errors</c> map) and returns the
-    /// <c>errors</c> object so callers can assert specific keys.
-    /// </summary>
-    private static async Task<JsonElement> AssertValidationProblem(HttpResponseMessage response)
-    {
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
-        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
-        Assert.Equal(400, problem.GetProperty("status").GetInt32());
-        Assert.Equal("One or more validation errors occurred.", problem.GetProperty("title").GetString());
-        var errors = problem.GetProperty("errors");
-        Assert.Equal(JsonValueKind.Object, errors.ValueKind);
-        Assert.NotEmpty(errors.EnumerateObject());
-        return errors;
-    }
-
-    private static void AssertJsonEquals(JsonElement element, TWire expected)
-    {
-        Assert.Equal(expected, element.Deserialize<TWire>());
-    }
 }

--- a/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Intervals/IntervalEntityTests.cs
+++ b/src/StrongTypes.Api.IntegrationTests/Tests/ApiTests/Intervals/IntervalEntityTests.cs
@@ -1,272 +1,43 @@
-using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using StrongTypes.Api.Entities;
 using StrongTypes.Api.IntegrationTests.Infrastructure;
-using StrongTypes.Api.Models;
 using Xunit;
 
 namespace StrongTypes.Api.IntegrationTests.Tests;
 
 /// <summary>
-/// Shared wire-to-DB suite for the four interval entities: create, get, update, and
-/// PATCH round-trips — including the null / value / clear semantics of the nullable
-/// slot — through the System.Text.Json converter, the ASP.NET Core pipeline, and EF
-/// Core against both providers.
+/// The object-wire adapter over <see cref="EntityCrudTestsBase{TEntity, T, TNullable}"/>:
+/// interval strong types serialize as a JSON object (<c>{ "start": …, "end": … }</c>) rather
+/// than a scalar. It supplies the GET read assertion for the shared create / get / update /
+/// PATCH suite and adds the interval-only invalid-payload cases (<c>Start &gt; End</c> and a
+/// missing required endpoint). Concrete variants supply the wire bodies and their strong-typed
+/// forms.
 /// </summary>
-/// <remarks>
-/// The object-wire twin of the scalar <see cref="EntityTests{TSelf, TEntity, T, TNullable, TWire}"/>.
-/// An interval serializes as an object (<c>{ "start": …, "end": … }</c>) rather than a
-/// scalar, so it cannot reuse that harness's scalar <c>TWire</c> bodies and assertions —
-/// hence a parallel base. The two cover the <b>same functional surface and must not
-/// drift</b>: the create / get / update / PATCH scenarios here mirror it one-for-one, and
-/// a scenario added to either base must be added to the other. Only the invalid-payload
-/// cases differ by nature (endpoint order or a missing required endpoint here, a malformed
-/// scalar there).
-/// </remarks>
 public abstract class IntervalEntityTests<TEntity, TInterval>(TestWebApplicationFactory factory)
-    : IntegrationTestBase<TEntity, TInterval, TInterval?>(factory)
+    : EntityCrudTestsBase<TEntity, TInterval, TInterval?>(factory)
     where TEntity : class, IEntity<TEntity, TInterval, TInterval?>
     where TInterval : struct
 {
     private static readonly JsonSerializerOptions WireJson = new(JsonSerializerDefaults.Web);
 
-    protected abstract string RoutePrefix { get; }
-
-    /// <summary>A valid interval as an anonymous wire body, plus its strong-type form.</summary>
-    protected abstract object ValidBody { get; }
-    protected abstract TInterval ValidValue { get; }
-
-    /// <summary>A second valid interval distinct from <see cref="ValidValue"/>, for update tests.</summary>
-    protected abstract object UpdatedBody { get; }
-    protected abstract TInterval UpdatedValue { get; }
-
     /// <summary>A wire body whose endpoints violate <c>Start &lt;= End</c>. Every variant has one.</summary>
     protected abstract object StartAfterEndBody { get; }
 
     /// <summary>
-    /// A wire body that sends <c>null</c> for an endpoint the variant requires,
-    /// or <see langword="null"/> when the variant has no required endpoint
-    /// (<see cref="Interval{T}"/>). Used to assert the framework rejects a
-    /// missing-but-required endpoint with a 400.
+    /// A wire body that sends <c>null</c> for an endpoint the variant requires, or
+    /// <see langword="null"/> when the variant has no required endpoint (<see cref="Interval{T}"/>).
     /// </summary>
     protected virtual object? NullRequiredEndpointBody => null;
 
     /// <summary>
-    /// A wire body that omits a required endpoint key entirely (vs. sending it as
-    /// <c>null</c>), or <see langword="null"/> when the variant has no required
-    /// endpoint (<see cref="Interval{T}"/>).
+    /// A wire body that omits a required endpoint key entirely (vs. sending it as <c>null</c>),
+    /// or <see langword="null"/> when the variant has no required endpoint (<see cref="Interval{T}"/>).
     /// </summary>
     protected virtual object? OmittedRequiredEndpointBody => null;
 
-    private string CreateEndpoint => $"/{RoutePrefix}";
-    private string UpdateEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
-    private string PatchEndpoint(Guid id) => $"/{RoutePrefix}/{id}";
-    private string SqlServerGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/sql-server";
-    private string PostgreSqlGetEndpoint(Guid id) => $"/{RoutePrefix}/{id}/postgresql";
-
-    private async Task<Guid> PostValid(object value, object? nullableValue)
-    {
-        var response = await Client.PostAsJsonAsync(CreateEndpoint, new { value, nullableValue }, Ct);
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        var created = await response.Content.ReadFromJsonAsync<EntityResponse>(Ct);
-        return created!.Id;
-    }
-
-    private async Task<JsonElement> Get(string url)
-    {
-        var response = await Client.GetAsync(url, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        return await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
-    }
-
-    private async Task<HttpResponseMessage> Patch(Guid id, object body)
-    {
-        using var content = JsonContent.Create(body);
-        return await Client.PatchAsync(PatchEndpoint(id), content, Ct);
-    }
-
-    private static TInterval ReadInterval(JsonElement element) => element.Deserialize<TInterval>(WireJson);
-
-    // ── Create + persist ─────────────────────────────────────────────────
-
-    [Fact]
-    public async Task ValidInterval_PersistsInBothDatabases()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-        await AssertEntity(id, ValidValue, ValidValue);
-    }
-
-    [Fact]
-    public async Task ValidValueWithNullNullable_PersistsInBothDatabases()
-    {
-        var id = await PostValid(ValidBody, null);
-        await AssertEntity(id, ValidValue, null);
-    }
-
-    // ── Read ─────────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Get_RoundTripsTheIntervalObjectFromBothDatabases()
-    {
-        var entity = TEntity.Create(ValidValue, ValidValue);
-        SqlSet.Add(entity);
-        PgSet.Add(entity);
-        await SqlDb.SaveChangesAsync(Ct);
-        await PgDb.SaveChangesAsync(Ct);
-
-        if (SqlServerAvailable)
-        {
-            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-            Assert.Equal(entity.Id, sqlJson.GetProperty("id").GetGuid());
-            Assert.Equal(ValidValue, ReadInterval(sqlJson.GetProperty("value")));
-            Assert.Equal(ValidValue, ReadInterval(sqlJson.GetProperty("nullableValue")));
-        }
-
-        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
-        Assert.Equal(entity.Id, pgJson.GetProperty("id").GetGuid());
-        Assert.Equal(ValidValue, ReadInterval(pgJson.GetProperty("value")));
-        Assert.Equal(ValidValue, ReadInterval(pgJson.GetProperty("nullableValue")));
-    }
-
-    [Fact]
-    public async Task Get_SerializesNullNullableValueAsJsonNullFromBothDatabases()
-    {
-        var entity = TEntity.Create(ValidValue, null);
-        SqlSet.Add(entity);
-        PgSet.Add(entity);
-        await SqlDb.SaveChangesAsync(Ct);
-        await PgDb.SaveChangesAsync(Ct);
-
-        if (SqlServerAvailable)
-        {
-            var sqlJson = await Get(SqlServerGetEndpoint(entity.Id));
-            Assert.Equal(JsonValueKind.Null, sqlJson.GetProperty("nullableValue").ValueKind);
-            Assert.Equal(ValidValue, ReadInterval(sqlJson.GetProperty("value")));
-        }
-
-        var pgJson = await Get(PostgreSqlGetEndpoint(entity.Id));
-        Assert.Equal(JsonValueKind.Null, pgJson.GetProperty("nullableValue").ValueKind);
-        Assert.Equal(ValidValue, ReadInterval(pgJson.GetProperty("value")));
-    }
-
-    // ── Update ───────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task Update_PersistsNewValueAndNullableValueInBothDatabases()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-        var response = await Client.PutAsJsonAsync(UpdateEndpoint(id), new { value = UpdatedBody, nullableValue = UpdatedBody }, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        await AssertEntity(id, UpdatedValue, UpdatedValue);
-    }
-
-    [Fact]
-    public async Task Update_SetsNullableValueFromNullToValueInBothDatabases()
-    {
-        var id = await PostValid(ValidBody, null);
-        var response = await Client.PutAsJsonAsync(UpdateEndpoint(id), new { value = ValidBody, nullableValue = UpdatedBody }, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        await AssertEntity(id, ValidValue, UpdatedValue);
-    }
-
-    [Fact]
-    public async Task Update_ClearsNullableValueToNullInBothDatabases()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-        var response = await Client.PutAsJsonAsync(UpdateEndpoint(id), new { value = ValidBody, nullableValue = (object?)null }, Ct);
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        await AssertEntity(id, ValidValue, null);
-    }
-
-    // ── Patch ────────────────────────────────────────────────────────────
-    // Same wire semantics as the scalar EntityTests PATCH suite; kept in lock-step
-    // (see the class remarks). "Empty" nullableValue on the wire ({}, {"Value":null})
-    // clears; null/absent skips.
-
-    [Fact]
-    public async Task Patch_EmptyBody_LeavesBothFieldsUnchanged()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-
-        var response = await Patch(id, new { });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, ValidValue, ValidValue);
-    }
-
-    [Fact]
-    public async Task Patch_ValueOnly_UpdatesValueLeavesNullableValueUnchanged()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-
-        var response = await Patch(id, new { value = UpdatedBody });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, UpdatedValue, ValidValue);
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueSome_UpdatesNullableValueLeavesValueUnchanged()
-    {
-        var id = await PostValid(ValidBody, null);
-
-        var response = await Patch(id, new { nullableValue = new { Value = UpdatedBody } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, ValidValue, UpdatedValue);
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueEmptyObject_ClearsNullableValue()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-
-        var response = await Patch(id, new { nullableValue = new { } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, ValidValue, null);
-    }
-
-    [Fact]
-    public async Task Patch_ExplicitNullValue_LeavesValueUnchanged()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-
-        var response = await Patch(id, new { value = (object?)null, nullableValue = (object?)null });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, ValidValue, ValidValue);
-    }
-
-    [Fact]
-    public async Task Patch_NullableValueWithExplicitNullInner_ClearsNullableValue()
-    {
-        var id = await PostValid(ValidBody, ValidBody);
-
-        var response = await Patch(id, new { nullableValue = new { Value = (object?)null } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, ValidValue, null);
-    }
-
-    [Fact]
-    public async Task Patch_UpdatesBothFieldsIndependently()
-    {
-        var id = await PostValid(ValidBody, null);
-
-        var response = await Patch(id, new { value = UpdatedBody, nullableValue = new { Value = UpdatedBody } });
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-        await AssertEntity(id, UpdatedValue, UpdatedValue);
-    }
-
-    [Fact]
-    public async Task Patch_NonExistentId_ReturnsNotFound()
-    {
-        var response = await Patch(Guid.NewGuid(), new { value = UpdatedBody });
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
+    protected override void AssertJsonIsValidValue(JsonElement element) =>
+        Assert.Equal(ValidValue, element.Deserialize<TInterval>(WireJson));
 
     // ── Invalid payloads ─────────────────────────────────────────────────
 
@@ -302,16 +73,6 @@ public abstract class IntervalEntityTests<TEntity, TInterval>(TestWebApplication
     }
 
     [Fact]
-    public async Task NullValue_ReturnsBadRequest()
-    {
-        var response = await Client.PostAsJsonAsync(
-            CreateEndpoint, new { value = (object?)null, nullableValue = ValidBody }, Ct);
-        var errors = await AssertValidationProblem(response);
-        var keys = errors.EnumerateObject().Select(p => p.Name).ToArray();
-        Assert.Contains(keys, k => k is "$.value" or "value" or "Value");
-    }
-
-    [Fact]
     public async Task NullRequiredEndpoint_ReturnsBadRequest()
     {
         Assert.SkipWhen(NullRequiredEndpointBody is null, "Variant has no required endpoint.");
@@ -320,18 +81,5 @@ public abstract class IntervalEntityTests<TEntity, TInterval>(TestWebApplication
             CreateEndpoint, new { value = NullRequiredEndpointBody, nullableValue = ValidBody }, Ct);
         var errors = await AssertValidationProblem(response);
         Assert.True(errors.TryGetProperty("$.value", out _));
-    }
-
-    private static async Task<JsonElement> AssertValidationProblem(HttpResponseMessage response)
-    {
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
-        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(Ct);
-        Assert.Equal(400, problem.GetProperty("status").GetInt32());
-        Assert.Equal("One or more validation errors occurred.", problem.GetProperty("title").GetString());
-        var errors = problem.GetProperty("errors");
-        Assert.Equal(JsonValueKind.Object, errors.ValueKind);
-        Assert.NotEmpty(errors.EnumerateObject());
-        return errors;
     }
 }

--- a/testing.md
+++ b/testing.md
@@ -72,11 +72,12 @@ request pipeline, and the EF Core value converter against both providers.
   payloads (full entity bodies, `ValidationProblemDetails`, etc.) parse as
   `JsonElement` and pull fields by name — that verifies the on-the-wire
   HTTP contract directly.
-- **Test base class** — inherit from `IntegrationTestBase(factory)` to get
-  `Client`, `SqlDb`, `PgDb`, `Ct` (the current test's `CancellationToken`),
-  route constants/builders, HTTP wrappers (`Post`/`Put`/`Get`) that capture
-  `Client` and `Ct` implicitly and bake in `StringEntityResponse` on the
-  success path, `Body<T>(value, nullableValue)`, and `AssertStringEntity`.
+- **Test base classes** — `IntegrationTestBase(factory)` provides `Client`,
+  `SqlDb`, `PgDb`, `Ct` (the current test's `CancellationToken`),
+  `SqlServerAvailable`, and the generic `AssertEntity`. The CRUD harness base
+  `EntityCrudTestsBase` adds the route constants/builders and the HTTP wrappers
+  (`Post`/`Put`/`Patch`/`Get`) that capture `Client` and `Ct` implicitly and
+  bake in `EntityResponse` on the success path.
 - **CancellationTokens** — xunit.v3's `xUnit1051` analyzer requires
   `TestContext.Current.CancellationToken` be threaded into every async
   call that accepts one (`PostAsJsonAsync`, `PutAsJsonAsync`,
@@ -92,23 +93,25 @@ persisted state on both `SqlSet` and `PgSet`), invalid payloads returning
 `400`, and `null` handling for the nullable variant. If the type has a
 custom JSON converter, add converter-only tests under `Tests/ConverterTests`.
 
-**Two parallel CRUD harnesses, one functional surface.** The create / get /
-update / PATCH matrix (with the null / value / clear-nullable semantics) is the
-same for every type — what differs is only the wire shape. Scalar strong types
-(numbers, and the reference types `NonEmptyString` / `Email` / `MailAddress`,
-which all serialize as a single JSON scalar) use `EntityTests<…, TWire>`;
-intervals serialize as a JSON **object** (`{ "start": …, "end": … }`), which does
-not fit the scalar `TWire` bodies, so they use the parallel
-`IntervalEntityTests<TEntity, TInterval>`. **These two bases must not drift** — a
-scenario added to one belongs in the other. Only the invalid-payload cases
-legitimately differ (a malformed scalar vs. `Start > End` / a missing required
-endpoint). A new type picks its base by wire shape, not by struct-vs-class.
-Unifying them behind one abstract base so this parity is enforced by
-construction rather than convention is tracked in
-[#116](https://github.com/KaliCZ/StrongTypes/issues/116).
+**One shared CRUD surface, two wire-shape adapters.** The create / get / update /
+PATCH matrix (with the null / value / clear-nullable semantics) is the same for
+every type — what differs is only the wire shape — so it lives exactly once, in
+the abstract `EntityCrudTestsBase<TEntity, T, TNullable>`. Two thin adapters
+supply the wire-shape-specific pieces (the request body for a value, its
+strong-typed form, and the GET read assertion) and add their own invalid-payload
+cases: `EntityTests<…, TWire>` for scalar strong types (numbers, and the
+reference types `NonEmptyString` / `Email` / `MailAddress`, which all serialize as
+a single JSON scalar), and `IntervalEntityTests<TEntity, TInterval>` for
+intervals, which serialize as a JSON **object** (`{ "start": …, "end": … }`) that
+does not fit the scalar `TWire` bodies. Because the shared scenarios exist once,
+they cannot drift: a new create / get / update / PATCH scenario goes in
+`EntityCrudTestsBase` and every type gets it automatically. Only the
+invalid-payload cases legitimately differ (a malformed scalar vs. `Start > End` /
+a missing required endpoint), and those stay in the adapters. A new type picks
+its adapter by wire shape, not by struct-vs-class.
 
 A `400` from an invalid body is not just a status code — the shared
-`EntityTests` base asserts the full `ValidationProblemDetails` shape
+`EntityCrudTestsBase` asserts the full `ValidationProblemDetails` shape
 (`AssertValidationProblem`: `application/problem+json`, `status`/`title`,
 a non-empty `errors` object) and the error key. Because `StrongTypes.Api`
 does **not** call `AddStrongTypes`, these are the raw framework keys: a


### PR DESCRIPTION
Fixes #116.

## Problem

The API integration CRUD/PATCH suite was split across two parallel bases — `EntityTests` (scalar wire) and `IntervalEntityTests` (object wire) — that cover the same create / get / update / PATCH surface but were kept in parity **by convention only**. Nothing forced a contributor who added a scenario to one to add it to the other, and the interval base had already drifted once before #77.

## Change

Factor the shared scenarios into a single abstract `EntityCrudTestsBase<TEntity, T, TNullable>`, so they exist **exactly once** and cannot drift. The wire-shape differences become abstract members:

- the request body for a value (`ValidBody` / `UpdatedBody`) — a bare scalar vs. a `{ start, end }` object,
- its strong-typed form (`ValidValue` / `UpdatedValue`), and
- the GET read assertion (`AssertJsonIsValidValue`).

`EntityTests` and `IntervalEntityTests` become thin adapters over the base that supply those members and add only their own invalid-payload cases (a malformed scalar vs. `Start > End` / a missing required endpoint). A new create / get / update / PATCH scenario now goes in the base and every type gets it automatically.

All **27 scalar and 4 interval leaf classes are unchanged** — the blast radius is the two bases plus the new shared base. Docs updated to match: `testing.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and the `IntegrationTestBase` XML.

## Verification

Full Testcontainers suite green against **both** providers (SQL Server + PostgreSQL): **1281 passed, 0 failed, 2 skipped** (the `Interval<int>` variant with no required endpoint). Clean compile, **0 warnings** under warnings-as-errors.

Test count rose 1254 → 1281 (**+27, purely additive**): the new shared `ValidValue_PersistsInBothDatabases` fact now also runs on the 27 scalar leaves (the interval leaves swapped their old equivalent for the inherited one). No coverage lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
